### PR TITLE
Open daily note picker on currently viewed note

### DIFF
--- a/src/plugins/daily-notes/HeaderItem.tsx
+++ b/src/plugins/daily-notes/HeaderItem.tsx
@@ -1,23 +1,33 @@
 import type { MouseEvent } from 'react'
 import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useRepo } from '@/context/repo.tsx'
 import { useRunAction } from '@/shortcuts/runAction.ts'
 import { openDailyNotePicker } from './events.ts'
 import {
   OPEN_NEXT_DAILY_NOTE_ACTION_ID,
   OPEN_PREVIOUS_DAILY_NOTE_ACTION_ID,
+  resolveCurrentDailyNoteIso,
 } from './actions.ts'
 
 const runHeaderActionEvent = (actionId: string) =>
   new CustomEvent('daily-note-header-action', {detail: {actionId}})
 
 export function DailyNotePickerHeaderItem() {
+  const repo = useRepo()
   const runAction = useRunAction()
 
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    // Capture the rect synchronously — `event.currentTarget` is nulled
+    // after the handler yields once we await below.
     const {bottom, height, left, right, top, width} =
       event.currentTarget.getBoundingClientRect()
+    const workspaceId = repo.activeWorkspaceId
+    const initialIso = workspaceId
+      ? (await resolveCurrentDailyNoteIso(repo, workspaceId)) ?? undefined
+      : undefined
     openDailyNotePicker({
       anchorRect: {bottom, height, left, right, top, width},
+      initialIso,
     })
   }
 
@@ -43,7 +53,11 @@ export function DailyNotePickerHeaderItem() {
       </button>
       <button
         className="inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:text-foreground"
-        onClick={handleClick}
+        onClick={event => {
+          void handleClick(event).catch(error => {
+            console.error('[DailyNotePickerHeaderItem] Open picker failed', error)
+          })
+        }}
         title="Open daily note picker"
         aria-label="Open daily note picker"
       >

--- a/src/plugins/daily-notes/actions.ts
+++ b/src/plugins/daily-notes/actions.ts
@@ -74,15 +74,26 @@ const findContainingDailyNoteIso = async (
   return null
 }
 
+/** Resolve the ISO date of the daily note currently visible in the
+ *  primary (or active, on mobile) panel. Returns null when the panel's
+ *  top-level block isn't a daily note or no panel is open. Used by both
+ *  the prev/next offset actions and the date picker to open with the
+ *  correct month + selected day. */
+export const resolveCurrentDailyNoteIso = async (
+  repo: Repo,
+  workspaceId: string,
+): Promise<string | null> => {
+  const topLevelBlockId = await resolveGlobalCommandTopLevelBlockId(repo, workspaceId)
+  if (!topLevelBlockId) return null
+  return findContainingDailyNoteIso(repo, topLevelBlockId, workspaceId)
+}
+
 const openDailyNoteByOffset = async (repo: Repo, offsetDays: number) => {
   const route = parseAppHash(window.location.hash)
   const workspaceId = route.workspaceId ?? repo.activeWorkspaceId
   if (!workspaceId) return
 
-  const topLevelBlockId = await resolveGlobalCommandTopLevelBlockId(repo, workspaceId)
-  const currentIso = topLevelBlockId
-    ? await findContainingDailyNoteIso(repo, topLevelBlockId, workspaceId)
-    : null
+  const currentIso = await resolveCurrentDailyNoteIso(repo, workspaceId)
   const targetIso = addDaysIso(currentIso ?? todayIso(), offsetDays)
   const note = await getOrCreateDailyNote(repo, workspaceId, targetIso)
   navigateFromGlobalCommand(repo, {blockId: note.id, workspaceId})

--- a/src/plugins/daily-notes/index.ts
+++ b/src/plugins/daily-notes/index.ts
@@ -48,8 +48,9 @@ import {
   type HeaderItemContribution,
 } from '@/extensions/core.ts'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types.ts'
+import { parseAppHash } from '@/utils/routing.ts'
 import { CalendarDays } from 'lucide-react'
-import { dailyNotesActions } from './actions.ts'
+import { dailyNotesActions, resolveCurrentDailyNoteIso } from './actions.ts'
 import { dateReferenceShiftActions } from './dateShift.ts'
 import { dailyNotesDataExtension } from './dataExtension.ts'
 import { DailyNotePicker } from './DailyNotePicker.tsx'
@@ -61,6 +62,7 @@ export {
   OPEN_NEXT_DAILY_NOTE_ACTION_ID,
   OPEN_PREVIOUS_DAILY_NOTE_ACTION_ID,
   OPEN_TODAY_ACTION_ID,
+  resolveCurrentDailyNoteIso,
 } from './actions.ts'
 export {
   openDailyNotePicker,
@@ -82,13 +84,27 @@ export const dailyNotePickerHeaderItem: HeaderItemContribution = {
   component: DailyNotePickerHeaderItem,
 }
 
-export const openDailyNotePickerAction: ActionConfig<typeof ActionContextTypes.GLOBAL> = {
+// Factory — handler resolves the currently-viewed daily note's ISO
+// (via `resolveCurrentDailyNoteIso`) so the picker opens on that
+// month with the day pre-selected, matching the header-button path.
+// Falls back to `repo.activeWorkspaceId` when the hash hasn't set a
+// workspace yet (parity with `openDailyNoteByOffset`).
+export const openDailyNotePickerAction = (
+  {repo}: {repo: Repo},
+): ActionConfig<typeof ActionContextTypes.GLOBAL> => ({
   id: OPEN_DAILY_NOTE_PICKER_ACTION_ID,
   description: 'Open daily note picker',
   context: ActionContextTypes.GLOBAL,
   icon: CalendarDays,
-  handler: () => openDailyNotePicker(),
-}
+  handler: async () => {
+    const route = parseAppHash(window.location.hash)
+    const workspaceId = route.workspaceId ?? repo.activeWorkspaceId
+    const initialIso = workspaceId
+      ? (await resolveCurrentDailyNoteIso(repo, workspaceId)) ?? undefined
+      : undefined
+    openDailyNotePicker({initialIso})
+  },
+})
 
 // Factory rather than a const because the action handlers close over
 // `repo` (they call `repo.activeWorkspaceId` and `getOrCreateDailyNote`
@@ -113,7 +129,7 @@ export const dailyNotesPlugin = ({repo}: {repo: Repo}): AppExtension => [
   dateReferenceShiftActions.map(action =>
     actionsFacet.of(action, {source: 'daily-notes'}),
   ),
-  actionsFacet.of(openDailyNotePickerAction, {source: 'daily-notes'}),
+  actionsFacet.of(openDailyNotePickerAction({repo}), {source: 'daily-notes'}),
   headerItemsFacet.of(dailyNotePickerHeaderItem, {
     source: 'daily-notes',
     precedence: 5,

--- a/src/plugins/daily-notes/test/DailyNotePicker.test.tsx
+++ b/src/plugins/daily-notes/test/DailyNotePicker.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { DailyNotePicker } from '../DailyNotePicker.tsx'
 import { DailyNotePickerHeaderItem } from '../HeaderItem.tsx'
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   })),
   navigateFromGlobalCommand: vi.fn(),
   repo: {activeWorkspaceId: 'ws-1'},
+  resolveCurrentDailyNoteIso: vi.fn<(_repo: unknown, _workspaceId: string) => Promise<string | null>>(async () => null),
   runAction: vi.fn(),
 }))
 
@@ -43,12 +44,72 @@ vi.mock('../dailyNotes.ts', async () => {
   }
 })
 
+vi.mock('../actions.ts', async () => {
+  const actual = await vi.importActual<typeof import('../actions.ts')>('../actions.ts')
+  return {
+    ...actual,
+    resolveCurrentDailyNoteIso: mocks.resolveCurrentDailyNoteIso,
+  }
+})
+
 describe('DailyNotePicker', () => {
+  beforeAll(() => {
+    // Pin "today" so the highlight assertions are stable across calendar
+    // dates. The picker reads `new Date()` via `todayIso()` for the
+    // today-highlight cell. Only fake Date — leaving setTimeout/Interval
+    // real so React Testing Library's `waitFor` can still poll.
+    vi.useFakeTimers({toFake: ['Date']})
+    vi.setSystemTime(new Date(2026, 4, 15, 12))
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
   afterEach(() => {
     cleanup()
     mocks.getOrCreateDailyNote.mockClear()
     mocks.navigateFromGlobalCommand.mockClear()
     mocks.runAction.mockClear()
+  })
+
+  it('opens to the initial ISO month and highlights both today and the selected day', () => {
+    render(<DailyNotePicker/>)
+
+    act(() => {
+      openDailyNotePicker({initialIso: '2026-03-21'})
+    })
+
+    const dialog = screen.getByRole('dialog', {name: 'Daily note picker'})
+    expect(dialog.textContent).toContain('March')
+    expect(dialog.textContent).toContain('2026')
+
+    // No `current` cell when today isn't in the visible month — but
+    // navigate forward two months and today (May 15) should be marked.
+    expect(dialog.querySelector('[aria-current="date"]')).toBeNull()
+
+    // The selected day is the only cell with the destructive background.
+    const selected = screen.getByRole('button', {name: 'March 21, 2026'})
+    expect(selected.className).toContain('bg-destructive')
+  })
+
+  it('highlights today alongside the selected day when both are visible', () => {
+    render(<DailyNotePicker/>)
+
+    act(() => {
+      openDailyNotePicker({initialIso: '2026-05-04'})
+    })
+
+    const dialog = screen.getByRole('dialog', {name: 'Daily note picker'})
+    expect(dialog.textContent).toContain('May')
+
+    const today = screen.getByRole('button', {name: 'May 15, 2026'})
+    expect(today.getAttribute('aria-current')).toBe('date')
+    expect(today.className).toContain('text-destructive')
+
+    const selected = screen.getByRole('button', {name: 'May 4, 2026'})
+    expect(selected.className).toContain('bg-destructive')
+    expect(selected.getAttribute('aria-current')).toBeNull()
   })
 
   it('opens from the shared event and navigates to the selected daily note', async () => {
@@ -102,9 +163,11 @@ describe('DailyNotePickerHeaderItem', () => {
   afterEach(() => {
     cleanup()
     mocks.runAction.mockClear()
+    mocks.resolveCurrentDailyNoteIso.mockClear()
+    mocks.resolveCurrentDailyNoteIso.mockImplementation(async () => null)
   })
 
-  it('opens the shared picker from the header button', () => {
+  it('opens the shared picker from the header button', async () => {
     const listener = vi.fn<(event: CustomEvent<OpenDailyNotePickerEventDetail>) => void>()
     const handleEvent: EventListener = event => {
       listener(event as CustomEvent<OpenDailyNotePickerEventDetail>)
@@ -114,8 +177,32 @@ describe('DailyNotePickerHeaderItem', () => {
     render(<DailyNotePickerHeaderItem/>)
     fireEvent.click(screen.getByRole('button', {name: 'Open daily note picker'}))
 
-    expect(listener).toHaveBeenCalledOnce()
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalledOnce()
+    })
     expect(listener.mock.calls[0][0].detail.anchorRect).toBeTruthy()
+    expect(listener.mock.calls[0][0].detail.initialIso).toBeUndefined()
+
+    window.removeEventListener(openDailyNotePickerEvent, handleEvent)
+  })
+
+  it('passes the currently viewed daily note ISO when opening', async () => {
+    mocks.resolveCurrentDailyNoteIso.mockImplementation(async () => '2026-03-21')
+
+    const listener = vi.fn<(event: CustomEvent<OpenDailyNotePickerEventDetail>) => void>()
+    const handleEvent: EventListener = event => {
+      listener(event as CustomEvent<OpenDailyNotePickerEventDetail>)
+    }
+    window.addEventListener(openDailyNotePickerEvent, handleEvent)
+
+    render(<DailyNotePickerHeaderItem/>)
+    fireEvent.click(screen.getByRole('button', {name: 'Open daily note picker'}))
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalledOnce()
+    })
+    expect(listener.mock.calls[0][0].detail.initialIso).toBe('2026-03-21')
+    expect(mocks.resolveCurrentDailyNoteIso).toHaveBeenCalledWith(mocks.repo, 'ws-1')
 
     window.removeEventListener(openDailyNotePickerEvent, handleEvent)
   })

--- a/src/plugins/daily-notes/test/plugin.test.ts
+++ b/src/plugins/daily-notes/test/plugin.test.ts
@@ -34,7 +34,10 @@ describe('dailyNotesPlugin', () => {
 
     expect(runtime.read(appMountsFacet)).toContain(dailyNotePickerMount)
     expect(runtime.read(headerItemsFacet)).toContain(dailyNotePickerHeaderItem)
-    expect(runtime.read(actionsFacet)).toContain(openDailyNotePickerAction)
-    expect(openDailyNotePickerAction.id).toBe(OPEN_DAILY_NOTE_PICKER_ACTION_ID)
+
+    const actions = runtime.read(actionsFacet)
+    const pickerAction = actions.find(action => action.id === OPEN_DAILY_NOTE_PICKER_ACTION_ID)
+    expect(pickerAction).toBeTruthy()
+    expect(openDailyNotePickerAction({repo: fakeRepo}).id).toBe(OPEN_DAILY_NOTE_PICKER_ACTION_ID)
   })
 })


### PR DESCRIPTION
## Summary
Enhanced the daily note picker to open on the currently viewed daily note's month with that day pre-selected, providing better UX continuity when navigating between notes.

## Key Changes
- **Extract `resolveCurrentDailyNoteIso` function**: Created a new exported utility in `actions.ts` that resolves the ISO date of the daily note currently visible in the primary panel. This function is now reused by both the prev/next offset actions and the date picker.

- **Update picker action to be a factory**: Changed `openDailyNotePickerAction` from a constant to a factory function that accepts `{repo}` and resolves the current daily note ISO before opening the picker. This ensures the picker opens with the correct `initialIso` parameter.

- **Update header button to pass `initialIso`**: Modified `DailyNotePickerHeaderItem` to resolve the current daily note ISO and pass it when opening the picker, matching the behavior of the global action.

- **Add comprehensive test coverage**: 
  - Added `beforeAll`/`afterAll` hooks to pin "today" to May 15, 2026 for stable highlight assertions
  - Added tests verifying the picker opens to the initial ISO month and highlights both today and the selected day
  - Added test verifying the header button passes the currently viewed daily note ISO
  - Updated existing tests to handle async operations with `waitFor`

- **Update plugin registration**: Changed the plugin to call `openDailyNotePickerAction({repo})` as a factory rather than using it as a constant.

## Implementation Details
- The `resolveCurrentDailyNoteIso` function reuses existing logic from `openDailyNoteByOffset`, reducing code duplication
- The header button captures the anchor rect synchronously before awaiting the ISO resolution to prevent event object nullification
- Error handling added to the header button's click handler with console logging for debugging
- Tests use `vi.useFakeTimers({toFake: ['Date']})` to pin the system time while keeping `setTimeout`/`setInterval` real for React Testing Library's polling

https://claude.ai/code/session_012PTQJx1RzJdH7RKET8MGsa