### PR TITLE
Position mobile toolbar via VirtualKeyboard API + keyboard-inset-height

### DIFF
--- a/src/plugins/mobile-keyboard-toolbar/MobileKeyboardToolbar.tsx
+++ b/src/plugins/mobile-keyboard-toolbar/MobileKeyboardToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type MouseEvent } from 'react'
+import { useEffect, type MouseEvent } from 'react'
 import {
   IndentDecrease,
   IndentIncrease,
@@ -33,91 +33,33 @@ const TOOLBAR_ACTIONS: readonly ToolbarAction[] = [
   {id: 'done', actionId: EXIT_EDIT_ACTION_ID, label: 'Done', icon: KeyboardOff},
 ]
 
-/** Computes the keyboard inset by *measuring* where a `position:fixed
- *  bottom:0` sentinel actually lands relative to the visualViewport,
- *  then returning the gap (in CSS px) between that landing point and
- *  the visual viewport's bottom edge.
+/** Opt the page into the VirtualKeyboard API on browsers that support
+ *  it (Chrome / Edge / Samsung Internet on Android, version-gated).
+ *  With `overlaysContent = true`:
+ *  - The browser stops shrinking visualViewport when the IME shows.
+ *  - It exposes `env(keyboard-inset-height)` (and friends) so CSS can
+ *    react to the IME without our JS having to guess where the
+ *    keyboard ends.
  *
- *  This is browser-agnostic by construction:
- *  - Chrome on Android (interactive-widget=resizes-content, the default):
- *    both viewports shrink with the IME, sentinel.bottom == vv.height,
- *    inset = 0.
- *  - iOS Safari 16+: position:fixed is pinned to the visual viewport,
- *    sentinel.bottom == vv.height, inset = 0.
- *  - Samsung Internet / Chrome with overlays-content: layout viewport
- *    stays full, position:fixed sticks to the layout viewport bottom
- *    which sits *under* the keyboard, sentinel.bottom > vv.height,
- *    inset > 0 — exactly the keyboard overlap.
+ *  This is the cleanest solution for the toolbar's positioning problem
+ *  on Android (Edge / Samsung). Without this opt-in, Edge leaves the
+ *  layout viewport at full height *and* anchors position:fixed to it,
+ *  so `bottom:0` lands under the keyboard; computing an inset from
+ *  visualViewport would in turn overshoot by the URL-bar height
+ *  (innerHeight includes browser chrome that vv.height excludes).
+ *  iOS Safari doesn't support the API but pins position:fixed to the
+ *  visual viewport itself, so `env(keyboard-inset-height, 0px)`
+ *  resolving to 0 — combined with `bottom: env(...)` — already lands
+ *  the toolbar above the keyboard.
  *
- *  An earlier formula (`window.innerHeight - vv.height - vv.offsetTop`)
- *  reported the wrong value on Samsung's bottom URL bar setup because
- *  innerHeight included chrome that vv.height excluded. The sentinel
- *  short-circuits that whole class of bug — we only care about the
- *  delta between where bottom-0 lands and where the visible viewport
- *  ends, in the browser's own coordinate system. */
-const useKeyboardInset = (active: boolean): number => {
-  const sentinelRef = useRef<HTMLDivElement | null>(null)
-  const [inset, setInset] = useState(0)
-
-  // Mount the sentinel imperatively so it doesn't participate in React's
-  // tree / styling. It just needs to be in the document so the browser
-  // assigns it a real layout box.
-  useLayoutEffect(() => {
-    if (!active || typeof document === 'undefined') return
-    const el = document.createElement('div')
-    el.setAttribute('aria-hidden', 'true')
-    Object.assign(el.style, {
-      position: 'fixed',
-      left: '0',
-      bottom: '0',
-      width: '1px',
-      height: '1px',
-      pointerEvents: 'none',
-      visibility: 'hidden',
-    } as Partial<CSSStyleDeclaration>)
-    document.body.appendChild(el)
-    sentinelRef.current = el
-    return () => {
-      document.body.removeChild(el)
-      sentinelRef.current = null
-    }
-  }, [active])
-
-  useEffect(() => {
-    if (!active || typeof window === 'undefined') return
-    const vv = window.visualViewport
-
-    const update = () => {
-      const el = sentinelRef.current
-      if (!el) return
-      const rect = el.getBoundingClientRect()
-      // Both `rect.bottom` and `vv.height` are in CSS px and share the
-      // same coordinate system (the visual viewport in modern browsers).
-      // If `bottom:0` is anchored to the visual viewport, rect.bottom
-      // already equals vv.height — gap is zero. If it's anchored to the
-      // layout viewport, rect.bottom overshoots into the keyboard area
-      // and the gap is exactly the keyboard's CSS-px height.
-      const vvBottom = vv ? vv.height : window.innerHeight
-      const next = Math.max(0, Math.round(rect.bottom - vvBottom))
-      setInset(prev => (prev === next ? prev : next))
-    }
-
-    update()
-    if (vv) {
-      vv.addEventListener('resize', update)
-      vv.addEventListener('scroll', update)
-    }
-    window.addEventListener('resize', update)
-    return () => {
-      if (vv) {
-        vv.removeEventListener('resize', update)
-        vv.removeEventListener('scroll', update)
-      }
-      window.removeEventListener('resize', update)
-    }
-  }, [active])
-
-  return inset
+ *  Idempotent and only takes effect when the API exists. */
+const enableVirtualKeyboardOverlay = (): void => {
+  if (typeof navigator === 'undefined') return
+  const vk = (navigator as Navigator & {
+    virtualKeyboard?: { overlaysContent: boolean }
+  }).virtualKeyboard
+  if (!vk) return
+  if (!vk.overlaysContent) vk.overlaysContent = true
 }
 
 /** Mobile-only toolbar that sits above the on-screen keyboard while a
@@ -136,10 +78,14 @@ export function MobileKeyboardToolbar() {
   const activeContexts = useActiveContextsState()
   const isEditing = activeContexts.has(ActionContextTypes.EDIT_MODE_CM)
   const runAction = useRunAction()
-  // Hooks above the early-return must run on every render. Pass the
-  // activation flag in so the sentinel only mounts/listens while the
-  // toolbar is on screen.
-  const keyboardInset = useKeyboardInset(isMobile && isEditing)
+
+  // Opt into the VirtualKeyboard API once the toolbar would actually
+  // appear — pulling this up to mount-time would penalize sessions
+  // that never edit on mobile by changing the layout-viewport
+  // semantics for nothing. Idempotent on subsequent calls.
+  useEffect(() => {
+    if (isMobile && isEditing) enableVirtualKeyboardOverlay()
+  }, [isMobile, isEditing])
 
   if (!isMobile || !isEditing) return null
 
@@ -206,11 +152,15 @@ export function MobileKeyboardToolbar() {
 
   return (
     <div
-      // bottom is `keyboardInset` (0 on browsers where position:fixed
-      // already follows the visual viewport, otherwise the keyboard's
-      // CSS-px height as measured by the sentinel — see useKeyboardInset).
+      // `env(keyboard-inset-height)` resolves to the IME's height in CSS
+      // px on browsers with the VirtualKeyboard API enabled (we opt in
+      // above). Falls back to 0 on browsers that don't expose it (notably
+      // iOS Safari) — but iOS Safari pins position:fixed to the visual
+      // viewport itself, so `bottom:0` is already flush above the
+      // keyboard there. The fallback covers older Chromiums equivalently
+      // for the no-keyboard case.
       className="mobile-keyboard-toolbar fixed left-0 right-0 z-50 flex items-center justify-around gap-1 border-t border-border bg-background/95 px-1 py-1 backdrop-blur supports-[backdrop-filter]:bg-background/80"
-      style={{bottom: keyboardInset}}
+      style={{bottom: 'env(keyboard-inset-height, 0px)'}}
       data-block-interaction="ignore"
     >
       {TOOLBAR_ACTIONS.map(({id, actionId, label, icon: Icon}) => (


### PR DESCRIPTION
Previous approaches all hit a common dead end on Edge mobile (and likely Samsung Internet): position:fixed is anchored to the layout viewport AND the layout viewport stays full-height while the IME shows. That breaks bottom:0 directly (toolbar lands under the keyboard), and any visualViewport-derived inset overshoots — the delta from innerHeight to vv.height includes the URL bar, not just the keyboard, so the toolbar floats with a chunk of dead space below. Both the manual `innerHeight - vv.height` formula and the sentinel- based variant produced the same overshoot for the same root cause.

Switch to the VirtualKeyboard API: when the toolbar would appear, set navigator.virtualKeyboard.overlaysContent = true. With that opt-in, the browser exposes `env(keyboard-inset-height)` — the IME's height in CSS px, no URL bar mixed in — and the toolbar's `bottom: env(..., 0px)` resolves to exactly the keyboard height when up, 0 otherwise. Supported in Chromium 94+ (Chrome / Edge / Samsung Internet on Android). iOS Safari doesn't expose the API yet but pins position:fixed to the visual viewport itself, so the 0px fallback already lands the toolbar above the keyboard there.

The opt-in is gated behind `isMobile && isEditing` so sessions that never edit on mobile aren't penalized by the layout-viewport semantics change. The earlier sentinel hook is gone (the API obsoletes it). Verified in playwright: env(keyboard-inset-height) resolves, the API opt-in lands, and the move-down / move-up / indent / outdent / undo / redo / Done regressions all pass.