### PR TITLE
Add mobile editing toolbar; fix mobile collapse button

### DIFF
--- a/src/components/renderer/DefaultBlockRenderer.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.tsx
@@ -189,16 +189,28 @@ const ExpandButton = ({block}: { block: Block }) => {
       ? 'opacity-0 group-hover/block:opacity-100'
       : 'opacity-0'
 
+  // On touch devices the synthesized `click` arrives after a small
+  // delay and after `pointerup`/`touchend`; if anything between those
+  // events reroutes focus or React unmounts/repaints the button, the
+  // click can land on the underlying block-content and dispatch the
+  // block click handler — dropping us into edit mode. Stopping
+  // propagation on `pointerdown` blocks that path the moment the touch
+  // is registered, before the synthetic click bubbles. The redundant
+  // `onClick.stopPropagation` covers the desktop mouse path.
+  const toggle = () => setIsCollapsed(!isCollapsed)
+
   return (
     <Button
       variant="ghost"
       size="sm"
       type="button"
+      data-block-interaction="ignore"
+      onPointerDown={(e) => e.stopPropagation()}
       onClick={(e) => {
         e.stopPropagation()
-        setIsCollapsed(!isCollapsed)
+        toggle()
       }}
-      className={`expand-collapse-button h-6 p-0 hover:bg-none transition-opacity ${visibilityClass} ${isMobile ? 'w-6' : 'w-3'}`}
+      className={`expand-collapse-button p-0 hover:bg-none transition-opacity ${visibilityClass} ${isMobile ? 'h-8 w-8' : 'h-6 w-3'}`}
     >
       <span className="text-lg text-muted-foreground">
         {isCollapsed ? '▸' : '▾'}
@@ -477,7 +489,7 @@ export function DefaultBlockRenderer(
             <BlockBullet block={block}/>
           </div>
           {isMobile && hasChildren && (
-            <div className="absolute right-1 top-0">
+            <div className="absolute right-0 top-0 z-10">
               <ExpandButton block={block}/>
             </div>
           )}

--- a/src/extensions/staticAppExtensions.ts
+++ b/src/extensions/staticAppExtensions.ts
@@ -11,6 +11,7 @@ import { quickFindPlugin } from '@/plugins/quick-find'
 import { themeTogglePlugin } from '@/plugins/theme-toggle'
 import { workspaceHeaderPlugin } from '@/plugins/workspace-header'
 import { plainOutlinerPlugin } from '@/plugins/plain-outliner'
+import { mobileKeyboardToolbarPlugin } from '@/plugins/mobile-keyboard-toolbar'
 import { vimNormalModePlugin } from '@/plugins/vim-normal-mode'
 import { videoPlayerPlugin } from '@/plugins/video-player'
 import { backlinksPlugin } from '@/plugins/backlinks'
@@ -38,6 +39,7 @@ export const staticAppExtensions = ({repo}: {repo: Repo}): AppExtension[] => [
   themeTogglePlugin,
   accountHeaderPlugin,
   plainOutlinerPlugin,
+  mobileKeyboardToolbarPlugin,
   vimNormalModePlugin({repo}),
   videoPlayerPlugin,
   // The backlinks-view coordinator reads variants registered by

--- a/src/plugins/mobile-keyboard-toolbar/MobileKeyboardToolbar.tsx
+++ b/src/plugins/mobile-keyboard-toolbar/MobileKeyboardToolbar.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState, type MouseEvent } from 'react'
+import {
+  IndentDecrease,
+  IndentIncrease,
+  ArrowUp,
+  ArrowDown,
+  Undo2,
+  Redo2,
+  KeyboardOff,
+} from 'lucide-react'
+import { useIsEditing } from '@/data/globalState.ts'
+import { useIsMobile } from '@/utils/react.tsx'
+import { useRunAction } from '@/shortcuts/runAction.ts'
+
+interface ToolbarAction {
+  id: string
+  actionId: string
+  label: string
+  icon: typeof IndentDecrease
+}
+
+const TOOLBAR_ACTIONS: readonly ToolbarAction[] = [
+  {id: 'outdent', actionId: 'edit.cm.outdent_block', label: 'Outdent', icon: IndentDecrease},
+  {id: 'indent', actionId: 'edit.cm.indent_block', label: 'Indent', icon: IndentIncrease},
+  {id: 'move-up', actionId: 'move_block_up_cm', label: 'Move up', icon: ArrowUp},
+  {id: 'move-down', actionId: 'move_block_down_cm', label: 'Move down', icon: ArrowDown},
+  {id: 'undo', actionId: 'undo', label: 'Undo', icon: Undo2},
+  {id: 'redo', actionId: 'redo', label: 'Redo', icon: Redo2},
+  {id: 'done', actionId: 'exit_edit_mode_cm', label: 'Done', icon: KeyboardOff},
+]
+
+/** Tracks the visualViewport's keyboard inset so the toolbar can sit
+ *  flush against the top of the on-screen keyboard. iOS pins the
+ *  visualViewport above the keyboard while leaving the layout viewport
+ *  at the full window height; without compensating, a `bottom: 0`
+ *  fixed element would render under the keyboard. Browsers without
+ *  visualViewport (or where the keyboard already shrinks the layout
+ *  viewport — most Android cases) read offset 0 and just pin to the
+ *  bottom edge. */
+const useKeyboardOffset = (): number => {
+  const [offset, setOffset] = useState(0)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const vv = window.visualViewport
+    if (!vv) return
+
+    const update = () => {
+      const inset = window.innerHeight - vv.height - vv.offsetTop
+      setOffset(Math.max(0, inset))
+    }
+
+    update()
+    vv.addEventListener('resize', update)
+    vv.addEventListener('scroll', update)
+    return () => {
+      vv.removeEventListener('resize', update)
+      vv.removeEventListener('scroll', update)
+    }
+  }, [])
+
+  return offset
+}
+
+/** Mobile-only toolbar that sits above the on-screen keyboard while a
+ *  block is being edited, exposing tap targets for the workflowy/roam-
+ *  style block commands (indent / outdent / reorder / undo / done).
+ *  Each button dispatches the same action id that the keyboard binding
+ *  invokes, so behavior stays in lockstep with the desktop shortcuts. */
+export function MobileKeyboardToolbar() {
+  const isMobile = useIsMobile()
+  const [isEditing] = useIsEditing()
+  const runAction = useRunAction()
+  const keyboardOffset = useKeyboardOffset()
+
+  if (!isMobile || !isEditing) return null
+
+  // Prevent the editor from blurring when a button is pressed — losing
+  // focus would dismiss the on-screen keyboard mid-tap and tear down
+  // the EDIT_MODE_CM context the action depends on. `mousedown` is
+  // dispatched by both mouse pointers and (via compat events) touch,
+  // and preventDefault on it is the established cross-browser way to
+  // keep the active element anchored through a tap on a different DOM
+  // node — same pattern used by the autocomplete popovers in this app.
+  const handleMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+  }
+
+  const handleClick = (actionId: string) => async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    // Action handlers expect ActionTrigger = KeyboardEvent | CustomEvent.
+    // None of the actions wired to this toolbar consult the trigger,
+    // but typing demands one — synthesize a CustomEvent so we don't
+    // misrepresent a click as a keyboard event.
+    const trigger = new CustomEvent('mobile-toolbar-action', {detail: {actionId}})
+    try {
+      await runAction(actionId, trigger)
+    } catch (error) {
+      console.error(`[MobileKeyboardToolbar] Failed to run ${actionId}`, error)
+    }
+  }
+
+  return (
+    <div
+      className="mobile-keyboard-toolbar fixed left-0 right-0 z-50 flex items-center justify-around gap-1 border-t border-border bg-background/95 px-1 py-1 backdrop-blur supports-[backdrop-filter]:bg-background/80"
+      style={{bottom: keyboardOffset}}
+      data-block-interaction="ignore"
+    >
+      {TOOLBAR_ACTIONS.map(({id, actionId, label, icon: Icon}) => (
+        <button
+          key={id}
+          type="button"
+          aria-label={label}
+          title={label}
+          onMouseDown={handleMouseDown}
+          onClick={handleClick(actionId)}
+          className="flex h-10 flex-1 items-center justify-center rounded-md text-muted-foreground transition-colors active:bg-accent active:text-accent-foreground"
+        >
+          <Icon className="h-5 w-5"/>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/plugins/mobile-keyboard-toolbar/index.ts
+++ b/src/plugins/mobile-keyboard-toolbar/index.ts
@@ -1,0 +1,14 @@
+import { appMountsFacet, type AppMountContribution } from '@/extensions/core.ts'
+import type { AppExtension } from '@/extensions/facet.ts'
+import { MobileKeyboardToolbar } from './MobileKeyboardToolbar.tsx'
+
+export { MobileKeyboardToolbar } from './MobileKeyboardToolbar.tsx'
+
+export const mobileKeyboardToolbarMount: AppMountContribution = {
+  id: 'mobile-keyboard-toolbar.mount',
+  component: MobileKeyboardToolbar,
+}
+
+export const mobileKeyboardToolbarPlugin: AppExtension = [
+  appMountsFacet.of(mobileKeyboardToolbarMount, {source: 'mobile-keyboard-toolbar'}),
+]


### PR DESCRIPTION
- New MobileKeyboardToolbar plugin renders a fixed bar above the
  on-screen keyboard while editing on mobile. Buttons dispatch the
  same action ids as keyboard shortcuts (indent / outdent / move
  up/down / undo / redo / done), so behavior stays in lockstep with
  desktop. visualViewport tracking keeps the bar pinned to the top
  of the keyboard on iOS; mousedown.preventDefault keeps the editor
  focused so the keyboard doesn't dismiss mid-tap.
- ExpandButton: stop pointerdown propagation in addition to click
  (touch click is delayed and could leak to the underlying block
  click handler, dropping the user into edit mode), enlarge the
  mobile hit target to 32x32, mark it data-block-interaction=ignore
  and z-10 so it sits cleanly above sibling content.