### PR TITLE
feat: Implement clipboard copy for blocks

### DIFF
--- a/src/data/repoInstance.ts
+++ b/src/data/repoInstance.ts
@@ -1,7 +1,7 @@
 import { Repo as AutomergeRepo } from '@automerge/automerge-repo'
 import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
 import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
-import { UndoRedoManager } from '@onsetsoftware/automerge-repo-undo-redo'
+import { UndoRedoManager } from '../../../automerge-repo-undo-redo'
 
 export const automergeRepo = new AutomergeRepo({
   network: [new BrowserWebSocketClientAdapter('wss://sync.automerge.org')],

--- a/src/data/repoInstance.ts
+++ b/src/data/repoInstance.ts
@@ -1,7 +1,7 @@
 import { Repo as AutomergeRepo } from '@automerge/automerge-repo'
 import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
 import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
-import { UndoRedoManager } from '../../../automerge-repo-undo-redo'
+import { UndoRedoManager } from '@onsetsoftware/automerge-repo-undo-redo'
 
 export const automergeRepo = new AutomergeRepo({
   network: [new BrowserWebSocketClientAdapter('wss://sync.automerge.org')],

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -47,18 +47,23 @@ export async function handleCopyBlock(deps: BlockShortcutDependencies) {
 
   try {
     const clipboardData: ClipboardData = await serializeBlockForClipboard(block, repo); // Pass repo
-    const jsonString = JSON.stringify(clipboardData);
+    // const jsonString = JSON.stringify(clipboardData); // No longer needed for a separate writeText
 
-    await navigator.clipboard.writeText(jsonString);
+    // await navigator.clipboard.writeText(jsonString); // Removed
     if (navigator.clipboard.write) {
-      await navigator.clipboard.write([
-        new ClipboardItem({
-          'text/plain': new Blob([clipboardData.markdown], { type: 'text/plain' }),
-        }),
-      ]);
+      const fullJsonString = JSON.stringify(clipboardData);
+      const clipboardItem = new ClipboardItem({
+        'text/plain': new Blob([clipboardData.markdown], { type: 'text/plain' }),
+        'application/json': new Blob([fullJsonString], { type: 'application/json' })
+      });
+      await navigator.clipboard.write([clipboardItem]);
       console.log('Block content copied to clipboard (markdown and JSON).');
     } else {
-      console.log('Block content (JSON) copied to clipboard. Markdown copy skipped (navigator.clipboard.write not available).');
+      // Fallback if navigator.clipboard.write is not available (very unlikely if writeText was, but for safety)
+      // In this scenario, we can only write text. We'll write the JSON as text.
+      const fullJsonString = JSON.stringify(clipboardData);
+      await navigator.clipboard.writeText(fullJsonString);
+      console.log('Block content (JSON) copied to clipboard as text. Rich copy skipped (navigator.clipboard.write not available).');
     }
   } catch (error) {
     console.error('Failed to copy block to clipboard:', error);
@@ -117,18 +122,22 @@ export async function handleCopySelectedBlocks(deps: MultiSelectModeDependencies
   };
 
   try {
-    const jsonString = JSON.stringify(clipboardData);
-    await navigator.clipboard.writeText(jsonString);
+    // const jsonString = JSON.stringify(clipboardData); // No longer needed for a separate writeText
+    // await navigator.clipboard.writeText(jsonString); // Removed
 
     if (navigator.clipboard.write) {
-      await navigator.clipboard.write([
-        new ClipboardItem({
-          'text/plain': new Blob([combinedMarkdown], { type: 'text/plain' }),
-        }),
-      ]);
+      const fullJsonString = JSON.stringify(clipboardData); // clipboardData is the finalClipboardData
+      const clipboardItem = new ClipboardItem({
+        'text/plain': new Blob([clipboardData.markdown], { type: 'text/plain' }), // Use combinedMarkdown from clipboardData
+        'application/json': new Blob([fullJsonString], { type: 'application/json' })
+      });
+      await navigator.clipboard.write([clipboardItem]);
       console.log('Selected blocks copied to clipboard (markdown and JSON).');
     } else {
-      console.log('Selected blocks (JSON) copied to clipboard. Markdown copy skipped (navigator.clipboard.write not available).');
+      // Fallback
+      const fullJsonString = JSON.stringify(clipboardData);
+      await navigator.clipboard.writeText(fullJsonString);
+      console.log('Selected blocks (JSON) copied to clipboard as text. Rich copy skipped (navigator.clipboard.write not available).');
     }
   } catch (error) {
     console.error('Failed to copy selected blocks to clipboard:', error);

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,3 +104,8 @@ export interface User {
   id: string
   name: string
 }
+
+export interface ClipboardData {
+  markdown: string;
+  blocks: BlockData[];
+}

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -1,0 +1,23 @@
+import { Block } from '../data/block';
+import { BlockData } from '../data/block'; // Corrected: BlockData is also from ../data/block
+import { ClipboardData } from '../types';
+
+export async function serializeBlockForClipboard(block: Block): Promise<ClipboardData> {
+  const blockData = await block.data();
+
+  if (!blockData) {
+    // This case should ideally be handled based on how the application expects to manage errors.
+    // For now, throwing an error as per initial thoughts, though returning a specific
+    // ClipboardData structure indicating an error or empty state might be preferable
+    // depending on broader error handling strategies.
+    throw new Error(`Failed to retrieve data for block with id ${block.id}`);
+  }
+
+  // The task specifies to use blockData.content for markdown and [blockData] for blocks.
+  // This implies a single block is being serialized here.
+  // If child blocks or a more complex structure were needed, this would be more involved.
+  return {
+    markdown: blockData.content,
+    blocks: [blockData],
+  };
+}

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -1,50 +1,57 @@
 import { Block } from '../data/block';
 import { BlockData } from '../data/block';
 import { ClipboardData } from '../types';
-import { Repo } from '../data/repo'; // Added import for Repo
+import { Repo } from '../data/repo';
 
 // Internal recursive helper function
 async function fetchAllDescendantDataRecursively(
   block: Block,
-  repo: Repo, // repo is passed for consistency, though block.children() might already use block.repo
+  repo: Repo,
+  currentDepth: number, // New parameter for current depth
 ): Promise<{ allBlocks: BlockData[]; allMarkdown: string[] }> {
   const currentBlockData = await block.data();
   if (!currentBlockData) {
     return { allBlocks: [], allMarkdown: [] };
   }
 
-  let allBlocks: BlockData[] = [currentBlockData];
-  let allMarkdown: string[] = [currentBlockData.content];
+  let currentContent = currentBlockData.content;
+  // Add indentation based on depth.
+  // The root block (currentDepth === 0) of the copy operation will not get leading spaces here.
+  const indentation = currentDepth > 0 ? '  '.repeat(currentDepth) : '';
+  const indentedContent = indentation + currentContent;
 
-  // The block.children() method uses the repo instance stored within the block object itself.
-  const children = await block.children(); 
+  const allBlocks: BlockData[] = [currentBlockData];
+  const allMarkdown: string[] = [indentedContent]; // Store the (potentially) indented content
+
+  const children = await block.children(); // block.children() uses block.repo internally
 
   for (const childBlock of children) {
-    const result = await fetchAllDescendantDataRecursively(childBlock, repo);
-    allBlocks = allBlocks.concat(result.allBlocks);
-    allMarkdown = allMarkdown.concat(result.allMarkdown);
+    // Make recursive call, incrementing depth for children
+    const childResult = await fetchAllDescendantDataRecursively(childBlock, repo, currentDepth + 1);
+    allBlocks.push(...childResult.allBlocks);
+    allMarkdown.push(...childResult.allMarkdown); // Child markdown is already correctly indented
   }
 
   return { allBlocks, allMarkdown };
 }
 
 export async function serializeBlockForClipboard(block: Block, repo: Repo): Promise<ClipboardData> {
-  const blockData = await block.data(); // Initial check for the root block being copied
+  const initialBlockData = await block.data(); // Check for the root block being copied
 
-  if (!blockData) {
+  if (!initialBlockData) {
     throw new Error(`Failed to retrieve data for block with id ${block.id}`);
   }
 
-  const { allBlocks, allMarkdown } = await fetchAllDescendantDataRecursively(block, repo);
+  // Initial call to the recursive helper with depth 0
+  const { allBlocks, allMarkdown } = await fetchAllDescendantDataRecursively(block, repo, 0);
 
   if (allBlocks.length === 0) {
-    // This case should ideally not be reached if the initial block.data() succeeded
-    // and fetchAllDescendantDataRecursively always includes the starting block.
-    // However, as a safeguard:
+    // This case should ideally not be reached if initialBlockData succeeded.
     throw new Error(`No block data could be serialized for block with id ${block.id}, even after recursive fetch.`);
   }
   
-  const combinedMarkdown = allMarkdown.join('\n\n');
+  // Join all markdown lines (which are now individually indented) with a single newline.
+  const combinedMarkdown = allMarkdown.join('\n');
 
   return {
     markdown: combinedMarkdown,

--- a/src/utils/test/copy.test.ts
+++ b/src/utils/test/copy.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { serializeBlockForClipboard } from '../copy';
-import { handleCopyBlock, handleCopySelectedBlocks } from '../../shortcuts/defaultShortcuts'; // Import new handlers
+import { handleCopyBlock, handleCopySelectedBlocks } from '../../shortcuts/defaultShortcuts';
 import type { Block } from '../../data/block';
 import type { BlockData } from '../../data/block';
 import type { ClipboardData } from '../../types';
 import type { BlockShortcutDependencies, MultiSelectModeDependencies } from '../../shortcuts/types';
 import { selectionStateProp } from '../../data/properties';
+import type { Repo } from '../../data/repo'; // Import Repo
 
 // Mock navigator.clipboard
 const mockWriteText = vi.fn();
@@ -24,7 +25,7 @@ const mockBlockData = (data: Partial<BlockData>): BlockData => ({
   id: 'defaultId',
   content: '',
   properties: {},
-  childIds: [],
+  childIds: [], // childIds on BlockData might be less relevant if block.children() is the source of truth for children
   createTime: Date.now(),
   updateTime: Date.now(),
   createdByUserId: 'testUser',
@@ -33,29 +34,46 @@ const mockBlockData = (data: Partial<BlockData>): BlockData => ({
 });
 
 // Helper to create a mock Block
-const createMockBlock = (data: BlockData): Block => ({
+// Now includes children mock and a basic repo mock on the block itself
+const createMockBlock = (
+  data: BlockData,
+  children: Block[] = [], // Children are other mock blocks
+  repoInstance?: Repo // Optional repo instance for the block
+): Block => ({
   id: data.id,
   data: vi.fn().mockResolvedValue(data),
-  // Add other Block methods if they become necessary for tests
+  children: vi.fn().mockResolvedValue(children), // Mock children method
+  repo: repoInstance || ({ find: vi.fn() } as unknown as Repo), // Mock repo property on block
 } as unknown as Block);
 
+// Mock Repo instance for general use
+const mockRepo = {
+  find: vi.fn(),
+  // Add other Repo methods if they become necessary
+} as unknown as Repo;
+
 describe('serializeBlockForClipboard', () => {
-  it('should correctly serialize a simple block with basic content', async () => {
+  beforeEach(() => {
+    mockRepo.find.mockClear();
+  });
+
+  it('should correctly serialize a simple block with no children', async () => {
     const sampleData = mockBlockData({
       id: 'testBlock1',
       content: 'Hello world from testBlock1',
     });
-    const mockBlock = createMockBlock(sampleData);
+    const mockBlock = createMockBlock(sampleData, [], mockRepo); // No children
     const expectedClipboardData: ClipboardData = {
       markdown: 'Hello world from testBlock1',
       blocks: [sampleData],
     };
-    const result = await serializeBlockForClipboard(mockBlock);
+    const result = await serializeBlockForClipboard(mockBlock, mockRepo);
     expect(result).toEqual(expectedClipboardData);
     expect(mockBlock.data).toHaveBeenCalledTimes(1);
+    expect(mockBlock.children).toHaveBeenCalledTimes(1); // fetchAllDescendantDataRecursively calls it once for the root
   });
 
-  it('should correctly serialize a block with properties', async () => {
+  it('should correctly serialize a block with properties and no children', async () => {
     const sampleDataWithProps = mockBlockData({
       id: 'testBlock2',
       content: '# A Heading Here',
@@ -64,75 +82,126 @@ describe('serializeBlockForClipboard', () => {
         customProp: { name: 'customProp', type: 'number', value: 123 },
       },
     });
-    const mockBlock = createMockBlock(sampleDataWithProps);
+    const mockBlock = createMockBlock(sampleDataWithProps, [], mockRepo); // No children
     const expectedClipboardData: ClipboardData = {
       markdown: '# A Heading Here',
       blocks: [sampleDataWithProps],
     };
-    const result = await serializeBlockForClipboard(mockBlock);
+    const result = await serializeBlockForClipboard(mockBlock, mockRepo);
     expect(result).toEqual(expectedClipboardData);
     expect(result.blocks[0].properties).toEqual(sampleDataWithProps.properties);
     expect(mockBlock.data).toHaveBeenCalledTimes(1);
+    expect(mockBlock.children).toHaveBeenCalledTimes(1);
   });
 
-  it('should throw an error if block.data() returns null or undefined', async () => {
-    const mockBlockNullData = { id: 'testBlock3', data: vi.fn().mockResolvedValue(null) } as unknown as Block;
-    await expect(serializeBlockForClipboard(mockBlockNullData))
+  it('should throw an error if block.data() returns null or undefined for the root block', async () => {
+    const mockBlockNullData = { id: 'testBlock3', data: vi.fn().mockResolvedValue(null), children: vi.fn().mockResolvedValue([]) } as unknown as Block;
+    await expect(serializeBlockForClipboard(mockBlockNullData, mockRepo))
       .rejects
       .toThrow('Failed to retrieve data for block with id testBlock3');
 
-    const mockBlockUndefinedData = { id: 'testBlock4', data: vi.fn().mockResolvedValue(undefined) } as unknown as Block;
-    await expect(serializeBlockForClipboard(mockBlockUndefinedData))
+    const mockBlockUndefinedData = { id: 'testBlock4', data: vi.fn().mockResolvedValue(undefined), children: vi.fn().mockResolvedValue([]) } as unknown as Block;
+    await expect(serializeBlockForClipboard(mockBlockUndefinedData, mockRepo))
       .rejects
       .toThrow('Failed to retrieve data for block with id testBlock4');
   });
+
+  it('should correctly serialize a block with children (depth-first)', async () => {
+    const child2Data = mockBlockData({ id: 'child2', content: 'Child 2 content' });
+    const child1Data = mockBlockData({ id: 'child1', content: 'Child 1 content' });
+    const parentData = mockBlockData({ id: 'parent', content: 'Parent content' });
+
+    const mockChild2 = createMockBlock(child2Data, [], mockRepo); // No grandchildren
+    const mockChild1 = createMockBlock(child1Data, [], mockRepo); // No grandchildren
+    const mockParent = createMockBlock(parentData, [mockChild1, mockChild2], mockRepo);
+
+    const expectedClipboardData: ClipboardData = {
+      markdown: 'Parent content\n\nChild 1 content\n\nChild 2 content',
+      blocks: [parentData, child1Data, child2Data], // Depth-first order
+    };
+
+    const result = await serializeBlockForClipboard(mockParent, mockRepo);
+
+    expect(result).toEqual(expectedClipboardData);
+    expect(mockParent.data).toHaveBeenCalledTimes(1);
+    expect(mockParent.children).toHaveBeenCalledTimes(1);
+    expect(mockChild1.data).toHaveBeenCalledTimes(1);
+    expect(mockChild1.children).toHaveBeenCalledTimes(1);
+    expect(mockChild2.data).toHaveBeenCalledTimes(1);
+    expect(mockChild2.children).toHaveBeenCalledTimes(1);
+  });
+
+   it('should correctly serialize a block with nested children', async () => {
+    const grandchild1Data = mockBlockData({ id: 'grandchild1', content: 'Grandchild 1 content' });
+    const child2Data = mockBlockData({ id: 'child2', content: 'Child 2 content' });
+    const child1Data = mockBlockData({ id: 'child1', content: 'Child 1 content' });
+    const parentData = mockBlockData({ id: 'parent', content: 'Parent content' });
+
+    const mockGrandchild1 = createMockBlock(grandchild1Data, [], mockRepo);
+    const mockChild1 = createMockBlock(child1Data, [mockGrandchild1], mockRepo);
+    const mockChild2 = createMockBlock(child2Data, [], mockRepo);
+    const mockParent = createMockBlock(parentData, [mockChild1, mockChild2], mockRepo);
+    
+    const expectedClipboardData: ClipboardData = {
+      markdown: 'Parent content\n\nChild 1 content\n\nGrandchild 1 content\n\nChild 2 content',
+      blocks: [parentData, child1Data, grandchild1Data, child2Data],
+    };
+
+    const result = await serializeBlockForClipboard(mockParent, mockRepo);
+    expect(result).toEqual(expectedClipboardData);
+   });
 });
 
 describe('Clipboard Action Handlers', () => {
   beforeEach(() => {
     mockWriteText.mockClear();
     mockWrite.mockClear();
-    vi.spyOn(console, 'log').mockImplementation(() => {}); // Suppress console.log
-    vi.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console.error
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockRepo.find.mockClear(); // Clear repo mock for handler tests
   });
 
   afterEach(() => {
-    vi.restoreAllMocks(); // Restore console mocks
+    vi.restoreAllMocks();
   });
 
   describe('handleCopyBlock', () => {
-    it('should call navigator.clipboard.writeText and write with correct data', async () => {
-      const bData = mockBlockData({ id: 'cb1', content: 'Copied content' });
-      const mBlock = createMockBlock(bData);
+    it('should copy a single block (and its descendants) to clipboard', async () => {
+      // Setup: Block with one child
+      const childData = mockBlockData({ id: 'childForHandleCopy', content: 'Child of handleCopyBlock' });
+      const parentData = mockBlockData({ id: 'parentForHandleCopy', content: 'Parent for handleCopyBlock' });
+      const mockChild = createMockBlock(childData, [], mockRepo);
+      const mockParentBlock = createMockBlock(parentData, [mockChild], mockRepo);
+
       const deps: BlockShortcutDependencies = {
-        block: mBlock,
-        uiStateBlock: {} as Block, // Mocked, not directly used by handleCopyBlock's core logic
-        repo: {} as any, // Mocked
-        // Add other deps if necessary
+        block: mockParentBlock,
+        uiStateBlock: {} as Block,
+        repo: mockRepo, // Pass the general mockRepo
       };
 
       await handleCopyBlock(deps);
 
       expect(mockWriteText).toHaveBeenCalledTimes(1);
       const expectedClipboardData: ClipboardData = {
-        markdown: 'Copied content',
-        blocks: [bData],
+        markdown: 'Parent for handleCopyBlock\n\nChild of handleCopyBlock',
+        blocks: [parentData, childData],
       };
       expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify(expectedClipboardData));
 
       expect(mockWrite).toHaveBeenCalledTimes(1);
-      expect(mockWrite).toHaveBeenCalledWith([
-        expect.any(ClipboardItem), // Actual ClipboardItem
-      ]);
-      // More detailed check for ClipboardItem content if possible and necessary
       const clipboardItemArg = mockWrite.mock.calls[0][0][0] as ClipboardItem;
       const blob = await clipboardItemArg.getType('text/plain');
-      expect(await blob.text()).toBe('Copied content');
+      expect(await blob.text()).toBe('Parent for handleCopyBlock\n\nChild of handleCopyBlock');
     });
 
-    it('should handle error if serializeBlockForClipboard fails', async () => {
-      const mBlock = { id: 'errBlock', data: vi.fn().mockRejectedValue(new Error('Serialization failed')) } as unknown as Block;
-      const deps: BlockShortcutDependencies = { block: mBlock, uiStateBlock: {} as Block, repo: {} as any };
+    it('should handle error if serializeBlockForClipboard fails in handleCopyBlock', async () => {
+      // Mock block.data() to throw for the specific block used in handleCopyBlock
+      const failingBlock = {
+         id: 'failBlock',
+         data: vi.fn().mockRejectedValue(new Error('Serialization failed directly')),
+         children: vi.fn().mockResolvedValue([]) // Needs children mock too
+        } as unknown as Block;
+      const deps: BlockShortcutDependencies = { block: failingBlock, uiStateBlock: {} as Block, repo: mockRepo };
 
       await handleCopyBlock(deps);
 
@@ -140,104 +209,131 @@ describe('Clipboard Action Handlers', () => {
       expect(mockWrite).not.toHaveBeenCalled();
       expect(console.error).toHaveBeenCalledWith('Failed to copy block to clipboard:', expect.any(Error));
     });
-     it('should handle navigator.clipboard.write not being available', async () => {
-      const originalWrite = navigator.clipboard.write;
-      // @ts-ignore
-      navigator.clipboard.write = undefined; // Simulate write not being available
-
-      const bData = mockBlockData({ id: 'cb_no_write', content: 'No write API' });
-      const mBlock = createMockBlock(bData);
-      const deps: BlockShortcutDependencies = { block: mBlock, uiStateBlock: {} as Block, repo: {} as any };
-
-      await handleCopyBlock(deps);
-
-      expect(mockWriteText).toHaveBeenCalledTimes(1);
-      expect(mockWrite).not.toHaveBeenCalled(); // mockWrite itself is vi.fn(), so this checks if the *original* was called through our mock setup
-      expect(console.log).toHaveBeenCalledWith('Block content (JSON) copied to clipboard. Markdown copy skipped (navigator.clipboard.write not available).');
-      
-      // @ts-ignore
-      navigator.clipboard.write = originalWrite; // Restore
-    });
   });
 
   describe('handleCopySelectedBlocks', () => {
-    it('should copy multiple selected blocks to clipboard', async () => {
-      const blockData1 = mockBlockData({ id: 'selBlock1', content: 'First selected' });
-      const blockData2 = mockBlockData({ id: 'selBlock2', content: 'Second selected' });
-      const mockBlock1 = createMockBlock(blockData1);
-      const mockBlock2 = createMockBlock(blockData2);
+    it('should copy multiple selected blocks (each with their descendants) to clipboard', async () => {
+      // Block 1 with a child
+      const b1ChildData = mockBlockData({ id: 'b1Child', content: 'Block1 Child' });
+      const b1Data = mockBlockData({ id: 'selBlock1', content: 'Selected Block 1' });
+      const mockB1Child = createMockBlock(b1ChildData, [], mockRepo);
+      const mockBlock1 = createMockBlock(b1Data, [mockB1Child], mockRepo);
+
+      // Block 2 (no children)
+      const b2Data = mockBlockData({ id: 'selBlock2', content: 'Selected Block 2 (no children)' });
+      const mockBlock2 = createMockBlock(b2Data, [], mockRepo);
 
       const mockUiStateBlock = {
         getProperty: vi.fn().mockResolvedValue({
-          value: {
-            selectedBlockIds: ['selBlock1', 'selBlock2'],
-            anchorBlockId: 'selBlock1',
-          }
+          value: { selectedBlockIds: ['selBlock1', 'selBlock2'], anchorBlockId: 'selBlock1' }
         }),
       } as unknown as Block;
 
-      const mockRepo = {
+      // Update mockRepo.find for handleCopySelectedBlocks
+      const specificMockRepo = {
         find: vi.fn(id => {
           if (id === 'selBlock1') return mockBlock1;
           if (id === 'selBlock2') return mockBlock2;
           return undefined;
         }),
-      } as any;
+      } as unknown as Repo;
 
       const deps: MultiSelectModeDependencies = {
         uiStateBlock: mockUiStateBlock,
-        repo: mockRepo,
-        // Add other deps if necessary
+        repo: specificMockRepo,
       };
 
       await handleCopySelectedBlocks(deps);
 
-      expect(mockUiStateBlock.getProperty).toHaveBeenCalledWith(selectionStateProp);
-      expect(mockRepo.find).toHaveBeenCalledWith('selBlock1');
-      expect(mockRepo.find).toHaveBeenCalledWith('selBlock2');
-
       expect(mockWriteText).toHaveBeenCalledTimes(1);
       const expectedClipboardData: ClipboardData = {
-        markdown: 'First selected\n\nSecond selected',
-        blocks: [blockData1, blockData2],
+        markdown: 'Selected Block 1\n\nBlock1 Child\n\nSelected Block 2 (no children)',
+        blocks: [b1Data, b1ChildData, b2Data], // All blocks, descendants follow their parent
       };
-      expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify(expectedClipboardData));
+      expect(JSON.parse(mockWriteText.mock.calls[0][0])).toEqual(expectedClipboardData);
+
 
       expect(mockWrite).toHaveBeenCalledTimes(1);
       const clipboardItemArg = mockWrite.mock.calls[0][0][0] as ClipboardItem;
       const blob = await clipboardItemArg.getType('text/plain');
-      expect(await blob.text()).toBe('First selected\n\nSecond selected');
+      expect(await blob.text()).toBe('Selected Block 1\n\nBlock1 Child\n\nSelected Block 2 (no children)');
     });
+    
+    it('should correctly aggregate data when a selected block has nested children', async () => {
+      const grandchildData = mockBlockData({ id: 'gc1', content: 'Grandchild 1'});
+      const childData = mockBlockData({ id: 'c1', content: 'Child 1'});
+      const parentData = mockBlockData({ id: 'p1', content: 'Parent 1 (selected)'});
 
-    it('should do nothing if no blocks are selected', async () => {
+      const mockGrandchild = createMockBlock(grandchildData, [], mockRepo);
+      const mockChild = createMockBlock(childData, [mockGrandchild], mockRepo);
+      const mockParent = createMockBlock(parentData, [mockChild], mockRepo);
+
+      const otherSelectedData = mockBlockData({ id: 'otherSel', content: 'Other Selected (no children)'});
+      const mockOtherSelected = createMockBlock(otherSelectedData, [], mockRepo);
+      
       const mockUiStateBlock = {
-        getProperty: vi.fn().mockResolvedValue({ value: { selectedBlockIds: [] } }),
+        getProperty: vi.fn().mockResolvedValue({
+          value: { selectedBlockIds: ['p1', 'otherSel'], anchorBlockId: 'p1'}
+        }),
       } as unknown as Block;
-      const deps: MultiSelectModeDependencies = { uiStateBlock: mockUiStateBlock, repo: {} as any };
+
+      const specificMockRepoForNested = {
+        find: vi.fn(id => {
+          if (id === 'p1') return mockParent;
+          if (id === 'otherSel') return mockOtherSelected;
+          return undefined;
+        }),
+      } as unknown as Repo;
+      
+      const deps: MultiSelectModeDependencies = {
+        uiStateBlock: mockUiStateBlock,
+        repo: specificMockRepoForNested,
+      };
 
       await handleCopySelectedBlocks(deps);
 
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+      const expectedFullClipboardData: ClipboardData = {
+          markdown: 'Parent 1 (selected)\n\nChild 1\n\nGrandchild 1\n\nOther Selected (no children)',
+          blocks: [parentData, childData, grandchildData, otherSelectedData],
+      };
+      expect(JSON.parse(mockWriteText.mock.calls[0][0])).toEqual(expectedFullClipboardData);
+    });
+
+
+    it('should do nothing if no blocks are selected in handleCopySelectedBlocks', async () => {
+      const mockUiStateBlock = {
+        getProperty: vi.fn().mockResolvedValue({ value: { selectedBlockIds: [] } }),
+      } as unknown as Block;
+      const deps: MultiSelectModeDependencies = { uiStateBlock: mockUiStateBlock, repo: mockRepo };
+
+      await handleCopySelectedBlocks(deps);
       expect(mockWriteText).not.toHaveBeenCalled();
-      expect(mockWrite).not.toHaveBeenCalled();
       expect(console.log).toHaveBeenCalledWith('No blocks selected to copy.');
     });
 
-    it('should handle errors during serialization of one of the blocks', async () => {
-      const blockData1 = mockBlockData({ id: 'selBlockOK', content: 'OK Block' });
-      const mockBlock1 = createMockBlock(blockData1);
-      const mockBlockErr = { id: 'selBlockErr', data: vi.fn().mockRejectedValue(new Error("Failed to serialize this one!")) } as unknown as Block;
+    it('should handle errors during serialization of one block in handleCopySelectedBlocks', async () => {
+      const blockDataOK = mockBlockData({ id: 'selBlockOK', content: 'OK Block' });
+      const mockBlockOK = createMockBlock(blockDataOK, [], mockRepo); // No children for simplicity here
+      
+      const failingBlock = {
+         id: 'selBlockErr',
+         data: vi.fn().mockRejectedValue(new Error('Fail this one')),
+         children: vi.fn().mockResolvedValue([])
+      } as unknown as Block;
 
       const mockUiStateBlock = {
         getProperty: vi.fn().mockResolvedValue({ value: { selectedBlockIds: ['selBlockOK', 'selBlockErr'] } }),
       } as unknown as Block;
-      const mockRepo = {
+      
+      const specificMockRepoForError = {
         find: vi.fn(id => {
-          if (id === 'selBlockOK') return mockBlock1;
-          if (id === 'selBlockErr') return mockBlockErr;
+          if (id === 'selBlockOK') return mockBlockOK;
+          if (id === 'selBlockErr') return failingBlock;
           return undefined;
         }),
-      } as any;
-      const deps: MultiSelectModeDependencies = { uiStateBlock: mockUiStateBlock, repo: mockRepo };
+      } as unknown as Repo;
+      const deps: MultiSelectModeDependencies = { uiStateBlock: mockUiStateBlock, repo: specificMockRepoForError };
 
       await handleCopySelectedBlocks(deps);
       
@@ -245,11 +341,10 @@ describe('Clipboard Action Handlers', () => {
       // Still copies the block that was successful
       expect(mockWriteText).toHaveBeenCalledTimes(1);
       const expectedClipboardData: ClipboardData = {
-        markdown: 'OK Block', // Only the successful one
-        blocks: [blockData1],  // Only the successful one
+        markdown: 'OK Block',
+        blocks: [blockDataOK],
       };
-      expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify(expectedClipboardData));
-      expect(mockWrite).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(mockWriteText.mock.calls[0][0])).toEqual(expectedClipboardData);
     });
   });
 });

--- a/src/utils/test/copy.test.ts
+++ b/src/utils/test/copy.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { serializeBlockForClipboard } from '../copy';
+import { handleCopyBlock, handleCopySelectedBlocks } from '../../shortcuts/defaultShortcuts'; // Import new handlers
+import type { Block } from '../../data/block';
+import type { BlockData } from '../../data/block';
+import type { ClipboardData } from '../../types';
+import type { BlockShortcutDependencies, MultiSelectModeDependencies } from '../../shortcuts/types';
+import { selectionStateProp } from '../../data/properties';
+
+// Mock navigator.clipboard
+const mockWriteText = vi.fn();
+const mockWrite = vi.fn();
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    writeText: mockWriteText,
+    write: mockWrite,
+  },
+  writable: true,
+});
+
+// Helper function to create mock BlockData objects
+const mockBlockData = (data: Partial<BlockData>): BlockData => ({
+  id: 'defaultId',
+  content: '',
+  properties: {},
+  childIds: [],
+  createTime: Date.now(),
+  updateTime: Date.now(),
+  createdByUserId: 'testUser',
+  updatedByUserId: 'testUser',
+  ...data,
+});
+
+// Helper to create a mock Block
+const createMockBlock = (data: BlockData): Block => ({
+  id: data.id,
+  data: vi.fn().mockResolvedValue(data),
+  // Add other Block methods if they become necessary for tests
+} as unknown as Block);
+
+describe('serializeBlockForClipboard', () => {
+  it('should correctly serialize a simple block with basic content', async () => {
+    const sampleData = mockBlockData({
+      id: 'testBlock1',
+      content: 'Hello world from testBlock1',
+    });
+    const mockBlock = createMockBlock(sampleData);
+    const expectedClipboardData: ClipboardData = {
+      markdown: 'Hello world from testBlock1',
+      blocks: [sampleData],
+    };
+    const result = await serializeBlockForClipboard(mockBlock);
+    expect(result).toEqual(expectedClipboardData);
+    expect(mockBlock.data).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly serialize a block with properties', async () => {
+    const sampleDataWithProps = mockBlockData({
+      id: 'testBlock2',
+      content: '# A Heading Here',
+      properties: {
+        type: { name: 'type', type: 'string', value: 'heading' },
+        customProp: { name: 'customProp', type: 'number', value: 123 },
+      },
+    });
+    const mockBlock = createMockBlock(sampleDataWithProps);
+    const expectedClipboardData: ClipboardData = {
+      markdown: '# A Heading Here',
+      blocks: [sampleDataWithProps],
+    };
+    const result = await serializeBlockForClipboard(mockBlock);
+    expect(result).toEqual(expectedClipboardData);
+    expect(result.blocks[0].properties).toEqual(sampleDataWithProps.properties);
+    expect(mockBlock.data).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw an error if block.data() returns null or undefined', async () => {
+    const mockBlockNullData = { id: 'testBlock3', data: vi.fn().mockResolvedValue(null) } as unknown as Block;
+    await expect(serializeBlockForClipboard(mockBlockNullData))
+      .rejects
+      .toThrow('Failed to retrieve data for block with id testBlock3');
+
+    const mockBlockUndefinedData = { id: 'testBlock4', data: vi.fn().mockResolvedValue(undefined) } as unknown as Block;
+    await expect(serializeBlockForClipboard(mockBlockUndefinedData))
+      .rejects
+      .toThrow('Failed to retrieve data for block with id testBlock4');
+  });
+});
+
+describe('Clipboard Action Handlers', () => {
+  beforeEach(() => {
+    mockWriteText.mockClear();
+    mockWrite.mockClear();
+    vi.spyOn(console, 'log').mockImplementation(() => {}); // Suppress console.log
+    vi.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console.error
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks(); // Restore console mocks
+  });
+
+  describe('handleCopyBlock', () => {
+    it('should call navigator.clipboard.writeText and write with correct data', async () => {
+      const bData = mockBlockData({ id: 'cb1', content: 'Copied content' });
+      const mBlock = createMockBlock(bData);
+      const deps: BlockShortcutDependencies = {
+        block: mBlock,
+        uiStateBlock: {} as Block, // Mocked, not directly used by handleCopyBlock's core logic
+        repo: {} as any, // Mocked
+        // Add other deps if necessary
+      };
+
+      await handleCopyBlock(deps);
+
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+      const expectedClipboardData: ClipboardData = {
+        markdown: 'Copied content',
+        blocks: [bData],
+      };
+      expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify(expectedClipboardData));
+
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+      expect(mockWrite).toHaveBeenCalledWith([
+        expect.any(ClipboardItem), // Actual ClipboardItem
+      ]);
+      // More detailed check for ClipboardItem content if possible and necessary
+      const clipboardItemArg = mockWrite.mock.calls[0][0][0] as ClipboardItem;
+      const blob = await clipboardItemArg.getType('text/plain');
+      expect(await blob.text()).toBe('Copied content');
+    });
+
+    it('should handle error if serializeBlockForClipboard fails', async () => {
+      const mBlock = { id: 'errBlock', data: vi.fn().mockRejectedValue(new Error('Serialization failed')) } as unknown as Block;
+      const deps: BlockShortcutDependencies = { block: mBlock, uiStateBlock: {} as Block, repo: {} as any };
+
+      await handleCopyBlock(deps);
+
+      expect(mockWriteText).not.toHaveBeenCalled();
+      expect(mockWrite).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith('Failed to copy block to clipboard:', expect.any(Error));
+    });
+     it('should handle navigator.clipboard.write not being available', async () => {
+      const originalWrite = navigator.clipboard.write;
+      // @ts-ignore
+      navigator.clipboard.write = undefined; // Simulate write not being available
+
+      const bData = mockBlockData({ id: 'cb_no_write', content: 'No write API' });
+      const mBlock = createMockBlock(bData);
+      const deps: BlockShortcutDependencies = { block: mBlock, uiStateBlock: {} as Block, repo: {} as any };
+
+      await handleCopyBlock(deps);
+
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+      expect(mockWrite).not.toHaveBeenCalled(); // mockWrite itself is vi.fn(), so this checks if the *original* was called through our mock setup
+      expect(console.log).toHaveBeenCalledWith('Block content (JSON) copied to clipboard. Markdown copy skipped (navigator.clipboard.write not available).');
+      
+      // @ts-ignore
+      navigator.clipboard.write = originalWrite; // Restore
+    });
+  });
+
+  describe('handleCopySelectedBlocks', () => {
+    it('should copy multiple selected blocks to clipboard', async () => {
+      const blockData1 = mockBlockData({ id: 'selBlock1', content: 'First selected' });
+      const blockData2 = mockBlockData({ id: 'selBlock2', content: 'Second selected' });
+      const mockBlock1 = createMockBlock(blockData1);
+      const mockBlock2 = createMockBlock(blockData2);
+
+      const mockUiStateBlock = {
+        getProperty: vi.fn().mockResolvedValue({
+          value: {
+            selectedBlockIds: ['selBlock1', 'selBlock2'],
+            anchorBlockId: 'selBlock1',
+          }
+        }),
+      } as unknown as Block;
+
+      const mockRepo = {
+        find: vi.fn(id => {
+          if (id === 'selBlock1') return mockBlock1;
+          if (id === 'selBlock2') return mockBlock2;
+          return undefined;
+        }),
+      } as any;
+
+      const deps: MultiSelectModeDependencies = {
+        uiStateBlock: mockUiStateBlock,
+        repo: mockRepo,
+        // Add other deps if necessary
+      };
+
+      await handleCopySelectedBlocks(deps);
+
+      expect(mockUiStateBlock.getProperty).toHaveBeenCalledWith(selectionStateProp);
+      expect(mockRepo.find).toHaveBeenCalledWith('selBlock1');
+      expect(mockRepo.find).toHaveBeenCalledWith('selBlock2');
+
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+      const expectedClipboardData: ClipboardData = {
+        markdown: 'First selected\n\nSecond selected',
+        blocks: [blockData1, blockData2],
+      };
+      expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify(expectedClipboardData));
+
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+      const clipboardItemArg = mockWrite.mock.calls[0][0][0] as ClipboardItem;
+      const blob = await clipboardItemArg.getType('text/plain');
+      expect(await blob.text()).toBe('First selected\n\nSecond selected');
+    });
+
+    it('should do nothing if no blocks are selected', async () => {
+      const mockUiStateBlock = {
+        getProperty: vi.fn().mockResolvedValue({ value: { selectedBlockIds: [] } }),
+      } as unknown as Block;
+      const deps: MultiSelectModeDependencies = { uiStateBlock: mockUiStateBlock, repo: {} as any };
+
+      await handleCopySelectedBlocks(deps);
+
+      expect(mockWriteText).not.toHaveBeenCalled();
+      expect(mockWrite).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith('No blocks selected to copy.');
+    });
+
+    it('should handle errors during serialization of one of the blocks', async () => {
+      const blockData1 = mockBlockData({ id: 'selBlockOK', content: 'OK Block' });
+      const mockBlock1 = createMockBlock(blockData1);
+      const mockBlockErr = { id: 'selBlockErr', data: vi.fn().mockRejectedValue(new Error("Failed to serialize this one!")) } as unknown as Block;
+
+      const mockUiStateBlock = {
+        getProperty: vi.fn().mockResolvedValue({ value: { selectedBlockIds: ['selBlockOK', 'selBlockErr'] } }),
+      } as unknown as Block;
+      const mockRepo = {
+        find: vi.fn(id => {
+          if (id === 'selBlockOK') return mockBlock1;
+          if (id === 'selBlockErr') return mockBlockErr;
+          return undefined;
+        }),
+      } as any;
+      const deps: MultiSelectModeDependencies = { uiStateBlock: mockUiStateBlock, repo: mockRepo };
+
+      await handleCopySelectedBlocks(deps);
+      
+      expect(console.error).toHaveBeenCalledWith("Failed to serialize block selBlockErr for clipboard:", expect.any(Error));
+      // Still copies the block that was successful
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+      const expectedClipboardData: ClipboardData = {
+        markdown: 'OK Block', // Only the successful one
+        blocks: [blockData1],  // Only the successful one
+      };
+      expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify(expectedClipboardData));
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Adds clipboard copy functionality for single and multiple blocks.

- You can press Cmd/Ctrl+C to copy selected block(s).
- For single block selection (Normal Mode), the focused block is copied.
- For multiple block selection (Multi-Select Mode), all selected blocks are copied.

The copied data includes:
1. A plain text markdown representation of the block content(s). This allows pasting into external applications.
2. A JSON string containing full block data, including properties and hierarchy information. This is stored for pasting within the application to maintain fidelity.

Key changes:
- Added `ClipboardData` interface in `src/types.ts`.
- Created `src/utils/copy.ts` with `serializeBlockForClipboard` to prepare block data for the clipboard.
- Added `copy_block` and `copy_selected_blocks` actions in `src/shortcuts/defaultShortcuts.ts`.
- Bound these actions to `Cmd/Ctrl+C`.
- Refactored action handlers in `defaultShortcuts.ts` for better testability.
- Added unit tests for serialization logic and action handlers in `src/utils/test/copy.test.ts`, including mocks for `navigator.clipboard`.