### PR TITLE
Swipe quick-actions: multi-row toolbar; register SRS quick actions & block decoration

### DIFF
--- a/src/plugins/srs-rescheduling/index.ts
+++ b/src/plugins/srs-rescheduling/index.ts
@@ -1,6 +1,8 @@
 import { actionsFacet } from '@/extensions/core.ts'
 import type { AppExtension } from '@/extensions/facet.ts'
 import type { Block } from '@/data/block'
+import type { BlockContentSurfaceContribution } from '@/extensions/blockInteraction.ts'
+import { blockContentSurfacePropsFacet } from '@/extensions/blockInteraction.ts'
 import { ChangeScope, type PropertySchema } from '@/data/api'
 import { getOrCreateDailyNote } from '@/plugins/daily-notes'
 import { getBlockTypes } from '@/data/properties.ts'
@@ -28,6 +30,7 @@ import {
   srsReviewCountProp,
   srsSnapshotHistoryProp,
 } from './schema.ts'
+import { quickActionItemsFacet } from '@/plugins/swipe-quick-actions'
 
 const shortcutKeysForSignal = (signal: SrsSignal): string[] => {
   const key = String(signal)
@@ -168,8 +171,27 @@ export const srsReschedulingActions: readonly ActionConfig[] = [
   })),
 ]
 
+const srsQuickActionItems = srsSignals.map(signal => ({
+  actionId: `srs.reschedule.${signalName(signal).toLowerCase()}`,
+  label: signalName(signal),
+  row: 2 as const,
+}))
+
+const srsContentSurfaceDecoration: BlockContentSurfaceContribution = ({block}) => {
+  const data = block.peek()
+  if (!data || !getBlockTypes(data).includes(SRS_SM25_TYPE)) return null
+  return {
+    className: 'srs-review-block border-l-2 border-primary/40 pl-2 before:mr-1 before:text-[10px] before:font-semibold before:uppercase before:tracking-wide before:text-primary/70 before:content-["srs"]',
+    title: 'Space Repetition block (SM-2.5 metadata present)',
+  }
+}
+
 export const srsReschedulingPlugin: AppExtension = [
   srsReschedulingDataExtension,
+  srsQuickActionItems.map(item =>
+    quickActionItemsFacet.of(item, {source: 'srs-rescheduling'}),
+  ),
+  blockContentSurfacePropsFacet.of(srsContentSurfaceDecoration, {source: 'srs-rescheduling'}),
   srsReschedulingActions.map(action =>
     actionsFacet.of(action, {source: 'srs-rescheduling'}),
   ),

--- a/src/plugins/srs-rescheduling/test/plugin.test.ts
+++ b/src/plugins/srs-rescheduling/test/plugin.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { actionsFacet } from '@/extensions/core.ts'
+import { blockContentSurfacePropsFacet } from '@/extensions/blockInteraction.ts'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.ts'
 import { propertySchemasFacet, typesFacet } from '@/data/facets.ts'
 import { ActionConfig, ActionContextTypes } from '@/shortcuts/types.ts'
+import { quickActionItemsFacet } from '@/plugins/swipe-quick-actions'
 import {
   SRS_SM25_TYPE,
   srsArchivedProp,
@@ -69,6 +71,20 @@ describe('srsReschedulingPlugin', () => {
       ['ctrl+shift+4', 'ctrl+shift+alt+cmd+4'],
       ['ctrl+shift+5', 'ctrl+shift+alt+cmd+5'],
     ])
+  })
+
+  it('contributes swipe quick actions and block decoration hook for SRS blocks', () => {
+    const runtime = resolveFacetRuntimeSync(srsReschedulingPlugin)
+    const items = runtime.read(quickActionItemsFacet)
+
+    expect(items.map(item => [item.actionId, item.row ?? 1])).toEqual([
+      ['srs.reschedule.again', 2],
+      ['srs.reschedule.hard', 2],
+      ['srs.reschedule.good', 2],
+      ['srs.reschedule.easy', 2],
+      ['srs.reschedule.sooner', 2],
+    ])
+    expect(runtime.contributions(blockContentSurfacePropsFacet)).toHaveLength(1)
   })
 
   it('does not rewrite legacy inline SRS content from edit mode', async () => {

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -106,14 +106,14 @@ interface ResolvedQuickAction {
 
 const FallbackIcon: ActionIcon = (props) => <Circle {...props}/>
 
-const TOOLBAR_HEIGHT_PX = 28
+const TOOLBAR_ROW_HEIGHT_PX = 28
 
 /** Build a render-ready view for the toolbar from `(items, registry)`,
  *  so the JSX below stays focused on layout. */
-const useResolvedActions = (
+const resolveActions = (
   items: readonly QuickActionItem[],
   registry: readonly ActionConfig[],
-): readonly ResolvedQuickAction[] => useMemo(() => items.map(item => {
+): readonly ResolvedQuickAction[] => items.map(item => {
   const action = registry.find(a => a.id === item.actionId)
   return {
     item,
@@ -121,7 +121,7 @@ const useResolvedActions = (
     Icon: action?.icon ?? FallbackIcon,
     label: item.label ?? action?.description ?? item.actionId,
   }
-}), [items, registry])
+})
 
 interface ActionButtonProps {
   resolved: ResolvedQuickAction
@@ -202,17 +202,31 @@ export const SwipeActionMenu = () => {
   // every render re-use the same icon / label.
   const allActions = runtime.read(actionsFacet)
   const actionItems = runtime.read(quickActionItemsFacet)
-  const [primaryItems, overflowItems] = useMemo(() => {
-    const primary: QuickActionItem[] = []
+  const [primaryRows, overflowItems] = useMemo(() => {
+    const rows = new Map<number, QuickActionItem[]>()
     const overflow: QuickActionItem[] = []
     for (const item of actionItems) {
       if (item.overflow) overflow.push(item)
-      else primary.push(item)
+      else {
+        const row = item.row ?? 1
+        const existing = rows.get(row)
+        if (existing) existing.push(item)
+        else rows.set(row, [item])
+      }
     }
-    return [primary, overflow] as const
+    return [
+      [...rows.entries()].sort((a, b) => a[0] - b[0]).map(([, items]) => items),
+      overflow,
+    ] as const
   }, [actionItems])
-  const primaryResolved = useResolvedActions(primaryItems, allActions)
-  const overflowResolved = useResolvedActions(overflowItems, allActions)
+  const primaryRowsResolved = useMemo(
+    () => primaryRows.map(items => resolveActions(items, allActions)),
+    [primaryRows, allActions],
+  )
+  const overflowResolved = useMemo(
+    () => resolveActions(overflowItems, allActions),
+    [overflowItems, allActions],
+  )
 
   // Close the overflow popout whenever the active block changes, so a
   // re-swipe on a different row doesn't carry stale popout state. Done
@@ -345,10 +359,11 @@ export const SwipeActionMenu = () => {
   // Align the strip's vertical center to the swiped row's center so it
   // replaces one normal text row (Workflowy-style), while spanning the
   // viewport horizontally.
+  const toolbarHeight = Math.max(primaryRowsResolved.length, 1) * TOOLBAR_ROW_HEIGHT_PX
   const centerY = anchor.top + anchor.height / 2
   const toolbarTop = Math.min(
-    Math.max(centerY, TOOLBAR_HEIGHT_PX / 2),
-    window.innerHeight - TOOLBAR_HEIGHT_PX / 2,
+    Math.max(centerY, toolbarHeight / 2),
+    window.innerHeight - toolbarHeight / 2,
   )
 
   return (
@@ -364,47 +379,54 @@ export const SwipeActionMenu = () => {
           onTouchMove={swallowTouch}
           onTouchEnd={swallowTouch}
         >
-          <div
-            className="flex h-7 w-full items-center justify-around border-y border-border bg-background/95 px-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/85"
-          >
-            {primaryResolved.map(resolved => (
-              <ActionButton
-                key={resolved.item.actionId}
-                resolved={resolved}
-                onRun={handleRun}
-              />
-            ))}
-            {overflowResolved.length > 0 && (
-              <button
-                type="button"
-                aria-label="More actions"
-                title="More actions"
-                aria-expanded={showOverflow}
-                data-block-interaction="ignore"
-                onClick={event => {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  setShowOverflow(prev => !prev)
-                }}
-                className="flex h-7 w-7 items-center justify-center rounded text-foreground hover:bg-muted active:bg-accent"
+          <div className="w-full border-y border-border bg-background/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/85">
+            {primaryRowsResolved.map((rowResolved, rowIndex) => (
+              <div
+                key={`row-${rowIndex}`}
+                className={`flex h-7 items-center justify-around px-4 ${rowIndex > 0 ? 'border-t border-border/80' : ''}`}
               >
-                <MoreHorizontal className="h-4 w-4"/>
-              </button>
-            )}
-            <button
-              type="button"
-              aria-label="Close"
-              title="Close"
-              data-block-interaction="ignore"
-              onClick={event => {
-                event.preventDefault()
-                event.stopPropagation()
-                dismiss()
-              }}
-              className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted active:bg-accent"
-            >
-              <X className="h-4 w-4"/>
-            </button>
+                {rowResolved.map(resolved => (
+                  <ActionButton
+                    key={resolved.item.actionId}
+                    resolved={resolved}
+                    onRun={handleRun}
+                  />
+                ))}
+                {rowIndex === 0 && overflowResolved.length > 0 && (
+                  <button
+                    type="button"
+                    aria-label="More actions"
+                    title="More actions"
+                    aria-expanded={showOverflow}
+                    data-block-interaction="ignore"
+                    onClick={event => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      setShowOverflow(prev => !prev)
+                    }}
+                    className="flex h-7 w-7 items-center justify-center rounded text-foreground hover:bg-muted active:bg-accent"
+                  >
+                    <MoreHorizontal className="h-4 w-4"/>
+                  </button>
+                )}
+                {rowIndex === 0 && (
+                  <button
+                    type="button"
+                    aria-label="Close"
+                    title="Close"
+                    data-block-interaction="ignore"
+                    onClick={event => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      dismiss()
+                    }}
+                    className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted active:bg-accent"
+                  >
+                    <X className="h-4 w-4"/>
+                  </button>
+                )}
+              </div>
+            ))}
           </div>
 
           {showOverflow && overflowResolved.length > 0 && (

--- a/src/plugins/swipe-quick-actions/actions.ts
+++ b/src/plugins/swipe-quick-actions/actions.ts
@@ -29,6 +29,10 @@ export interface QuickActionItem {
   /** True renders under the overflow menu; false/omitted renders in
    *  the primary one-row strip. */
   overflow?: boolean
+  /** Optional toolbar row in the primary strip on mobile. Defaults to 1.
+   *  Ignored for overflow items. Rows are grouped and rendered in
+   *  ascending order, so plugins can add row 3+ without core changes. */
+  row?: number
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -39,7 +43,8 @@ export const isQuickActionItem = (value: unknown): value is QuickActionItem =>
   typeof value.actionId === 'string' &&
   (value.label === undefined || typeof value.label === 'string') &&
   (value.destructive === undefined || typeof value.destructive === 'boolean') &&
-  (value.overflow === undefined || typeof value.overflow === 'boolean')
+  (value.overflow === undefined || typeof value.overflow === 'boolean') &&
+  (value.row === undefined || (Number.isInteger(value.row) && value.row >= 1))
 
 export const quickActionItemsFacet = defineFacet<QuickActionItem, readonly QuickActionItem[]>({
   id: 'swipe-quick-actions.items',

--- a/src/plugins/swipe-quick-actions/test/plugin.test.ts
+++ b/src/plugins/swipe-quick-actions/test/plugin.test.ts
@@ -21,15 +21,15 @@ describe('swipeQuickActionsPlugin', () => {
         component: SwipeActionMenu,
       },
     ])
-    expect(items.map(item => [item.actionId, item.overflow === true])).toEqual([
-      ['copy_block', false],
-      ['copy_block_ref', false],
-      ['open_focused_in_panel', false],
-      ['delete_block', false],
-      ['zoom_in', true],
-      ['toggle_collapse', true],
-      ['toggle_properties', true],
-      ['copy_block_embed', true],
+    expect(items.map(item => [item.actionId, item.overflow === true, item.row ?? 1])).toEqual([
+      ['copy_block', false, 1],
+      ['copy_block_ref', false, 1],
+      ['open_focused_in_panel', false, 1],
+      ['delete_block', false, 1],
+      ['zoom_in', true, 1],
+      ['toggle_collapse', true, 1],
+      ['toggle_properties', true, 1],
+      ['copy_block_embed', true, 1],
     ])
   })
 })


### PR DESCRIPTION
### Motivation

- Allow plugins to surface multiple rows of quick actions in the mobile swipe toolbar so groups of actions can be organized vertically.
- Surface SRS-related quick actions and a visual decoration for blocks containing SRS SM-2.5 metadata so those blocks are easier to identify and act on.

### Description

- Add optional `row?: number` to `QuickActionItem` and validate it in `isQuickActionItem`, and expose `quickActionItemsFacet` for plugins to contribute items with rows.  
- Update `SwipeActionMenu` to group `quickActionItems` into ordered rows, compute toolbar height from row count (`TOOLBAR_ROW_HEIGHT_PX` -> `TOOLBAR_ROW_HEIGHT_PX`), resolve actions once, and render multiple rows with separators while keeping overflow and close buttons on the primary row.  
- Rename/adjust helper to `resolveActions` and move some memoization logic to group rows and resolve them; adjust touch/click handling accordingly.  
- Extend the `srs-rescheduling` plugin to contribute `quickActionItems` for each SRS signal and register a `blockContentSurfacePropsFacet` decoration for blocks of type `SRS_SM25_TYPE`.  
- Update tests to assert the new `row` behavior and the SRS plugin contributions, and add imports for the new facets where necessary.

### Testing

- Ran unit tests with `vitest` including `swipe-quick-actions` and `srs-rescheduling` plugin tests, and the updated tests passed.  
- Verified the new test asserting row defaults in `swipe-quick-actions/test/plugin.test.ts` succeeds.  
- Verified the added SRS plugin test in `srs-rescheduling/test/plugin.test.ts` that checks quick action items and block decoration contributions succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03da74797c832798c8268e15686823)