### PR TITLE
Add design doc for shares and API tokens

### DIFF
--- a/docs/share-aliases-explainer.html
+++ b/docs/share-aliases-explainer.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Share-mode aliases & references — explainer</title>
+<style>
+  body { font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         max-width: 1040px; margin: 2rem auto; padding: 0 1.25rem; color: #1f2328; }
+  h1 { font-size: 1.55rem; margin-bottom: .25rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #d0d7de; padding-bottom: .25rem; }
+  h3 { font-size: 1.02rem; margin-top: 1.4rem; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; }
+  pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+        padding: .75rem .9rem; overflow-x: auto; }
+  code { background: #f6f8fa; padding: .1em .3em; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .65rem; vertical-align: top; text-align: left; }
+  th { background: #f6f8fa; }
+  .tldr { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+          padding: .85rem 1rem; margin: 1rem 0 1.5rem; }
+  .tldr strong { color: #0969da; }
+  .note { background: #fff8c5; border-left: 4px solid #d4a72c; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .insight { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
+             border-radius: 4px; margin: 1rem 0; }
+  .verdict { background: #dafbe1; border-left: 4px solid #1a7f37; padding: .75rem 1rem;
+             border-radius: 4px; margin: 1.5rem 0; }
+  .warn { background: #ffebe9; border-left: 4px solid #cf222e; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  small { color: #57606a; }
+  ul.tight li, ol.tight li { margin: .2rem 0; }
+  figure { margin: 1.25rem 0; }
+  figcaption { font-size: 12px; color: #57606a; text-align: center; margin-top: .35rem; }
+  svg.diagram { width: 100%; height: auto; display: block; margin: 0 auto; }
+</style>
+</head>
+<body>
+
+<h1>Share-mode aliases &amp; references — explainer</h1>
+<small>Companion to <a href="./shares-and-api-tokens.html">shares-and-api-tokens.html</a>.
+Focuses on what happens when a share recipient types <code>[[Foo]]</code> and Foo already exists
+in the workspace but they can't see it. 2026-05-15.</small>
+
+<div class="tldr">
+<strong>TL;DR.</strong> Reference creation in a share stays local-first. The guest types
+<code>[[Foo]]</code>, the client creates a local block claiming alias "Foo" (just like today),
+and syncs. The <em>only</em> new thing is what happens if Postgres rejects the upload because
+the workspace already has a "Foo": the existing
+<a href="https://github.com/Stvad/knowledge-medium/blob/main/src/data/repo.ts#L1085"><code>ProcessorRejection('alias.collision')</code></a>
+machinery hands us the canonical block id, and we use that to (1) rewrite any references that
+pointed at the local block to point at canonical instead, and (2) remove the failed alias claim
+from the local block. The local block stays put with its children intact &mdash; it just stops
+claiming the alias. No pre-flight remote calls. The remote endpoint we <em>do</em> need is a
+small <code>peek_block(id)</code> for rendering chips when a reference target isn't in local view
+&mdash; same shape as resolving any cross-scope reference.
+</div>
+
+<h2>1. What I got wrong in the design discussion</h2>
+
+<p>Earlier I described a flow with a <code>resolve_workspace_alias</code> RPC the client would
+  call <em>before</em> creating a reference. That breaks the local-first model: every keystroke
+  that produces a <code>[[name]]</code> would require a remote round-trip before the local block
+  exists.</p>
+
+<p>It's also unnecessary. The information that RPC would return (canonical id for an alias) is
+  exactly what the server already includes in the
+  <code>alias_collision</code> rejection payload when an optimistic local write collides at sync
+  time. So we can run the happy path entirely locally and only do remote work in the (rare)
+  collision case.</p>
+
+<p>The "annotation block" concept I introduced is also less novel than I made it sound. An
+  annotation is just <em>what a share-local block looks like after its alias claim got rejected
+  on sync</em>. It's a state of a normal block, not a new schema concept.</p>
+
+<h2>2. What's in the local DB for a share recipient</h2>
+
+<p>Recap the data architecture so the rest of the doc has the right vocabulary:</p>
+
+<ul class="tight">
+  <li>Each device has a local SQLite, populated by PowerSync streams keyed off the user's grants.</li>
+  <li>For a workspace member: the <code>workspace_data</code> stream gives them every non-deleted
+    block in their workspaces.</li>
+  <li>For a share recipient (whether human or API token): the <code>shared_blocks</code> stream
+    gives them only the blocks their share covers &mdash; the subtree (or the workspace, if it's
+    a workspace-scope share).</li>
+  <li>The client maintains a derived <code>block_aliases(workspace_id, alias, block_id)</code>
+    table locally, updated by triggers as blocks change. <strong>It only contains aliases of
+    blocks present in the local DB.</strong></li>
+</ul>
+
+<p>So a share recipient's local alias index sees only aliases of blocks <em>inside their share</em>.
+  Aliases anywhere else in the workspace are invisible to them.</p>
+
+<h2>3. The optimistic flow for <code>[[Foo]]</code></h2>
+
+<p>When the share recipient types <code>[[Foo]]</code> in some block <code>B</code> inside the
+  share, the client does what it does today:</p>
+
+<ol class="tight">
+  <li>Look up <code>"Foo"</code> in the local <code>block_aliases</code> table.</li>
+  <li>If found, set <code>B.references_json</code> to include that local block's id. Done.</li>
+  <li>If not found:
+    <ul class="tight">
+      <li>Create a new block locally: id <code>L</code>, alias <code>"Foo"</code>, parent =
+        wherever new pages go in the share (the share root, by default).</li>
+      <li>Set <code>B.references_json</code> to include <code>L</code>.</li>
+    </ul>
+  </li>
+  <li>Queue both writes for sync.</li>
+</ol>
+
+<p>This is identical to the workspace-member flow. No new code path on the "type and create" side.</p>
+
+<h2>4. What can go wrong at sync time</h2>
+
+<p>The local block <code>L</code> uploads to Postgres. The Postgres-side
+  <code>block_aliases (workspace_id, alias) UNIQUE</code> constraint (the Phase B prereq from
+  the main doc) checks for a collision in the workspace's namespace. Two outcomes:</p>
+
+<table>
+<tr><th>Outcome</th><th>Meaning</th><th>Server response</th></tr>
+<tr><td><strong>No collision</strong></td>
+    <td>No block in the workspace claims "Foo" anywhere.</td>
+    <td>Upload succeeds. <code>L</code> becomes the canonical "Foo" of the workspace. Whether
+      it's currently inside or outside any share doesn't matter &mdash; it's the only claimant.
+      Done.</td></tr>
+<tr><td><strong>Collision</strong></td>
+    <td>A block with id <code>C</code> already claims "Foo" somewhere in the workspace, possibly
+      outside the share recipient's view.</td>
+    <td><code>alias_collision</code> rejection, payload includes <code>C</code> (the canonical
+      id). The client's existing
+      <code>ProcessorRejection('alias.collision', meta)</code>
+      handler in <code>repo.ts:1085</code> receives this.</td></tr>
+</table>
+
+<p>The non-collision case is the typical one for fresh page names &mdash; nothing more to discuss.
+  Everything below is about handling collisions.</p>
+
+<h2>5. Reconciliation on collision (this is Case C)</h2>
+
+<p>The rejection tells the client that <code>L</code> can't claim the alias because canonical
+  <code>C</code> already does. The client's job: get to a consistent state where:</p>
+
+<ul class="tight">
+  <li>No local block claims <code>"Foo"</code> as an alias (the canonical does, and we can't
+    duplicate it).</li>
+  <li>Any references that pointed at <code>L</code> instead point at <code>C</code>.</li>
+  <li>The user's typed work (the block <code>L</code> itself, any children they typed under it)
+    is preserved.</li>
+</ul>
+
+<p>The reconciliation has three steps:</p>
+
+<ol class="tight">
+  <li><strong>Demote <code>L</code> from canonical to annotation.</strong>
+    Remove the <code>alias = "Foo"</code> entry from <code>L.properties_json</code>. The block
+    keeps its id, its other content, and its children. It's now a normal share-local block.</li>
+  <li><strong>Add a reference from <code>L</code> to canonical <code>C</code>.</strong>
+    Append <code>C</code> to <code>L.references_json</code>. <code>L</code> is now an "annotation
+    of C" &mdash; a share-local outline node whose content is associated with the workspace's
+    canonical Foo.</li>
+  <li><strong>Rewrite references that pointed at <code>L</code> to point at <code>C</code>.</strong>
+    In particular, <code>B.references_json</code> entry for <code>L</code> gets replaced with
+    <code>C</code>. (Other blocks in the share that also reference <code>L</code> get the same
+    rewrite.) The references now resolve to canonical, which is the right answer semantically.</li>
+</ol>
+
+<p>All three steps are local writes against the local SQLite. They're enqueued for sync. None of
+  them collide with the workspace (we removed the alias claim; <code>L</code> is now just a
+  share-local block with some references; <code>B</code>'s updated references_json is just an
+  ordinary edit).</p>
+
+<h2>6. Timeline diagram</h2>
+
+<figure>
+<svg viewBox="0 0 980 460" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Timeline showing local and server state through optimistic create, sync collision, and reconciliation."
+     class="diagram" style="max-width:980px;">
+  <defs>
+    <marker id="aMrk" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <polygon points="0 0, 9 4.5, 0 9" fill="#0969da"/>
+    </marker>
+  </defs>
+  <style>
+    .t-row { fill: #f6f8fa; stroke: #57606a; stroke-width: 1.2; }
+    .t-srv { fill: #fff8c5; stroke: #d4a72c; stroke-width: 1.2; }
+    .t-loc { fill: #ddf4ff; stroke: #0969da; stroke-width: 1.2; }
+    .t-ann { fill: #dafbe1; stroke: #1a7f37; stroke-width: 1.2; }
+    .t-msg { stroke: #0969da; stroke-width: 1.4; fill: none; marker-end: url(#aMrk); }
+    .t-lbl { font: 600 12px -apple-system, sans-serif; fill: #1f2328; }
+    .t-mono{ font: 11px ui-monospace, "SF Mono", Menlo, monospace; fill: #1f2328; }
+    .t-sub { font: 10.5px -apple-system, sans-serif; fill: #57606a; }
+    .t-time{ font: 600 12px -apple-system, sans-serif; fill: #0969da; }
+  </style>
+  <!-- Column headers -->
+  <rect class="t-loc" x="20"  y="20" width="220" height="32" rx="6"/>
+  <text x="130" y="40" text-anchor="middle" class="t-lbl">Local DB (guest's device)</text>
+  <rect class="t-srv" x="260" y="20" width="220" height="32" rx="6"/>
+  <text x="370" y="40" text-anchor="middle" class="t-lbl">PowerSync upload</text>
+  <rect class="t-srv" x="500" y="20" width="220" height="32" rx="6"/>
+  <text x="610" y="40" text-anchor="middle" class="t-lbl">Postgres (server)</text>
+  <rect class="t-loc" x="740" y="20" width="220" height="32" rx="6"/>
+  <text x="850" y="40" text-anchor="middle" class="t-lbl">Local DB (after reconcile)</text>
+  <!-- T0 -->
+  <text x="20" y="78" class="t-time">T0  Initial state</text>
+  <rect class="t-row" x="20"  y="84" width="220" height="58" rx="4"/>
+  <text x="30" y="100" class="t-mono">B: { content: "..." }</text>
+  <text x="30" y="116" class="t-mono">refs_json: []</text>
+  <text x="30" y="132" class="t-sub">(no local block aliased "Foo")</text>
+  <rect class="t-row" x="500" y="84" width="220" height="58" rx="4"/>
+  <text x="510" y="100" class="t-mono">C: { alias: "Foo", ... }</text>
+  <text x="510" y="116" class="t-mono">(outside guest's share)</text>
+  <text x="510" y="132" class="t-sub">canonical exists, guest can't see it</text>
+  <!-- T1 -->
+  <text x="20" y="170" class="t-time">T1  Guest types [[Foo]] in B</text>
+  <rect class="t-row" x="20"  y="176" width="220" height="74" rx="4"/>
+  <text x="30" y="192" class="t-mono">B: { content: "…[[Foo]]…" }</text>
+  <text x="30" y="208" class="t-mono">refs_json: [L]</text>
+  <text x="30" y="224" class="t-mono">L: { alias: "Foo", ... }</text>
+  <text x="30" y="240" class="t-sub">L created locally, claims alias</text>
+  <rect class="t-row" x="500" y="176" width="220" height="74" rx="4"/>
+  <text x="510" y="192" class="t-mono">C: { alias: "Foo", ... }</text>
+  <text x="510" y="224" class="t-sub">unchanged</text>
+  <!-- T2 -->
+  <text x="20" y="270" class="t-time">T2  Sync attempts to upload L</text>
+  <path class="t-msg" d="M 240 296 L 480 296"/>
+  <text x="360" y="290" text-anchor="middle" class="t-mono">INSERT L (alias = "Foo")</text>
+  <path class="t-msg" d="M 480 322 L 245 322" marker-end="url(#aMrk)"/>
+  <text x="362" y="316" text-anchor="middle" class="t-mono">REJECT: alias_collision { canonical = C }</text>
+  <text x="362" y="338" text-anchor="middle" class="t-sub">block_aliases UNIQUE(workspace_id, alias) fires</text>
+  <!-- T3 -->
+  <text x="20" y="368" class="t-time">T3  Client reconciles locally</text>
+  <rect class="t-row" x="740" y="374" width="220" height="80" rx="4"/>
+  <text x="750" y="390" class="t-mono">B: { content: "…[[Foo]]…" }</text>
+  <text x="750" y="406" class="t-mono">refs_json: [C]   ← rewritten</text>
+  <text x="750" y="422" class="t-mono">L: { (no alias) }</text>
+  <text x="750" y="438" class="t-mono">    refs_json: [C]   ← annotates C</text>
+</svg>
+<figcaption>Local-first happy-path is on the left. Sync hits the alias-uniqueness constraint
+  server-side at T2; the rejection carries the canonical id; the client rewrites local state at
+  T3 entirely from local memory using the value in the rejection payload.</figcaption>
+</figure>
+
+<h2>7. What does <code>references_json</code> end up pointing to</h2>
+
+<p>This was the second part of your question. The answer changes across the timeline:</p>
+
+<table>
+<tr><th>When</th><th><code>B.references_json</code></th><th><code>L.references_json</code></th></tr>
+<tr><td>T1, just after typing</td>
+    <td><code>[L]</code> &mdash; points at the local block we just made</td>
+    <td><code>[]</code></td></tr>
+<tr><td>T3, after reconcile</td>
+    <td><code>[C]</code> &mdash; rewritten to canonical</td>
+    <td><code>[C]</code> &mdash; L now annotates C</td></tr>
+</table>
+
+<p>So <strong>references in the share converge to canonical block ids</strong>, even though the
+  client never had to ask the server "what's the canonical id for this alias" up front. The
+  collision rejection is what conveys the canonical id to the client, lazily.</p>
+
+<p>Why is this important? Because the "append from share into the main workspace" flow requires
+  that references inside the share already resolve to the right workspace blocks. If the owner
+  promotes a guest-authored subtree out of the share, the references inside it work without
+  rewriting.</p>
+
+<h2>8. What the user sees</h2>
+
+<p>From the guest's perspective:</p>
+
+<ol class="tight">
+  <li>They type <code>[[Foo]]</code>. <code>L</code> appears locally with its label "Foo." They
+    can outline under it (Tab/Enter). Their children land under <code>L</code>'s id, share-local.</li>
+  <li>Sync runs in the background. If no collision, nothing changes visually.</li>
+  <li>If collision, the renderer's view of <code>L</code> updates: where before it looked like
+    a normal block named "Foo," now it shows with an indicator that there's a workspace-canonical
+    "Foo" outside their view (e.g., a chip "Foo &middot; referenced from workspace"). Their
+    children are still there, still editable, attached to <code>L</code>.</li>
+  <li>The <code>[[Foo]]</code> reference in <code>B</code> still renders as "Foo," but clicking
+    it now leads them to <code>L</code> (the annotation in their share) rather than canonical
+    (which they can't reach). The chip can offer "Foo (workspace) &middot; no access" as a
+    secondary affordance.</li>
+</ol>
+
+<p>The key UX property: <strong>no work is lost on collision</strong>. The local block stays,
+  its children stay, the reference still resolves to a renderable thing.</p>
+
+<h2>9. The remote endpoint we still need (and the one we don't)</h2>
+
+<h3>Needed: <code>peek_block(id) → {exists, accessible, label}</code></h3>
+
+<p>For the renderer to display "Foo &middot; referenced from workspace" on the chip after
+  reconciliation, it needs to know <em>something</em> about canonical <code>C</code>: at
+  minimum that <code>C</code> exists and isn't accessible. Optionally a label.</p>
+
+<p>This is a small SECURITY DEFINER RPC. It bypasses RLS for the existence/accessibility check,
+  but only returns metadata derivable without exposing content (e.g., the alias). It's called
+  lazily by the renderer when it encounters a reference id not present in the local DB. Results
+  can be cached per session.</p>
+
+<p>This is the <em>same</em> RPC needed for cross-workspace references (a separate but related
+  feature). One helper, two use cases.</p>
+
+<h3>Not needed: a pre-flight <code>resolve_workspace_alias</code></h3>
+
+<p>I described this earlier. It's redundant. The information it would convey (canonical id for
+  an alias) is already in the <code>alias_collision</code> rejection. Adding a pre-flight RPC
+  would mean every <code>[[Foo]]</code> keystroke costs a remote round-trip on the synchronous
+  write path, which is exactly what the local-first model was designed to avoid.</p>
+
+<p>An <em>optional</em> background-prefetch of "aliases in this workspace I might want to
+  reference" could exist as a perf tweak (warm a local hint table), but it's not part of the
+  correctness model.</p>
+
+<h2>10. Putting it all together</h2>
+
+<div class="verdict">
+The model that keeps the architecture local-first while supporting subtree shares with workspace-
+canonical aliases:
+<ol class="tight">
+  <li>Type-and-create stays local, with optimistic alias claim.</li>
+  <li>Server-side <code>block_aliases UNIQUE(workspace_id, alias)</code> is the source of truth
+    for uniqueness. On collision, it rejects loudly.</li>
+  <li>The rejection's payload carries the canonical id.</li>
+  <li>The client demotes its local block to an annotation (drops the alias claim, references
+    canonical) and rewrites in-share references to canonical. All locally.</li>
+  <li>Subsequent rendering uses <code>peek_block</code> to display references to inaccessible
+    canonicals.</li>
+</ol>
+The "annotation block" is just the post-collision state of an ordinary block. No new schema
+concept, no synchronous remote calls in the typing path.
+</div>
+
+<h2>11. Open questions worth being explicit about</h2>
+
+<ol class="tight">
+  <li><strong>Collision-handling latency.</strong> Between T1 (type) and T3 (reconcile), the
+    local state has <code>L</code> claiming "Foo" and <code>B</code> referencing <code>L</code>.
+    If the user types more references to "Foo" in this window, those too point at <code>L</code>.
+    The reconciliation step rewrites <em>all</em> of them at once. Manageable, but tests should
+    cover the "five quick refs before sync completes" case.</li>
+  <li><strong>Concurrent shares both first-creating "Foo".</strong> Two share recipients in
+    different shares both type <code>[[Foo]]</code> at the same time, neither sees any canonical
+    yet. Both create local <code>L1</code> and <code>L2</code>. Both upload. First one wins;
+    second gets <code>alias_collision</code> with the winner's id as canonical. Self-healing via
+    the same reconciliation.</li>
+  <li><strong>What does <code>peek_block</code> reveal?</strong> Returning the alias as
+    <code>label</code> is harmless (the guest already typed it). Returning content snippets is
+    a leak; default to alias-only.</li>
+  <li><strong>What if the guest deletes their annotation block <code>L</code>?</strong>
+    Annotations are normal blocks; delete cascades to children. References to <code>L</code>
+    elsewhere become stale (point to a deleted block). After T3, though, references should
+    point to <code>C</code> &mdash; not <code>L</code> &mdash; so deletion of <code>L</code>
+    affects only its children, not other refs.</li>
+  <li><strong>Aliases on non-share-leaf blocks.</strong> The flow above describes
+    <em>creating</em> an alias via reference auto-create. The guest could also try to alias an
+    existing block in the share (set its properties_json to include an alias). Same code path:
+    optimistic local claim, server-side uniqueness check, collision handled identically. No new
+    machinery.</li>
+</ol>
+
+</body>
+</html>

--- a/docs/share-aliases-explainer.html
+++ b/docs/share-aliases-explainer.html
@@ -46,14 +46,16 @@ in the workspace but they can't see it. 2026-05-15.</small>
 <strong>TL;DR.</strong> Reference creation in a share stays local-first. The guest types
 <code>[[Foo]]</code>, the client creates a local block claiming alias "Foo" (just like today),
 and syncs. The <em>only</em> new thing is what happens if Postgres rejects the upload because
-the workspace already has a "Foo": the existing
-<a href="https://github.com/Stvad/knowledge-medium/blob/main/src/data/repo.ts#L1085"><code>ProcessorRejection('alias.collision')</code></a>
-machinery hands us the canonical block id, and we use that to (1) rewrite any references that
-pointed at the local block to point at canonical instead, and (2) remove the failed alias claim
-from the local block. The local block stays put with its children intact &mdash; it just stops
-claiming the alias. No pre-flight remote calls. The remote endpoint we <em>do</em> need is a
-small <code>peek_block(id)</code> for rendering chips when a reference target isn't in local view
-&mdash; same shape as resolving any cross-scope reference.
+the workspace already has a "Foo": a Phase-B-prereq server-side trigger raises a structured
+rejection that includes the <em>canonical</em> block id (the existing client-side
+<a href="https://github.com/Stvad/knowledge-medium/blob/main/src/data/internals/clientSchema.ts#L639"><code>alias_collision</code></a>
+trigger only knows the attempting id, and the client-side rejection builder can't find the
+canonical via local lookup because it lives outside the share — see &sect;5.1). With canonical
+in hand, the client (1) rewrites any references that pointed at the local block to point at
+canonical instead, and (2) removes the failed alias claim from the local block. The local block
+stays put with its children intact &mdash; it just stops claiming the alias. No pre-flight
+remote calls. A small <code>peek_block(id)</code> RPC handles rendering chips when a reference
+target isn't in local view &mdash; same shape as resolving any cross-scope reference.
 </div>
 
 <h2>1. What I got wrong in the design discussion</h2>
@@ -128,10 +130,11 @@ small <code>peek_block(id)</code> for rendering chips when a reference target is
 <tr><td><strong>Collision</strong></td>
     <td>A block with id <code>C</code> already claims "Foo" somewhere in the workspace, possibly
       outside the share recipient's view.</td>
-    <td><code>alias_collision</code> rejection, payload includes <code>C</code> (the canonical
-      id). The client's existing
-      <code>ProcessorRejection('alias.collision', meta)</code>
-      handler in <code>repo.ts:1085</code> receives this.</td></tr>
+    <td>Rejection emitted by the <em>server-side</em> alias trigger (Phase B prereq), shaped
+      so it carries <code>C</code> alongside the existing payload. See &sect;5.1 for why this
+      can't reuse the current client-side trigger as-is. Client receives a
+      <code>ProcessorRejection('alias.collision', { canonicalId: C, ... })</code> via the
+      existing rejection-handling path in <code>repo.ts:1085</code>.</td></tr>
 </table>
 
 <p>The non-collision case is the typical one for fresh page names &mdash; nothing more to discuss.
@@ -170,6 +173,73 @@ small <code>peek_block(id)</code> for rendering chips when a reference target is
   them collide with the workspace (we removed the alias claim; <code>L</code> is now just a
   share-local block with some references; <code>B</code>'s updated references_json is just an
   ordinary edit).</p>
+
+<h3>5.1 The rejection has to come from the server, with the canonical id in it</h3>
+
+<p>Important caveat: the reconciliation above depends on having <code>C</code> &mdash; the
+  canonical block id &mdash; in hand at T3. The <em>current</em> alias-collision machinery
+  doesn't supply it for share-mode collisions:</p>
+
+<ul class="tight">
+  <li>The SQLite trigger in
+    <a href="../src/data/internals/clientSchema.ts"><code>clientSchema.ts:639</code></a>
+    raises <code>'alias_collision' || hex(workspace_id) || hex(alias) || hex(attempted_block_id)</code>.
+    Three fields; the canonical/existing claimant is <em>not</em> in the payload.</li>
+  <li><code>Repo.buildAliasCollisionRejection</code> in <code>repo.ts</code> currently derives
+    <code>conflictingBlockId</code> by querying the local <code>block_aliases</code> table for
+    the alias. In share-mode collisions, <em>the canonical lives outside the local view</em>,
+    so the lookup returns null and <code>conflictingBlockId</code> is empty.</li>
+  <li>So as-is, a share-recipient's reconciliation has the alias name, knows the upload was
+    rejected, but doesn't have <code>C</code> to rewrite references to.</li>
+</ul>
+
+<p>The fix is part of the Phase B prereq (server-side alias uniqueness in Postgres). The new
+  Postgres-side trigger has full workspace visibility and can include canonical in the rejection:</p>
+
+<pre><code>-- inside a server-side BEFORE INSERT/UPDATE trigger on public.blocks
+-- that maintains public.block_aliases and enforces uniqueness:
+declare
+  v_canonical text;
+begin
+  if new_alias_for_row is not null then
+    select block_id into v_canonical
+    from public.block_aliases
+    where workspace_id = NEW.workspace_id
+      and alias = new_alias_for_row
+      and block_id &lt;&gt; NEW.id;
+
+    if v_canonical is not null then
+      -- Structured rejection. PowerSync surfaces this back to the client
+      -- via its upload-rejection channel; the client's existing alias-collision
+      -- handler is extended to read `canonical` from the payload (or from the
+      -- DETAIL field, depending on how PowerSync forwards Postgres errors).
+      raise exception 'alias_collision'
+        using errcode = 'unique_violation',
+              detail  = format('workspace=%s alias=%s attempted=%s canonical=%s',
+                               NEW.workspace_id, new_alias_for_row, NEW.id, v_canonical);
+    end if;
+  end if;
+  ...
+end;</code></pre>
+
+<p>Client changes that follow:</p>
+
+<ul class="tight">
+  <li>Extend the SQLite-side trigger to also include a canonical lookup (it works for local-only
+    collisions where canonical <em>is</em> in the local view; still null for share-mode cases
+    until the server's rejection comes back).</li>
+  <li>Extend <code>buildAliasCollisionRejection</code> to read canonical from the server's
+    rejection payload (parsing the structured DETAIL or whatever PowerSync surfaces).</li>
+  <li>Extend the rejection's <code>meta</code> shape to carry <code>canonicalId</code>
+    explicitly. The reconciliation in &sect;5 then has what it needs.</li>
+</ul>
+
+<div class="note">
+The existing client-side trigger isn't redundant &mdash; it catches local-only collisions
+optimistically, which is faster (no round-trip) and keeps the existing UX. It just can't see
+outside the share. The server-side trigger is the authoritative check for cross-share collisions
+and is what the share-recipient flow specifically relies on.
+</div>
 
 <h2>6. Timeline diagram</h2>
 

--- a/docs/share-aliases-explainer.html
+++ b/docs/share-aliases-explainer.html
@@ -347,14 +347,129 @@ and is what the share-recipient flow specifically relies on.
     a normal block named "Foo," now it shows with an indicator that there's a workspace-canonical
     "Foo" outside their view (e.g., a chip "Foo &middot; referenced from workspace"). Their
     children are still there, still editable, attached to <code>L</code>.</li>
-  <li>The <code>[[Foo]]</code> reference in <code>B</code> still renders as "Foo," but clicking
-    it now leads them to <code>L</code> (the annotation in their share) rather than canonical
-    (which they can't reach). The chip can offer "Foo (workspace) &middot; no access" as a
-    secondary affordance.</li>
+  <li>The <code>[[Foo]]</code> reference in <code>B</code> still renders as "Foo." Clicking it
+    navigates via the rule in &sect;8.1 below &mdash; in the share, that means landing on the
+    annotation <code>L</code>, since <code>L</code> is the only renderable thing the guest has
+    for this canonical.</li>
 </ol>
 
 <p>The key UX property: <strong>no work is lost on collision</strong>. The local block stays,
   its children stay, the reference still resolves to a renderable thing.</p>
+
+<h3>8.1 Navigation: how a reference id resolves to a destination</h3>
+
+<p>After reconciliation, <code>B.references_json</code> points at canonical <code>C</code>, but
+  the guest can't navigate to <code>C</code> directly (RLS hides it). The renderer needs a
+  redirect rule. A small client-side index does the job:</p>
+
+<pre><code>CREATE TABLE share_annotations (
+  share_id              TEXT,
+  canonical_block_id    TEXT,
+  annotation_block_id   TEXT,
+  PRIMARY KEY (share_id, canonical_block_id)
+);
+-- Populated whenever a reconciliation creates an annotation. One row per
+-- (share, canonical) pair so all references to the same canonical resolve
+-- to the same annotation block.</code></pre>
+
+<p>Click handler for a <code>[[name]]</code> reference whose target is <code>C</code>:</p>
+
+<ol class="tight">
+  <li>Is <code>C</code> in the local DB? <strong>Yes</strong> &rarr; navigate to <code>C</code>.</li>
+  <li>Else: is there a <code>share_annotations</code> row for the current share + <code>C</code>?
+    <strong>Yes</strong> &rarr; navigate to the annotation block <code>L</code>.</li>
+  <li>Else: stay put, render the chip as "no access" / "referenced from workspace."</li>
+</ol>
+
+<p>This decouples the <em>reference target</em> (canonical, stable across promotion) from the
+  <em>navigation destination</em> (whatever the guest can actually render in their current share).
+  Annotations from a different share the guest is also in resolve through the same rule &mdash;
+  when looking up <code>(some_other_share, C)</code>, the row may exist there too if the guest
+  annotated Foo in that share separately.</p>
+
+<h2>8.2 Subsequent <code>[[Foo]]</code> after reconciliation: the <code>alias_hints</code> cache</h2>
+
+<p>Without something else in place, the next time the guest types <code>[[Foo]]</code> the
+  lookup hits <code>block_aliases</code> (now empty for "Foo" since we stripped <code>L</code>'s
+  claim), and the optimistic-create-then-collide-then-reconcile dance repeats. That's pure
+  waste &mdash; the client already knows canonical's id from the first round.</p>
+
+<p>The fix is a small local-only cache:</p>
+
+<pre><code>CREATE TABLE alias_hints (
+  workspace_id        TEXT,
+  alias               TEXT,
+  canonical_block_id  TEXT,
+  PRIMARY KEY (workspace_id, alias)
+);
+-- Populated by the reconciliation step in §5 (canonical id from the
+-- server rejection payload). Never synced; local-only.</code></pre>
+
+<p>Alias lookup path becomes:</p>
+
+<ol class="tight">
+  <li>Look in <code>block_aliases</code> &rarr; hit means a locally-resident block claims it,
+    use that id. Done.</li>
+  <li>Else, look in <code>alias_hints</code> &rarr; hit means we know about a canonical we
+    can't see locally; set the reference to that id and skip block creation entirely.</li>
+  <li>Else, optimistic create with the alias (the original flow).</li>
+</ol>
+
+<p>Cache invalidation: when <code>peek_block(canonical_id)</code> ever reports
+  <code>exists: false</code>, evict the hint. The next type-event reverts to step 3, attempts a
+  fresh create, succeeds if the alias is truly free. Self-healing.</p>
+
+<h2>8.3 Deterministic alias-seat ids</h2>
+
+<p>This codebase uses
+  <a href="../src/data/targets.ts"><code>computeAliasSeatId(alias, workspaceId, index)</code></a>
+  &mdash; <code>uuidv5(${workspaceId}:${alias}:${index}, ALIAS_NS)</code> &mdash; so two clients
+  in the same workspace deterministically arrive at the same id for the same alias at index 0.
+  Convergence by construction.</p>
+
+<p>In share mode this has an interesting side-effect: when the guest probes "Foo" at slot 0,
+  the deterministic id <code>D0 = computeAliasSeatId("Foo", W, 0)</code> equals canonical's
+  existing id. The guest's local probe sees slot 0 "available" (no row at <code>D0</code> in
+  their local view) and claims it. The local block at <code>D0</code> uploads to Postgres,
+  where <code>D0</code> already exists as canonical &mdash; held by an owner the guest can't
+  write to. Two possible failure paths:</p>
+
+<ul class="tight">
+  <li><strong>PK conflict on INSERT</strong> if PowerSync treats new local rows as inserts only.</li>
+  <li><strong>RLS denial on UPDATE/UPSERT</strong> if PowerSync treats them as upserts &mdash;
+    the guest has no write coverage on canonical, WITH CHECK rejects.</li>
+</ul>
+
+<p>Either way the upload fails. <strong>Important property of the deterministic-id setup: the
+  canonical id is already known.</strong> It's the same as the id the guest just tried to
+  claim. No new information needs to come back in the rejection payload &mdash; the client
+  already has it.</p>
+
+<p>Reconciliation is slightly different from the random-id case:</p>
+
+<ol class="tight">
+  <li><strong>Rename the local block from <code>D0</code> to a fresh non-deterministic id
+    <code>D'</code></strong> (e.g., <code>gen_random_uuid</code>). Reparent any local children
+    from <code>D0</code> to <code>D'</code>. Pure local SQLite operation.</li>
+  <li><strong>Strip the alias claim from <code>D'</code></strong> &mdash; canonical owns it.</li>
+  <li><strong>Set <code>D'.references_json = [D0]</code></strong> &mdash; <code>D'</code> is
+    now the share's annotation block, pointing at canonical.</li>
+  <li><strong>Populate the <code>share_annotations</code> and <code>alias_hints</code> entries:</strong>
+    <code>(current_share, D0, D')</code> and <code>(W, "Foo", D0)</code>.</li>
+  <li><strong><code>B.references_json</code> stays untouched</strong> &mdash; it already points
+    at <code>D0</code>, which IS canonical. The deterministic id meant our optimistic refs were
+    "accidentally correct" all along. Lucky outcome.</li>
+</ol>
+
+<div class="note">
+<strong>Probe-escalation behavior in share mode.</strong> Today's <code>resolveAliasSeatId</code>
+walks to higher slot indices (1, 2, …) when slot 0 has a <em>different</em> alias claimed
+locally (post-rename probing). In share mode, the failure mode is <em>different</em>: slot 0
+exists remotely, claims the right alias, but the guest can't write to it. Escalating to higher
+indices would just create another doomed claim. The share-mode reconciliation should
+<strong>not</strong> retry at a higher seat; it should rename to a non-deterministic id and
+mark the local block as an annotation. Worth a separate code path or a flag on the probe.
+</div>
 
 <h2>9. The remote endpoint we still need (and the one we don't)</h2>
 

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -967,7 +967,12 @@ Authorization: Bearer &lt;caller's Supabase JWT&gt;
 
 <h4>Database RPC contract (called from inside the edge function only)</h4>
 
-<pre><code>private.create_api_token_records(
+<p>Three RPCs make up the two-phase create + compensation path. All in <code>private</code>,
+  all <code>security definer</code>, all granted only to <code>service_role</code>.</p>
+
+<pre><code>-- Phase 1: everything that doesn't need the service user id.
+-- Creates the share, roots, link, and secret in one transaction.
+private.create_api_token_records_phase1(
   p_caller_user_id   text,    -- issuing user, already verified by the edge function
   p_scope            text,
   p_workspace_id     text,
@@ -975,7 +980,6 @@ Authorization: Bearer &lt;caller's Supabase JWT&gt;
   p_role             text,
   p_name             text,
   p_expires_at       bigint,
-  p_service_user_id  text,    -- service user already created by the edge function
   p_token_hash       bytea    -- sha256(plaintext); plaintext is NEVER passed in
 ) returns table (
   share  public.block_shares,
@@ -983,26 +987,46 @@ Authorization: Bearer &lt;caller's Supabase JWT&gt;
 )
 language plpgsql security definer set search_path = public, private;
 
+-- Phase 2: attach the now-created service user to the share.
+-- Run after the edge function successfully creates the auth.users row.
+private.create_api_token_records_phase2(
+  p_share_id         text,
+  p_service_user_id  text,
+  p_role             text
+) returns public.block_share_members
+language plpgsql security definer set search_path = public, private;
+
+-- Compensation: hard delete on failure between phase 1 and phase 2 (or after).
+-- Cascades to block_share_roots, share_links, share_link_secrets, and any
+-- block_share_members rows already inserted. NOT used for normal revocation
+-- (see 8.5 -- that path is soft-delete via revoked_at).
+private.delete_api_token_records(p_share_id text) returns void
+language plpgsql security definer set search_path = public, private;
+
 -- Belt-and-braces: even though `private` schema is not exposed via PostgREST by
--- default, explicitly deny client roles from calling this function. REVOKE FROM
--- PUBLIC strips every role, so re-grant the edge function's role afterward --
--- otherwise the edge function would also hit "permission denied".
-revoke execute on function private.create_api_token_records(
-  text, text, text, text[], text, text, bigint, text, bytea
-) from public, anon, authenticated;
+-- default, explicitly deny client roles from calling these functions. REVOKE FROM
+-- PUBLIC strips every role, so re-grant service_role afterward -- otherwise the
+-- edge function would also hit "permission denied".
+revoke execute on function
+  private.create_api_token_records_phase1(text, text, text, text[], text, text, bigint, bytea),
+  private.create_api_token_records_phase2(text, text, text),
+  private.delete_api_token_records(text)
+from public, anon, authenticated;
 
-grant execute on function private.create_api_token_records(
-  text, text, text, text[], text, text, bigint, text, bytea
-) to service_role;</code></pre>
+grant execute on function
+  private.create_api_token_records_phase1(text, text, text, text[], text, text, bigint, bytea),
+  private.create_api_token_records_phase2(text, text, text),
+  private.delete_api_token_records(text)
+to service_role;</code></pre>
 
-<p>The RPC lives in the <code>private</code> schema (alongside <code>private.is_workspace_member</code>,
-  <code>private.is_workspace_writer</code>, and the new <code>private.role_max</code>). Supabase's
-  PostgREST only exposes the <code>public</code> schema, so client roles cannot reach this function
-  via REST at all. The explicit <code>REVOKE</code> is there as a second line of defense: if the
-  schema-exposure setting is ever changed, the function still rejects calls from
-  <code>anon</code> / <code>authenticated</code>. Only the edge function (running with
-  <code>service_role</code>) can invoke it. This is the boundary that prevents a workspace viewer
-  from minting themselves an editor token by calling the RPC directly.</p>
+<p>These RPCs live in the <code>private</code> schema (alongside
+  <code>private.is_workspace_member</code>, <code>private.is_workspace_writer</code>, and the new
+  <code>private.role_max</code>). Supabase's PostgREST only exposes the <code>public</code> schema,
+  so client roles cannot reach them via REST at all. The explicit <code>REVOKE</code> is there as
+  a second line of defense: if the schema-exposure setting is ever changed, the functions still
+  reject calls from <code>anon</code> / <code>authenticated</code>. Only the edge function
+  (running with <code>service_role</code>) can invoke them. This is the boundary that prevents a
+  workspace viewer from minting themselves an editor token by calling the RPCs directly.</p>
 
 <p>Edge-function flow. The order matters &mdash; service user creation comes <strong>after</strong>
   the SQL transaction so a downstream failure can't orphan an <code>auth.users</code> row:</p>
@@ -1040,8 +1064,17 @@ const hash      = crypto.createHash('sha256').update(plaintext).digest()</code><
 can't be inside the SQL transaction. Splitting the SQL work into "phase 1: everything that
 doesn't need the service user" + "phase 2: the membership row" gives a clean compensation point:
 service user creation sits between two SQL transactions, and a failure in either step has a
-defined cleanup. The same <code>delete_api_token_records</code> helper is also what
-<code>revoke_api_token</code> in &sect;8.5 calls when the user explicitly revokes.
+defined cleanup via <code>private.delete_api_token_records</code>.
+
+<br><br>
+
+<strong>Compensation vs. revocation are different paths.</strong>
+<code>private.delete_api_token_records</code> is <em>hard-delete</em> (cascade removes the share,
+roots, link, secret, and any member rows). It is used <em>only</em> as failure compensation
+during creation, when the token never successfully reached the caller. Normal revocation
+(&sect;8.5) is a separate <em>soft</em>-delete that sets <code>share_links.revoked_at</code> /
+<code>block_shares.revoked_at</code> while keeping all rows around for audit. The two paths don't
+share an implementation.
 </div>
 
 <div class="note">

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -979,10 +979,16 @@ Authorization: Bearer &lt;caller's Supabase JWT&gt;
 language plpgsql security definer set search_path = public, private;
 
 -- Belt-and-braces: even though `private` schema is not exposed via PostgREST by
--- default, explicitly deny client roles from calling this function.
+-- default, explicitly deny client roles from calling this function. REVOKE FROM
+-- PUBLIC strips every role, so re-grant the edge function's role afterward --
+-- otherwise the edge function would also hit "permission denied".
 revoke execute on function private.create_api_token_records(
   text, text, text, text[], text, text, bigint, text, bytea
-) from public, anon, authenticated;</code></pre>
+) from public, anon, authenticated;
+
+grant execute on function private.create_api_token_records(
+  text, text, text, text[], text, text, bigint, text, bytea
+) to service_role;</code></pre>
 
 <p>The RPC lives in the <code>private</code> schema (alongside <code>private.is_workspace_member</code>,
   <code>private.is_workspace_writer</code>, and the new <code>private.role_max</code>). Supabase's
@@ -1089,8 +1095,12 @@ public.list_my_api_tokens() returns table (... no token, no hash ...);
 -- the edge function generates new plaintext + hash, then calls a private hash-only RPC.
 private.rotate_api_token_hash(p_link_id text, p_new_token_hash bytea) returns void;
   -- Updates share_link_secrets.token_hash for the link. Authorization is done in the
-  -- edge function (caller must own the link); execute is REVOKEd from anon/authenticated.
-  -- Returns void: plaintext is in the edge function's HTTP response only.</code></pre>
+  -- edge function (caller must own the link). Returns void: plaintext is in the edge
+  -- function's HTTP response only. Grants follow the same pattern as 8.2:
+  --   revoke execute on function private.rotate_api_token_hash(text, bytea)
+  --     from public, anon, authenticated;
+  --   grant  execute on function private.rotate_api_token_hash(text, bytea)
+  --     to service_role;</code></pre>
 
 <div class="warn">
 <strong>Revocation lag.</strong> Issued JWTs live for the configured TTL (default 15 minutes &mdash;

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -855,9 +855,17 @@ language plpgsql security definer set search_path = public</code></pre>
     register an extension. The service user gets an opaque generated email
     (<code>svc-&lt;random&gt;@knowledge-medium.local</code>) and a random unrecoverable password.</li>
   <li>Insert <code>block_share_members(share_id, user_id = service_user_id, role, source='api_token')</code>.</li>
-  <li>Generate token: <code>'km_live_' || encode(gen_random_bytes(32), 'base64url')</code>.</li>
-  <li>Insert <code>share_links</code> + <code>share_link_secrets(token_hash = sha256(token))</code>.</li>
-  <li>Return <code>token_plain</code> to the caller, once.</li>
+  <li>Generate the token <strong>in the edge function</strong> (not in SQL &mdash; Postgres'
+    <code>encode()</code> only supports <code>'base64' | 'hex' | 'escape'</code>, not
+    <code>'base64url'</code>, and keeping plaintext out of the database avoids it appearing in
+    <code>pg_stat_statements</code> or replication logs):
+<pre><code>const plaintext = 'km_live_' + crypto.randomBytes(32).toString('base64url')
+const hash      = crypto.createHash('sha256').update(plaintext).digest()</code></pre>
+  </li>
+  <li>Pass only <code>hash</code> into the SQL RPC; insert <code>share_links</code> +
+    <code>share_link_secrets(token_hash = hash)</code>.</li>
+  <li>Return <code>plaintext</code> from the edge function to the caller, once. Postgres never sees
+    the plaintext.</li>
 </ol>
 
 <div class="note">

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -28,6 +28,15 @@
           border-radius: 4px; margin: 1rem 0; }
   small { color: #57606a; }
   ul.tight li, ol.tight li { margin: .2rem 0; }
+  .tldr { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+          padding: .85rem 1rem; margin: 1rem 0 1.5rem; }
+  .tldr strong { color: #0969da; }
+  .scenario { background: #fbfbfb; border: 1px solid #d0d7de; border-radius: 6px;
+              padding: .75rem 1rem; margin: 1rem 0; }
+  .scenario h4 { margin-top: .25rem; }
+  figure { margin: 1.25rem 0; }
+  figcaption { font-size: 12px; color: #57606a; text-align: center; margin-top: .35rem; }
+  svg.diagram { width: 100%; height: auto; display: block; margin: 0 auto; }
 </style>
 </head>
 <body>
@@ -35,6 +44,23 @@
 <h1>Shares + API tokens</h1>
 <small>Design for scoped programmatic access. 2026-05-15. Standalone — supersedes
   <a href="./subtree-sharing.md">subtree-sharing.md</a> (historical reference only).</small>
+
+<div class="tldr">
+<strong>TL;DR.</strong> Agents and third parties need to read/write specific notes via an API. The
+right primitive is a <em>share</em>: a workspace-or-subtree scope plus an audience. An API token is
+the same shape as a future human invite &mdash; it puts a principal (a per-token service user) into a
+share's audience. <em>One</em> RLS predicate on <code>blocks</code> then covers everyone &mdash;
+workspace members, share recipients, and API tokens alike. PostgREST is the v1 API surface; an edge
+function swaps a token for a short-lived JWT and clients use Supabase as normal. The non-trivial
+piece is materializing "which subtree shares reach this block" onto a
+<code>blocks.effective_share_ids</code> column &mdash; workspaces can be 300k+ blocks and we can't
+walk parent pointers on every read.
+</div>
+
+<p><small><strong>Reading guide:</strong> &sect;1&ndash;3 are the conceptual picture; &sect;3a is a
+  concrete end-to-end walkthrough; &sect;4&ndash;7 are the schema/RLS/sync mechanics; &sect;8 is the
+  API-token lifecycle; &sect;9&ndash;14 are operational (UI, phasing, tests, tradeoffs).
+  If you only read three things: the TL;DR, &sect;3a, and &sect;6 with its tree picture.</small></p>
 
 <h2>1. What we have today</h2>
 
@@ -80,7 +106,51 @@ query time" RLS or sync predicate &mdash; access decisions on the read path must
 <h2>3. The unifying primitive</h2>
 
 <p>A <em>share</em> is the access primitive. Everything else is a way of putting a principal into a
-  share's audience.</p>
+  share's audience. The diagram below shows how three different "ways of joining a share" all funnel
+  into the same audience table, which a single RLS predicate then evaluates against.</p>
+
+<figure>
+<svg viewBox="0 0 720 290" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Three authentication paths (human invite, link redemption, API token exchange) funnel into block_share_members, which is read by one RLS predicate on blocks."
+     class="diagram" style="max-width:720px;">
+  <defs>
+    <marker id="arrowU" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <polygon points="0 0, 9 4.5, 0 9" fill="#57606a"/>
+    </marker>
+  </defs>
+  <style>
+    .u-card { fill: #f6f8fa; stroke: #57606a; stroke-width: 1.2; }
+    .u-blue { fill: #ddf4ff; stroke: #0969da; stroke-width: 1.4; }
+    .u-yel  { fill: #fff8c5; stroke: #d4a72c; stroke-width: 1.4; }
+    .u-grn  { fill: #dafbe1; stroke: #1a7f37; stroke-width: 1.4; }
+    .u-arr  { stroke: #57606a; stroke-width: 1.4; fill: none; marker-end: url(#arrowU); }
+    .u-tt   { font: 600 12px -apple-system, sans-serif; fill: #1f2328; }
+    .u-sub  { font: 11px -apple-system, sans-serif; fill: #57606a; }
+    .u-code { font: 11px ui-monospace, "SF Mono", Menlo, monospace; fill: #1f2328; }
+  </style>
+  <rect class="u-card" x="20"  y="20" width="200" height="60" rx="6"/>
+  <text x="120" y="44" text-anchor="middle" class="u-tt">Human invite (email)</text>
+  <text x="120" y="64" text-anchor="middle" class="u-code">accept_share_invitation</text>
+  <rect class="u-card" x="260" y="20" width="200" height="60" rx="6"/>
+  <text x="360" y="44" text-anchor="middle" class="u-tt">Link redemption</text>
+  <text x="360" y="64" text-anchor="middle" class="u-code">redeem_share_link</text>
+  <rect class="u-blue" x="500" y="20" width="200" height="60" rx="6"/>
+  <text x="600" y="44" text-anchor="middle" class="u-tt">API token exchange</text>
+  <text x="600" y="64" text-anchor="middle" class="u-code">/api-token-exchange</text>
+  <path class="u-arr" d="M 120 80 Q 120 110 280 132"/>
+  <path class="u-arr" d="M 360 80 L 360 132"/>
+  <path class="u-arr" d="M 600 80 Q 600 110 440 132"/>
+  <rect class="u-yel" x="180" y="135" width="360" height="68" rx="6"/>
+  <text x="360" y="158" text-anchor="middle" class="u-tt">block_share_members</text>
+  <text x="360" y="178" text-anchor="middle" class="u-code">(share_id, user_id, role, source)</text>
+  <text x="360" y="194" text-anchor="middle" class="u-sub">user_id is a human OR a per-token service user</text>
+  <path class="u-arr" d="M 360 203 L 360 230"/>
+  <rect class="u-grn" x="180" y="232" width="360" height="46" rx="6"/>
+  <text x="360" y="255" text-anchor="middle" class="u-tt">One RLS predicate on public.blocks</text>
+  <text x="360" y="270" text-anchor="middle" class="u-sub">workspace member &nbsp;OR&nbsp; share recipient</text>
+</svg>
+<figcaption>Three audience-entry paths, one audience table, one access rule.</figcaption>
+</figure>
 
 <pre><code>Share
   workspace_id    text                          // always lives inside one workspace
@@ -106,9 +176,145 @@ members, workspace-scope shares, subtree-scope shares, human invites, link redem
 tokens. Adding a "future" share type (e.g. by-tag) doesn't disturb anything.
 </div>
 
+<h2>3a. End-to-end: what happens when you create an API token</h2>
+
+<p>The rest of this doc gets into schema and triggers. To make the picture concrete first, here is
+  one full scenario from token creation through a single API call to revocation.</p>
+
+<div class="scenario">
+<h4>The setup</h4>
+<p>You want to let Claude (an agent) read and write three project pages in your workspace. You open
+  <em>Settings &rarr; API tokens</em>, click "Create token", and fill in:
+  scope = <em>subtree</em>, roots = those three pages, role = <em>editor</em>,
+  name = "Claude on laptop", expiry = 90 days.</p>
+
+<h4>What the server does (one transaction)</h4>
+<ol class="tight">
+  <li>Inserts a <code>block_shares</code> row: <code>scope='subtree'</code>,
+    <code>purpose='api'</code>, <code>default_role='editor'</code>.</li>
+  <li>Inserts three <code>block_share_roots</code> rows, one per chosen page.</li>
+  <li>An <code>AFTER INSERT</code> trigger on <code>block_share_roots</code> fires
+    <code>recompute_share_ids_subtree</code> for each root &mdash; this stamps the share's id onto
+    <code>blocks.effective_share_ids</code> for the root <em>and every descendant</em>. The
+    materialization picture in &sect;6 shows what this looks like.</li>
+  <li>Creates a dedicated <em>service user</em> (a <code>auth.users</code> row whose only purpose is
+    to authenticate this token). This is the only step that needs <code>service_role</code>; it lives
+    inside the edge function.</li>
+  <li>Inserts a <code>block_share_members</code> row tying the service user to the share with
+    <code>role='editor'</code>, <code>source='api_token'</code>.</li>
+  <li>Generates a token, <code>km_live_&lt;43 chars&gt;</code>, stores
+    <code>sha256(token)</code> in <code>share_link_secrets</code>, stores
+    <code>share_links</code> metadata pointing at the service user.</li>
+  <li>Returns the plaintext token to your browser <em>exactly once</em>. You paste it into Claude's
+    config.</li>
+</ol>
+
+<h4>What every Claude API call does</h4>
+<ol class="tight">
+  <li>Claude <code>POST</code>s the token in <code>Authorization: Bearer</code> to
+    <code>/functions/v1/api-token-exchange</code>.</li>
+  <li>The edge function hashes the bearer, looks up the row in <code>share_link_secrets</code>,
+    checks the share/link aren't revoked or expired, mints a 15-minute Supabase JWT signed with
+    <code>sub = service_user_id</code>.</li>
+  <li>Claude calls <code>/rest/v1/blocks?id=eq.&lt;some_block_id&gt;</code> with that JWT.</li>
+  <li>Postgres evaluates the RLS predicate as the service user: <em>is there a
+    <code>block_share_members</code> row whose share covers this block?</em>
+    <ul class="tight">
+      <li>For blocks in the three chosen subtrees and their descendants: yes &mdash; matched because
+        the share id appears in that block's <code>effective_share_ids</code>. Row returned.</li>
+      <li>For any other block in the workspace: no &mdash; the service user has no
+        <code>workspace_members</code> row and no other share grant. Row denied.</li>
+    </ul>
+  </li>
+</ol>
+
+<h4>Revoking</h4>
+<p>You click "Revoke" in the UI. <code>revoke_api_token</code> sets <code>revoked_at</code> on the
+  share and the link. The RLS predicate filters revoked shares out automatically &mdash; new requests
+  fail. JWTs that were already issued continue to work until their 15-minute TTL expires.</p>
+</div>
+
+<p>That's the entire feature in one trace. Everything below is either the precise schema/RLS to make
+  the trace work, or operational concerns (UI, phases, tests, tradeoffs).</p>
+
 <h2>4. Schema</h2>
 
-<p>All additive. Existing tables and migrations are not touched destructively.</p>
+<p>All additive. Existing tables and migrations are not touched destructively. The picture below is
+  the at-a-glance shape of the new tables; SQL details follow.</p>
+
+<figure>
+<svg viewBox="0 0 980 380" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Schema ERD. block_shares is the center; block_share_roots, block_share_members, and share_links hang off it. share_link_secrets is locked behind share_links. The existing blocks table gains an effective_share_ids array column that references block_shares.id."
+     class="diagram" style="max-width:980px;">
+  <defs>
+    <marker id="arrowE" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <polygon points="0 0, 9 4.5, 0 9" fill="#57606a"/>
+    </marker>
+  </defs>
+  <style>
+    .e-new   { fill: #ddf4ff; stroke: #0969da; stroke-width: 1.4; }
+    .e-exist { fill: #f6f8fa; stroke: #57606a; stroke-width: 1.2; }
+    .e-lock  { fill: #ffebe9; stroke: #cf222e; stroke-width: 1.4; }
+    .e-line  { stroke: #57606a; stroke-width: 1.2; fill: none; }
+    .e-line-dash { stroke: #0969da; stroke-width: 1.2; fill: none; stroke-dasharray: 4,3; }
+    .e-tt    { font: 600 13px ui-monospace, "SF Mono", Menlo, monospace; fill: #1f2328; }
+    .e-sub   { font: 10.5px -apple-system, sans-serif; fill: #57606a; }
+    .e-col   { font: 10.5px ui-monospace, "SF Mono", Menlo, monospace; fill: #1f2328; }
+    .e-hi    { font: 600 10.5px ui-monospace, "SF Mono", Menlo, monospace; fill: #cf222e; }
+    .e-newcol{ font: 600 10.5px ui-monospace, "SF Mono", Menlo, monospace; fill: #0969da; }
+  </style>
+  <!-- block_shares (center) -->
+  <rect class="e-new" x="370" y="20" width="240" height="124" rx="6"/>
+  <text x="490" y="40" text-anchor="middle" class="e-tt">block_shares</text>
+  <text x="380" y="60" class="e-col">id</text>
+  <text x="380" y="76" class="e-col">workspace_id</text>
+  <text x="380" y="92" class="e-col">scope: 'workspace'|'subtree'</text>
+  <text x="380" y="108" class="e-col">purpose: 'human'|'api'</text>
+  <text x="380" y="124" class="e-col">default_role, revoked_at</text>
+  <text x="380" y="138" class="e-sub">the share definition</text>
+  <!-- block_share_roots (left) -->
+  <rect class="e-new" x="20" y="180" width="240" height="84" rx="6"/>
+  <text x="140" y="200" text-anchor="middle" class="e-tt">block_share_roots</text>
+  <text x="30" y="220" class="e-col">share_id  →  block_shares</text>
+  <text x="30" y="236" class="e-col">root_block_id  →  blocks</text>
+  <text x="30" y="256" class="e-sub">only for scope='subtree'; one row per root</text>
+  <!-- block_share_members (center bottom) -->
+  <rect class="e-new" x="370" y="180" width="240" height="84" rx="6"/>
+  <text x="490" y="200" text-anchor="middle" class="e-tt">block_share_members</text>
+  <text x="380" y="220" class="e-col">share_id, user_id, role</text>
+  <text x="380" y="236" class="e-col">source: invite|link|api_token</text>
+  <text x="380" y="256" class="e-sub">audience &mdash; humans OR service users</text>
+  <!-- share_links (right) -->
+  <rect class="e-new" x="720" y="180" width="240" height="84" rx="6"/>
+  <text x="840" y="200" text-anchor="middle" class="e-tt">share_links</text>
+  <text x="730" y="220" class="e-col">share_id, role, expires_at</text>
+  <text x="730" y="236" class="e-col">purpose, service_user_id</text>
+  <text x="730" y="252" class="e-col">last_used_at, revoked_at</text>
+  <!-- share_link_secrets (right, locked) -->
+  <rect class="e-lock" x="720" y="296" width="240" height="56" rx="6"/>
+  <text x="840" y="316" text-anchor="middle" class="e-tt">share_link_secrets</text>
+  <text x="730" y="332" class="e-col">link_id, token_hash (sha256)</text>
+  <text x="730" y="346" class="e-hi">creator-only · never synced</text>
+  <!-- blocks (existing) -->
+  <rect class="e-exist" x="20" y="296" width="500" height="56" rx="6"/>
+  <text x="270" y="316" text-anchor="middle" class="e-tt">blocks  <tspan class="e-sub">(existing table)</tspan></text>
+  <text x="30" y="332" class="e-col">id, parent_id, workspace_id, content, …</text>
+  <text x="30" y="346" class="e-newcol">+ effective_share_ids text[]   (new; GIN-indexed)</text>
+  <!-- Lines from block_shares to its three relatives -->
+  <path class="e-line" d="M 410 144 L 200 180"/>
+  <path class="e-line" d="M 490 144 L 490 180"/>
+  <path class="e-line" d="M 580 144 L 800 180"/>
+  <!-- share_links -> secrets -->
+  <path class="e-line" d="M 840 264 L 840 296"/>
+  <!-- effective_share_ids array references block_shares.id -->
+  <path class="e-line-dash" d="M 270 296 L 270 270 L 370 220"/>
+  <text x="278" y="288" class="e-newcol">array-of-ids ↗</text>
+</svg>
+<figcaption>The new tables in dark blue, the existing <code>blocks</code> table in gray with its new
+  column highlighted, and <code>share_link_secrets</code> in red as the strictly-isolated token
+  store. The dashed line is not a real foreign key &mdash; it's the array of share ids stamped on each
+  block.</figcaption>
+</figure>
 
 <h3>4.1 New column on <code>blocks</code></h3>
 
@@ -293,7 +499,88 @@ update on every share create/revoke. The RLS branch on <code>workspace_id</code>
 already indexed.
 </div>
 
+<p>The picture is the easiest way to grasp this. When share <code>s1</code> is created with one of
+  its roots set to block <code>A</code>, a trigger walks the descendants of <code>A</code> and
+  stamps <code>s1</code> onto every block's <code>effective_share_ids</code> array. RLS later just
+  asks "is any share id in this block's array one I'm a member of?"</p>
+
+<figure>
+<svg viewBox="0 0 720 340" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="A tree of blocks. Share s1 is rooted at block A. The share's id is stamped on A, C, D, G (A and its descendants). Sibling B and its descendant E are unaffected."
+     class="diagram" style="max-width:720px;">
+  <style>
+    .m-edge  { stroke: #57606a; stroke-width: 1.4; fill: none; }
+    .m-node  { fill: #f6f8fa; stroke: #57606a; stroke-width: 1.4; }
+    .m-root  { fill: #ddf4ff; stroke: #0969da; stroke-width: 2.4; }
+    .m-in    { fill: #dafbe1; stroke: #1a7f37; stroke-width: 1.6; }
+    .m-lbl   { font: 600 13px -apple-system, sans-serif; fill: #1f2328; }
+    .m-ann   { font: 11px ui-monospace, "SF Mono", Menlo, monospace; fill: #57606a; }
+    .m-stamp { font: 600 11px ui-monospace, "SF Mono", Menlo, monospace; fill: #1a7f37; }
+    .m-share { font: 600 11px ui-monospace, "SF Mono", Menlo, monospace; fill: #0969da; }
+    .m-title { font: 600 13px -apple-system, sans-serif; fill: #1f2328; }
+  </style>
+  <text x="20" y="22" class="m-title">Share s1 rooted at A &rarr; trigger stamps s1 onto A and every descendant.</text>
+  <!-- Edges first so nodes overlay -->
+  <path class="m-edge" d="M 360 78 L 200 144"/>
+  <path class="m-edge" d="M 360 78 L 520 144"/>
+  <path class="m-edge" d="M 200 144 L 120 218"/>
+  <path class="m-edge" d="M 200 144 L 280 218"/>
+  <path class="m-edge" d="M 520 144 L 520 218"/>
+  <path class="m-edge" d="M 280 218 L 280 290"/>
+  <!-- W (workspace root) -->
+  <circle class="m-node" cx="360" cy="60" r="22"/>
+  <text x="360" y="65" text-anchor="middle" class="m-lbl">W</text>
+  <text x="392" y="48" class="m-ann">[ ]</text>
+  <!-- A (share root) -->
+  <circle class="m-root" cx="200" cy="146" r="22"/>
+  <text x="200" y="151" text-anchor="middle" class="m-lbl">A</text>
+  <text x="232" y="138" class="m-stamp">[s1]</text>
+  <text x="232" y="154" class="m-share">&larr; root of s1</text>
+  <!-- B (unshared sibling) -->
+  <circle class="m-node" cx="520" cy="146" r="22"/>
+  <text x="520" y="151" text-anchor="middle" class="m-lbl">B</text>
+  <text x="552" y="146" class="m-ann">[ ]</text>
+  <!-- C (descendant of A) -->
+  <circle class="m-in" cx="120" cy="222" r="22"/>
+  <text x="120" y="227" text-anchor="middle" class="m-lbl">C</text>
+  <text x="62" y="222" text-anchor="end" class="m-stamp">[s1]</text>
+  <!-- D (descendant of A) -->
+  <circle class="m-in" cx="280" cy="222" r="22"/>
+  <text x="280" y="227" text-anchor="middle" class="m-lbl">D</text>
+  <text x="312" y="222" class="m-stamp">[s1]</text>
+  <!-- E (descendant of B, unshared) -->
+  <circle class="m-node" cx="520" cy="222" r="22"/>
+  <text x="520" y="227" text-anchor="middle" class="m-lbl">E</text>
+  <text x="552" y="222" class="m-ann">[ ]</text>
+  <!-- G (descendant of D) -->
+  <circle class="m-in" cx="280" cy="294" r="22"/>
+  <text x="280" y="299" text-anchor="middle" class="m-lbl">G</text>
+  <text x="312" y="299" class="m-stamp">[s1]</text>
+  <!-- Legend -->
+  <g transform="translate(20, 320)">
+    <circle class="m-root" cx="10" cy="0" r="8"/>
+    <text x="24" y="4" class="m-ann">share root</text>
+    <circle class="m-in" cx="120" cy="0" r="8"/>
+    <text x="134" y="4" class="m-ann">stamped (in share's subtree)</text>
+    <circle class="m-node" cx="340" cy="0" r="8"/>
+    <text x="354" y="4" class="m-ann">untouched (empty array)</text>
+  </g>
+</svg>
+<figcaption>What the recompute function (&sect;6.1) produces. <code>effective_share_ids</code> shown
+  in brackets next to each block.</figcaption>
+</figure>
+
+<p>A second share <code>s2</code> nested at, say, block <code>D</code> would result in
+  <code>D</code> and <code>G</code> carrying <code>[s1, s2]</code>. Different audiences can be granted
+  to <code>s1</code> and <code>s2</code> &mdash; effective access becomes the union, role becomes
+  the max. The array shape (rather than a scalar nearest-ancestor) is what makes nesting work without
+  losing the outer audience.</p>
+
 <h3>6.1 Recompute function</h3>
+
+<p>One function, one recursive CTE. Walks descendants from a root, unioning each block's existing
+  <code>effective_share_ids</code> contribution from the parent with any new share ids anchored at
+  the block itself. The result is an O(subtree-size) <code>UPDATE</code> on <code>public.blocks</code>.</p>
 
 <pre><code>create or replace function public.recompute_share_ids_subtree(p_root_block_id text)
 returns void
@@ -434,6 +721,83 @@ the same triggers; only the storage shape changes, all RLS / RPC logic carries o
 </div>
 
 <h2>8. API tokens</h2>
+
+<p>An API call has two hops: first the client trades its long-lived bearer token for a short-lived
+  Supabase JWT, then it uses that JWT against PostgREST exactly like the in-app client would. The
+  diagram below shows the full round trip; subsections below give the details.</p>
+
+<figure>
+<svg viewBox="0 0 880 420" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Sequence diagram. Agent posts the bearer token to the exchange edge function, which validates against share_link_secrets and mints a 15-minute JWT. The agent then calls PostgREST with the JWT; RLS enforces scope; rows are returned."
+     class="diagram" style="max-width:880px;">
+  <defs>
+    <marker id="arrowS" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <polygon points="0 0, 9 4.5, 0 9" fill="#0969da"/>
+    </marker>
+  </defs>
+  <style>
+    .s-head  { fill: #ddf4ff; stroke: #0969da; stroke-width: 1.4; }
+    .s-svc   { fill: #fff8c5; stroke: #d4a72c; stroke-width: 1.4; }
+    .s-line  { stroke: #d0d7de; stroke-width: 1; stroke-dasharray: 4,3; }
+    .s-msg   { stroke: #0969da; stroke-width: 1.6; fill: none; marker-end: url(#arrowS); }
+    .s-label { font: 600 12px -apple-system, sans-serif; fill: #1f2328; }
+    .s-msg-l { font: 11px ui-monospace, "SF Mono", Menlo, monospace; fill: #1f2328; }
+    .s-annot { font: 10.5px -apple-system, sans-serif; fill: #57606a; font-style: italic; }
+    .s-phase { font: 600 11px -apple-system, sans-serif; fill: #0969da; }
+  </style>
+  <!-- Lifelines headers -->
+  <rect class="s-head" x="20"  y="20" width="140" height="36" rx="6"/>
+  <text x="90"  y="44" text-anchor="middle" class="s-label">Agent (client)</text>
+  <rect class="s-head" x="200" y="20" width="170" height="36" rx="6"/>
+  <text x="285" y="44" text-anchor="middle" class="s-label">/api-token-exchange</text>
+  <rect class="s-svc"  x="410" y="20" width="160" height="36" rx="6"/>
+  <text x="490" y="44" text-anchor="middle" class="s-label">share_link_secrets</text>
+  <rect class="s-head" x="610" y="20" width="120" height="36" rx="6"/>
+  <text x="670" y="44" text-anchor="middle" class="s-label">PostgREST</text>
+  <rect class="s-svc"  x="770" y="20" width="100" height="36" rx="6"/>
+  <text x="820" y="44" text-anchor="middle" class="s-label">RLS / blocks</text>
+  <!-- Lifelines -->
+  <line class="s-line" x1="90"  y1="56" x2="90"  y2="400"/>
+  <line class="s-line" x1="285" y1="56" x2="285" y2="400"/>
+  <line class="s-line" x1="490" y1="56" x2="490" y2="400"/>
+  <line class="s-line" x1="670" y1="56" x2="670" y2="400"/>
+  <line class="s-line" x1="820" y1="56" x2="820" y2="400"/>
+  <!-- Phase label: exchange -->
+  <text x="20" y="80" class="s-phase">① EXCHANGE (once per ~15 min)</text>
+  <!-- 1: agent -> exchange -->
+  <path class="s-msg" d="M 90 100 L 280 100"/>
+  <text x="185" y="94" text-anchor="middle" class="s-msg-l">POST  Authorization: Bearer km_live_…</text>
+  <!-- 2: exchange -> secrets -->
+  <path class="s-msg" d="M 285 134 L 485 134"/>
+  <text x="385" y="128" text-anchor="middle" class="s-msg-l">SELECT … WHERE token_hash = sha256(bearer)</text>
+  <!-- 3: secrets -> exchange -->
+  <path class="s-msg" d="M 490 162 L 290 162"/>
+  <text x="390" y="156" text-anchor="middle" class="s-msg-l">link_id, service_user_id, expires_at, …</text>
+  <!-- validation note -->
+  <text x="285" y="184" class="s-annot">validate (not revoked, not expired) · mint JWT { sub: service_user_id, exp: now + 15m }</text>
+  <!-- 4: exchange -> agent -->
+  <path class="s-msg" d="M 285 212 L 95 212"/>
+  <text x="190" y="206" text-anchor="middle" class="s-msg-l">access_token (JWT)</text>
+  <!-- Phase label: use -->
+  <text x="20" y="244" class="s-phase">② USE (every API call, JWT until expiry)</text>
+  <!-- 5: agent -> postgrest -->
+  <path class="s-msg" d="M 90 268 L 665 268"/>
+  <text x="377" y="262" text-anchor="middle" class="s-msg-l">GET /rest/v1/blocks?…    Bearer &lt;JWT&gt;</text>
+  <!-- 6: postgrest -> RLS -->
+  <path class="s-msg" d="M 670 302 L 815 302"/>
+  <text x="742" y="296" text-anchor="middle" class="s-msg-l">SELECT * FROM blocks WHERE …</text>
+  <text x="820" y="324" text-anchor="middle" class="s-annot">policy: workspace member</text>
+  <text x="820" y="338" text-anchor="middle" class="s-annot">OR share covers this row</text>
+  <!-- 7: RLS -> PostgREST -->
+  <path class="s-msg" d="M 820 362 L 675 362"/>
+  <text x="747" y="356" text-anchor="middle" class="s-msg-l">filtered rows</text>
+  <!-- 8: PostgREST -> agent -->
+  <path class="s-msg" d="M 670 392 L 95 392"/>
+  <text x="380" y="386" text-anchor="middle" class="s-msg-l">200 OK + rows</text>
+</svg>
+<figcaption>Phase ① runs once per JWT lifetime; phase ② runs on every API call with the cached JWT.
+  No service_role secrets ever leave the edge function.</figcaption>
+</figure>
 
 <h3>8.1 Why service-users-per-token</h3>
 

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -735,11 +735,16 @@ end $$;</code></pre>
       policy check so the share-membership branch can match. (Workspace writers pass the policy
       regardless.)</td></tr>
 <tr><td><code>blocks AFTER INSERT</code></td>
-    <td>Fix-up: if the inserted row has any pre-existing children whose
-      <code>effective_share_ids</code> is empty, recompute the subtree from <code>NEW.id</code>.
-      Handles the PowerSync replay case where a child arrives before its parent &mdash; the child's
-      BEFORE trigger saw no parent and stamped <code>'{}'</code>; this AFTER trigger backfills once
-      the parent lands.</td></tr>
+    <td>Fix-up: if any pre-existing rows have <code>parent_id = NEW.id</code>, call
+      <code>recompute_share_ids_subtree(NEW.id)</code> <em>unconditionally</em>. Handles the
+      PowerSync replay case where a child arrived before its parent &mdash; the child's BEFORE
+      trigger saw no parent and stamped <code>'{}'</code>, OR the child already had a non-empty
+      array (e.g., from a <code>block_share_roots</code> row anchored at the child itself) but
+      is still missing inherited share ids that should arrive through the newly inserted parent.
+      The unconditional recompute is idempotent: if the existing arrays are already correct, the
+      <code>UPDATE … SET effective_share_ids = …</code> writes the same values and the
+      <code>block_share_coverage</code> sync resolves to a no-op (the existing rows match
+      <code>target_coverage</code>).</td></tr>
 <tr><td><code>blocks AFTER UPDATE OF parent_id</code></td>
     <td>Call <code>recompute_share_ids_subtree(NEW.id)</code>. The moved subtree gets reconsidered
       against its new ancestor chain.</td></tr>

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -683,15 +683,44 @@ begin
       from walk
       join public.blocks child on child.parent_id = walk.block_id
     )
-  update public.blocks
-  set effective_share_ids = (
-    select array(select distinct unnest(walk.share_ids) order by 1)
+  ,
+  -- 1. Refresh the dense array on each affected block.
+  upd as (
+    update public.blocks b
+    set effective_share_ids = (
+      select array(select distinct unnest(walk.share_ids) order by 1)
+      from walk where walk.block_id = b.id
+    )
     from walk
-    where walk.block_id = blocks.id
+    where b.id = walk.block_id
+    returning b.id, b.workspace_id, b.effective_share_ids
+  ),
+  -- 2. Re-derive the (block_id, share_id) target set from the new arrays.
+  target_coverage as (
+    select upd.id as block_id, upd.workspace_id, sid as share_id
+    from upd, unnest(upd.effective_share_ids) as sid
+  ),
+  -- 3. Delete junction rows that are no longer covered.
+  del as (
+    delete from public.block_share_coverage c
+    using upd
+    where c.block_id = upd.id
+      and not exists (
+        select 1 from target_coverage t
+        where t.block_id = c.block_id and t.share_id = c.share_id
+      )
+    returning 1
   )
-  from walk
-  where blocks.id = walk.block_id;
+  -- 4. Insert junction rows for newly-covered (block, share) pairs.
+  insert into public.block_share_coverage (block_id, share_id, workspace_id)
+  select t.block_id, t.share_id, t.workspace_id
+  from target_coverage t
+  on conflict (block_id, share_id) do nothing;
 end $$;</code></pre>
+
+<p>Steps (1)&ndash;(4) all execute inside the same transaction under the advisory lock taken at the
+  top of the function, so the array and the junction can never diverge under concurrent recomputes
+  on the same root.</p>
 
 <h3>6.2 Triggers calling it</h3>
 

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -1,0 +1,597 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Shares + API tokens — unified access model</title>
+<style>
+  body { font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         max-width: 1040px; margin: 2rem auto; padding: 0 1.25rem; color: #1f2328; }
+  h1 { font-size: 1.6rem; margin-bottom: .25rem; }
+  h2 { font-size: 1.18rem; margin-top: 2rem; border-bottom: 1px solid #d0d7de; padding-bottom: .25rem; }
+  h3 { font-size: 1.02rem; margin-top: 1.4rem; }
+  h4 { font-size: .96rem; margin-top: 1rem; margin-bottom: .25rem; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; }
+  pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+        padding: .75rem .9rem; overflow-x: auto; }
+  code { background: #f6f8fa; padding: .1em .3em; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .65rem; vertical-align: top; text-align: left; }
+  th { background: #f6f8fa; }
+  .note { background: #fff8c5; border-left: 4px solid #d4a72c; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .delta { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
+           border-radius: 4px; margin: 1rem 0; }
+  .verdict { background: #dafbe1; border-left: 4px solid #1a7f37; padding: .75rem 1rem;
+             border-radius: 4px; margin: 1.5rem 0; }
+  .warn { background: #ffebe9; border-left: 4px solid #cf222e; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  small { color: #57606a; }
+  .kbd { background: #f6f8fa; border: 1px solid #d0d7de; border-bottom-width: 2px;
+         border-radius: 4px; padding: 0 .35em; font-size: 11.5px; }
+  ul.tight li, ol.tight li { margin: .2rem 0; }
+  .colcompare { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  .colcompare > div { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+                      padding: .6rem .8rem; }
+  .colcompare h4 { margin-top: 0; }
+</style>
+</head>
+<body>
+
+<h1>Shares + API tokens — unified access model</h1>
+<small>Supersedes the &ldquo;single-root subtree share&rdquo; framing in
+  <a href="./subtree-sharing.md">subtree-sharing.md</a>. Draft, 2026-05-15.</small>
+
+<h2>1. Why a new doc</h2>
+
+<p>The existing <a href="./subtree-sharing.md">subtree-sharing.md</a> nails the hard parts:
+  RLS unification via <code>blocks.effective_share_ids</code>, role monotonicity, token isolation,
+  trigger-maintained access materialization, and a single-mode-per-session bootstrap. We're keeping all
+  of that. What's changed since it was written:</p>
+
+<ol class="tight">
+  <li><strong>API access is now a first-class requirement.</strong> Programmatic agents and third-party
+    integrations need stable scoped access without a browser session. Treating an API token as a kind of
+    share grant collapses two designs into one.</li>
+  <li><strong>A single share should cover multiple subtrees</strong> &mdash; &ldquo;share these three
+    projects with my contractor&rdquo; or &ldquo;the agent gets read access to <em>this</em> page and
+    <em>that</em> page.&rdquo;</li>
+  <li><strong>Workspace-scoped tokens are valuable.</strong> Both for &ldquo;give my agent the whole
+    workspace&rdquo; and as the natural ceiling of the subtree model.</li>
+</ol>
+
+<p>This doc is the diff against
+  <a href="./subtree-sharing.md">subtree-sharing.md</a>. Sections that aren't re-litigated here
+  (read-only snapshot RPC, presentation root clipping, advisory locks in the recompute, the
+  &ldquo;workspace member overrides share grant&rdquo; rule, the test plan, the guardrails) remain
+  authoritative in the original doc.</p>
+
+<h2>2. The unifying primitive</h2>
+
+<p>A <em>share</em> is the access primitive. Everything else &mdash; human invites, link URLs, API
+  tokens &mdash; is a way of putting some principal into a share's audience.</p>
+
+<pre><code>Share = {
+  workspace_id,                       // a share always lives inside one workspace
+  scope:    'workspace' | 'subtree',  // entire workspace, or a set of subtree roots
+  roots:    text[]                    // only meaningful for scope='subtree'; one or more block ids
+  role:     'viewer' | 'editor',      // default role for new audience members
+  purpose:  'human' | 'api',          // who this share is for; drives UI/listing only
+}
+
+ShareMember = (share_id, principal_id, role, source)
+  // principal_id is auth.users.id, whether human or API service user
+  // source is one of: 'invite' | 'link' | 'api_token'
+
+ShareLink = a redeemable URL fragment (one-shot per user) for humans
+ApiToken  = a long-lived credential (re-usable, single service principal) for integrations
+</code></pre>
+
+<p>The two are the same shape: an opaque secret stored in a tightest-RLS sidecar table, validated by a
+  SECURITY DEFINER RPC, which then upserts a row into <code>block_share_members</code> for the redeeming
+  principal. The differences are operational: lifecycle (one-shot human redeem vs. long-lived API
+  exchange), audit fields, and UI surface.</p>
+
+<div class="verdict">
+<strong>Mental model:</strong> a workspace member is just a built-in &ldquo;workspace-scope share with
+the user as a member.&rdquo; A subtree share is the same idea narrowed to N roots. An API token is a
+share whose audience is a per-token service user. <em>One RLS predicate handles all four cases.</em>
+</div>
+
+<h2>3. Schema deltas vs. the existing doc</h2>
+
+<p>Same migration posture as <a href="./subtree-sharing.md">subtree-sharing.md</a> &sect;1: existing
+  tables (<code>blocks</code>, <code>workspaces</code>, <code>workspace_members</code>,
+  <code>workspace_invitations</code>) are not touched destructively. The delta below changes only the
+  <em>new</em> tables introduced by the share design, plus one additional column on
+  <code>blocks</code>.</p>
+
+<h3>3.1 <code>block_shares</code> — multi-root + scope kind</h3>
+
+<table>
+<tr><th>Column</th><th>Original (subtree-sharing.md &sect;4.2)</th><th>New</th></tr>
+<tr><td><code>root_block_id</code></td>
+    <td>scalar <code>text</code>, immutable</td>
+    <td><strong>removed</strong> — moved to <code>block_share_roots</code></td></tr>
+<tr><td><code>scope</code></td>
+    <td>(implicit: always subtree)</td>
+    <td><strong>new:</strong> <code>text not null check (scope in ('workspace','subtree'))</code></td></tr>
+<tr><td><code>purpose</code></td>
+    <td>(not present)</td>
+    <td><strong>new:</strong> <code>text not null default 'human' check (purpose in ('human','api'))</code></td></tr>
+<tr><td><code>workspace_id</code></td>
+    <td>denormalized + stamped at insert, immutable</td>
+    <td>unchanged</td></tr>
+<tr><td><code>default_role</code>, <code>created_by_user_id</code>, <code>create_time</code>, <code>revoked_at</code></td>
+    <td>as before</td>
+    <td>unchanged</td></tr>
+</table>
+
+<pre><code>create table public.block_shares (
+  id                   text primary key,
+  workspace_id         text not null references public.workspaces(id) on delete cascade,
+  scope                text not null check (scope in ('workspace','subtree')),
+  purpose              text not null default 'human' check (purpose in ('human','api')),
+  default_role         text not null check (default_role in ('viewer','editor')),
+  created_by_user_id   text not null,
+  create_time          bigint not null,
+  revoked_at           bigint
+);</code></pre>
+
+<h3>3.2 <code>block_share_roots</code> — new junction table</h3>
+
+<p>One row per (share, root) pair. Only populated for shares with <code>scope='subtree'</code>; enforced
+  by trigger.</p>
+
+<pre><code>create table public.block_share_roots (
+  share_id       text not null references public.block_shares(id) on delete cascade,
+  root_block_id  text not null references public.blocks(id)        on delete cascade,
+  workspace_id   text not null,  -- stamped + checked equal to block_shares.workspace_id and blocks.workspace_id
+  create_time    bigint not null,
+  primary key (share_id, root_block_id)
+);
+create index idx_block_share_roots_root_block_id on public.block_share_roots(root_block_id);</code></pre>
+
+<div class="delta">
+<strong>Why a junction table instead of <code>text[]</code> on <code>block_shares</code>:</strong>
+roots get added/removed over time, and we want a per-root foreign key with cascade-on-delete so
+deleting a block that's a share root cleanly removes that scope without leaving a dangling id in an
+array. The same reasoning that made <code>workspace_members</code> a table rather than an array on
+<code>workspaces</code> applies here.
+</div>
+
+<h3>3.3 <code>blocks.effective_share_ids</code> — unchanged shape, narrower scope</h3>
+
+<p>The column stays as designed in <a href="./subtree-sharing.md">subtree-sharing.md &sect;4.1</a>,
+  but with one rule change: <strong>it only carries <code>block_shares.id</code>s for shares with
+  <code>scope='subtree'</code>.</strong> Workspace-scope shares are matched by joining
+  <code>workspace_id</code> directly in RLS &mdash; cheaper than re-stamping every block in the
+  workspace whenever a workspace-scope share is created or revoked.</p>
+
+<p>This keeps the recompute function (<a href="./subtree-sharing.md">subtree-sharing.md &sect;5</a>)
+  unchanged: it still walks descendants from one root, unioning <code>block_share_roots</code> matches.
+  When a multi-root share is created, we just call <code>recompute_share_ids_subtree</code> once per
+  root. Adding/removing a root is one recompute on that root.</p>
+
+<h3>3.4 <code>share_links</code> — add <code>purpose</code> and audit fields</h3>
+
+<table>
+<tr><th>Column</th><th>Original</th><th>New</th></tr>
+<tr><td><code>purpose</code></td>
+    <td>n/a</td>
+    <td><strong>new:</strong> <code>text not null default 'human_link' check (purpose in ('human_link','api_token'))</code></td></tr>
+<tr><td><code>name</code></td>
+    <td>n/a</td>
+    <td><strong>new:</strong> <code>text</code> &mdash; human label for API tokens (&ldquo;laptop CLI&rdquo;, &ldquo;Readwise sync&rdquo;)</td></tr>
+<tr><td><code>last_used_at</code></td>
+    <td>n/a</td>
+    <td><strong>new:</strong> <code>bigint</code> &mdash; bumped on every exchange (API tokens) or redeem (human links)</td></tr>
+<tr><td><code>last_used_ip</code></td>
+    <td>n/a</td>
+    <td><strong>new:</strong> <code>text</code> &mdash; best-effort, may be null</td></tr>
+<tr><td><code>service_user_id</code></td>
+    <td>n/a</td>
+    <td><strong>new:</strong> <code>text</code> &mdash; for <code>purpose='api_token'</code>, the dedicated <code>auth.users</code> row that this token authenticates as. Null for human links. One-to-one with the link.</td></tr>
+<tr><td><code>expires_at</code>, <code>max_redemptions</code>, <code>redemption_count</code>, <code>revoked_at</code></td>
+    <td>as before</td>
+    <td>semantics unchanged; for API tokens, <code>redemption_count</code> increments on first exchange only (a single service user redeems once, then re-uses the JWT)</td></tr>
+</table>
+
+<h3>3.5 <code>share_link_secrets</code> — unchanged</h3>
+
+<p>Token storage table from <a href="./subtree-sharing.md">subtree-sharing.md &sect;4.2</a> is reused
+  as-is for both human links and API tokens. Same RLS (creator-only SELECT), same hash-not-plaintext
+  storage, same one-time-reveal-on-creation discipline.</p>
+
+<div class="note">
+For API tokens, we store the SHA-256 of the token in <code>share_link_secrets.token</code>. Human
+links can do the same (it was an open choice in the original doc); switching both to hashed storage
+makes the table genuinely &ldquo;a secret never escapes Postgres alive&rdquo;.
+</div>
+
+<h2>4. RLS — the unified <code>blocks</code> predicate</h2>
+
+<p>One read policy, one write policy, four cases covered:</p>
+
+<pre><code>create policy blocks_read on public.blocks
+for select using (
+  -- 1. Workspace member (existing behavior)
+  public.is_workspace_member(workspace_id, auth.uid()::text)
+
+  -- 2. Workspace-scope share recipient or API-token principal
+  or exists (
+    select 1
+    from public.block_share_members sm
+    join public.block_shares s on s.id = sm.share_id
+    where sm.user_id = auth.uid()::text
+      and s.revoked_at is null
+      and s.scope = 'workspace'
+      and s.workspace_id = blocks.workspace_id
+  )
+
+  -- 3. Subtree-scope share recipient or API-token principal
+  or exists (
+    select 1
+    from public.block_share_members sm
+    join public.block_shares s on s.id = sm.share_id
+    where sm.user_id = auth.uid()::text
+      and s.revoked_at is null
+      and s.scope = 'subtree'
+      and s.id = any (blocks.effective_share_ids)
+  )
+);</code></pre>
+
+<p>The <code>blocks_write</code> policy mirrors this with <code>sm.role = 'editor'</code> in both share
+  branches and a matching <code>with check</code>. (Same shape as
+  <a href="./subtree-sharing.md">subtree-sharing.md &sect;6.1</a>.)</p>
+
+<div class="delta">
+<strong>Notice what this buys us.</strong> An API token is just an <code>auth.uid()</code> with a
+<code>block_share_members</code> row. <em>The RLS predicate doesn't know it's an API call.</em> No
+&ldquo;is this a token request?&rdquo; branch in policy, no service-role bypass anywhere in the data
+path. PostgREST + Supabase auth handle it natively.
+</div>
+
+<h2>5. Recompute — what changes</h2>
+
+<p><a href="./subtree-sharing.md">subtree-sharing.md &sect;5.1</a>'s <code>recompute_share_ids_subtree(p_root_block_id)</code>
+  needs one small tweak: it currently joins <code>block_shares</code> on
+  <code>root_block_id = child.id</code>. With the junction table, that becomes:</p>
+
+<pre><code>-- inside the recursive CTE, replacing the existing join:
+coalesce((
+  select array_agg(s.id)
+  from public.block_share_roots r
+  join public.block_shares     s on s.id = r.share_id
+  where r.root_block_id = child.id
+    and s.scope = 'subtree'
+    and s.revoked_at is null
+), '{}'::text[])</code></pre>
+
+<p>Triggers calling the recompute (<a href="./subtree-sharing.md">subtree-sharing.md &sect;5.2</a>)
+  fan out one additional case:</p>
+
+<table>
+<tr><th>Trigger</th><th>Argument(s)</th></tr>
+<tr><td><code>blocks AFTER INSERT</code></td><td>parent's <code>effective_share_ids</code> (unchanged)</td></tr>
+<tr><td><code>blocks AFTER UPDATE OF parent_id</code></td><td><code>recompute(NEW.id)</code> (unchanged)</td></tr>
+<tr><td><code>block_share_roots AFTER INSERT or DELETE</code></td><td><code>recompute(NEW.root_block_id)</code> (or <code>OLD</code>)</td></tr>
+<tr><td><code>block_shares AFTER UPDATE OF revoked_at</code></td><td>for <code>scope='subtree'</code>: <code>recompute</code> on each root. For <code>scope='workspace'</code>: no recompute needed.</td></tr>
+</table>
+
+<p>Workspace-scope share creation/revocation does <em>not</em> trigger a recompute. It's RLS-only;
+  membership is checked against <code>blocks.workspace_id</code> directly.</p>
+
+<h2>6. PowerSync sync streams</h2>
+
+<p>Two changes to <a href="./subtree-sharing.md">subtree-sharing.md &sect;7</a>:</p>
+
+<h3>6.1 <code>shared_blocks</code> stream — multi-root, scope-aware</h3>
+
+<p>The original stream joins blocks via <code>block_share_members</code> &harr;
+  <code>effective_share_ids</code>. With workspace-scope shares, we union two predicates:</p>
+
+<pre><code>shared_blocks:
+  auto_subscribe: true
+  query: |
+    SELECT blocks.*
+    FROM public.blocks
+    JOIN public.block_share_members sm ON sm.user_id = auth.user_id()
+    JOIN public.block_shares          s ON s.id = sm.share_id AND s.revoked_at IS NULL
+    WHERE (
+      (s.scope = 'workspace' AND s.workspace_id = blocks.workspace_id)
+      OR (s.scope = 'subtree' AND s.id = ANY(blocks.effective_share_ids))
+    )</code></pre>
+
+<p>For API tokens this stream isn't reached because API consumers don't run PowerSync &mdash; they hit
+  PostgREST or a snapshot RPC. The stream exists for <em>human</em> share recipients. A workspace-scope
+  human share recipient (rare in v1 &mdash; see &sect;6.2) gets the entire workspace via this stream
+  without us having to put them in <code>workspace_members</code>.</p>
+
+<h3>6.2 V1 simplification: workspace-scope shares are API-only</h3>
+
+<div class="delta">
+For v1, <strong>only <code>purpose='api'</code> shares may have <code>scope='workspace'</code>.</strong>
+Human shares stay subtree-only. Rationale: the human flow for &ldquo;share my whole workspace with
+you&rdquo; is already covered by <code>invite_member_by_email</code> + workspace_members. Adding a
+parallel path for humans creates a fork in the share-mode bootstrap (which root do we land on?
+breadcrumbs to where?) for no real benefit.
+</div>
+
+<p>Enforced by check constraint:</p>
+
+<pre><code>alter table public.block_shares
+  add constraint workspace_scope_is_api_only
+  check (scope = 'subtree' or purpose = 'api');</code></pre>
+
+<p>If a real use case for &ldquo;guest with the whole workspace, not yet a member&rdquo; appears, drop
+  the constraint and finish the human bootstrap path. The RLS predicate already supports it.</p>
+
+<h2>7. API token lifecycle</h2>
+
+<h3>7.1 Creation (UI flow, in-app)</h3>
+
+<ol class="tight">
+  <li>User opens <em>Settings &rarr; API tokens</em> in the app, or invokes &ldquo;Create API
+    token&rdquo; from the existing share dialog (when context is a specific block).</li>
+  <li>User chooses:
+    <ul class="tight">
+      <li><strong>Scope</strong>: this block + descendants / these blocks (multi-select) / entire workspace</li>
+      <li><strong>Role</strong>: viewer or editor</li>
+      <li><strong>Name</strong>: e.g. &ldquo;Claude on laptop&rdquo;</li>
+      <li><strong>Expiry</strong>: 30/90/365 days / never</li>
+    </ul>
+  </li>
+  <li>Client calls one RPC: <code>create_api_token(p_scope, p_roots, p_role, p_name, p_expires_at)</code>.
+    Server-side it:
+    <ol class="tight">
+      <li>Creates a <code>block_shares</code> row with <code>purpose='api'</code> and the chosen scope.</li>
+      <li>For subtree scope, inserts <code>block_share_roots</code> rows.</li>
+      <li>Creates a dedicated service user (<code>auth.admin.createUser</code> with a generated email
+        like <code>svc+&lt;random&gt;@knowledge-medium.local</code> and a random password; user is
+        never used for password sign-in &mdash; the token <em>is</em> the credential).</li>
+      <li>Inserts <code>block_share_members(share_id, user_id=service_user_id, role)</code>.</li>
+      <li>Generates the token (<code>encode(gen_random_bytes(32), 'base64url')</code> = 43 chars
+        prefixed with <code>km_</code>).</li>
+      <li>Inserts <code>share_links(purpose='api_token', service_user_id, ...)</code> +
+        <code>share_link_secrets(token=sha256(plaintext))</code>.</li>
+      <li>Returns the share + the plaintext token <strong>once</strong>.</li>
+    </ol>
+  </li>
+  <li>Client surfaces the plaintext token with copy-to-clipboard and a &ldquo;you won't see this
+    again&rdquo; warning, then stores nothing.</li>
+</ol>
+
+<div class="note">
+The service user creation step is the only piece that needs a Supabase Edge Function or a
+<code>service_role</code>-keyed RPC &mdash; <code>auth.admin.createUser</code> isn't callable from
+client SQL. Everything else stays as regular <code>SECURITY DEFINER</code> RPCs callable by
+authenticated clients.
+</div>
+
+<h3>7.2 Exchange (every API call)</h3>
+
+<p>Third-party clients <code>POST</code> to a small edge function
+  <code>/functions/v1/api-token-exchange</code>:</p>
+
+<pre><code>POST /functions/v1/api-token-exchange
+Authorization: Bearer km_&lt;43 chars&gt;
+
+200 OK
+{
+  "access_token": "&lt;short-lived Supabase JWT, sub=service_user_id&gt;",
+  "expires_in": 900,
+  "share": { "id": "...", "scope": "subtree", "workspace_id": "..." }
+}</code></pre>
+
+<p>The edge function:</p>
+<ol class="tight">
+  <li>Hashes the bearer token, looks it up in <code>share_link_secrets</code>.</li>
+  <li>Validates: link not revoked, not past <code>expires_at</code>, share not revoked.</li>
+  <li>Bumps <code>last_used_at</code>, <code>last_used_ip</code> on <code>share_links</code>.</li>
+  <li>Signs a JWT with the project JWT secret claiming <code>sub = service_user_id</code>,
+    <code>role = 'authenticated'</code>, <code>aud = 'authenticated'</code>, short TTL (15 min).</li>
+  <li>Returns the JWT.</li>
+</ol>
+
+<p>The client now uses the JWT against PostgREST exactly like any Supabase client. RLS resolves
+  through the <code>block_share_members</code> row attached to the service user.</p>
+
+<h3>7.3 What 3rd parties get for free</h3>
+
+<ul class="tight">
+  <li><code>GET /rest/v1/blocks?workspace_id=eq.&lt;id&gt;&amp;deleted=eq.false</code></li>
+  <li><code>GET /rest/v1/blocks?parent_id=eq.&lt;id&gt;&amp;order=order_key.asc</code></li>
+  <li><code>POST /rest/v1/blocks</code> (editor role only; <code>workspace_id</code> trigger enforces
+    immutability, RLS enforces scope match)</li>
+  <li><code>PATCH /rest/v1/blocks?id=eq.&lt;id&gt;</code></li>
+</ul>
+
+<p>For ergonomic agent surfaces (subtree fetch in one round trip, search across
+  <code>properties_json</code>, batch tree creation), a separate <code>/functions/v1/api/&hellip;</code>
+  edge function exposes high-level endpoints over the same JWT. These wrap RPCs and are the layer that
+  shields third parties from schema churn. v1 can ship without this and rely on PostgREST; the
+  high-level surface is a follow-up.</p>
+
+<div class="delta">
+<strong>Read-only fast path.</strong> For tokens with <code>role='viewer'</code> the existing
+<a href="./subtree-sharing.md">subtree-sharing.md &sect;8.4</a> <code>get_shared_subtree(token)</code>
+RPC is already a perfectly good zero-state read endpoint. It validates the token, returns a flat
+snapshot, doesn't need the service user round-trip. <em>This is the v1 &ldquo;public read&rdquo;
+endpoint already designed.</em> Extend it to accept multi-root subtree shares and workspace shares
+(returns paginated blocks for workspace scope).
+</div>
+
+<h3>7.4 Revocation, rotation, list</h3>
+
+<ul class="tight">
+  <li><code>revoke_api_token(p_link_id)</code> &rarr; sets <code>share_links.revoked_at</code> and
+    revokes the share (cascades to membership). Service user kept around for audit (so blocks updated
+    by the token still resolve).</li>
+  <li><code>rotate_api_token(p_link_id)</code> &rarr; generates a new token, updates the secret row,
+    returns the new plaintext once. Old token stops working immediately.</li>
+  <li><code>list_my_api_tokens()</code> &rarr; returns rows with everything <em>except</em> the token.</li>
+</ul>
+
+<h2>8. Where this lands in the existing codebase</h2>
+
+<table>
+<tr><th>Concern</th><th>Touches</th></tr>
+<tr><td>Schema migration</td>
+    <td>new <code>supabase/migrations/&lt;ts&gt;_shares_and_api_tokens.sql</code>, alongside the original
+      sharing migration. (If the sharing work has not landed yet, fold both into one migration.)</td></tr>
+<tr><td>Sync rules</td>
+    <td><a href="../powersync/sync-config.yaml">powersync/sync-config.yaml</a> &mdash; one new stream
+      <code>shared_blocks</code> (replaces the original doc's version), plus
+      <code>block_shares</code>, <code>block_share_members</code>, <code>block_share_roots</code>,
+      <code>share_links</code>. Regenerate via <code>yarn gen:sync-config</code>.</td></tr>
+<tr><td>Client schema</td>
+    <td><a href="../src/data/blockSchema.ts">src/data/blockSchema.ts</a> adds
+      <code>effective_share_ids</code>; new <code>src/data/shareSchema.ts</code> covers the new tables;
+      <a href="../src/data/repoInstance.ts">src/data/repoInstance.ts</a> registers them.</td></tr>
+<tr><td>Repo guards</td>
+    <td><a href="../src/data/repo.ts">src/data/repo.ts:271</a> &mdash; add immutability guard for
+      <code>effectiveShareIds</code> next to the existing <code>workspace_id</code> one.</td></tr>
+<tr><td>Routing</td>
+    <td><a href="../src/utils/routing.ts">src/utils/routing.ts</a> &mdash; gains the
+      <code>#share/&lt;token&gt;</code> branch from the original doc; no change for API tokens (no
+      hash route).</td></tr>
+<tr><td>Share dialog</td>
+    <td>new <code>src/components/share/ShareDialog.tsx</code> with three tabs:
+      <em>People</em>, <em>Link</em>, <em>API tokens</em>. (Original doc had two tabs; we add the
+      third.) For workspace-scope tokens, surface from <em>Settings &rarr; API tokens</em>.</td></tr>
+<tr><td>Token exchange</td>
+    <td>new <code>supabase/functions/api-token-exchange/index.ts</code> &mdash; the only new edge
+      function for v1.</td></tr>
+<tr><td>Agent runtime bridge</td>
+    <td><a href="../README.md">README.md</a> &sect;&ldquo;Agent Runtime Access&rdquo; today uses a
+      local relay paired with the running browser. With API tokens, an agent that doesn't need a
+      browser can use <code>yarn agent</code> against the remote API instead. Add a
+      <code>yarn agent login-token &lt;km_&hellip;&gt;</code> command + a <code>--remote</code> mode that
+      hits the exchange endpoint and calls PostgREST/RPCs directly. Existing local-bridge path stays
+      intact.</td></tr>
+</table>
+
+<h2>9. Phased plan (rolled into the original 8 phases)</h2>
+
+<p>Phases 1&ndash;8 from <a href="./subtree-sharing.md">subtree-sharing.md &sect;10</a> stay, with the
+  deltas below folded in. Phase 9&ndash;10 are new.</p>
+
+<table>
+<tr><th>Phase</th><th>Delta vs. original</th></tr>
+<tr><td>1 (Schema + recompute + RLS)</td>
+    <td>Drop <code>block_shares.root_block_id</code>, add <code>scope</code> + <code>purpose</code>;
+      add <code>block_share_roots</code> table; tweak recompute to join through it; widen the
+      <code>blocks_read/write</code> policies with the workspace-scope branch.</td></tr>
+<tr><td>2 (RPCs)</td>
+    <td><code>create_block_share</code> now accepts <code>p_roots text[]</code> instead of a scalar;
+      <code>add_share_root</code> / <code>remove_share_root</code> are new; rest unchanged.</td></tr>
+<tr><td>3 (PowerSync rules)</td>
+    <td><code>shared_blocks</code> query changes to the union form. <code>block_share_roots</code>
+      added to publication; secrets table still not published.</td></tr>
+<tr><td>4 (Client schema/types)</td>
+    <td><code>BlockShare</code> type loses <code>rootBlockId</code>, gains <code>scope</code> /
+      <code>purpose</code>; new <code>BlockShareRoot</code> type; raw table registered.</td></tr>
+<tr><td>5 (Routing + share-mode bootstrap)</td>
+    <td>Bootstrap into a multi-root subtree share picks the first root for the initial
+      <code>activeBlockId</code> (or honors the optional <code>#share/&lt;token&gt;/&lt;blockId&gt;</code>
+      suffix). Presentation root clipping (&sect;6 of original) accepts <code>clipAt: Set&lt;string&gt;</code>
+      &mdash; the walk stops at any member of the set.</td></tr>
+<tr><td>6 (Presentation clipping)</td>
+    <td>Same as above &mdash; <code>getRootBlock(blockId, clipAt?: Set&lt;string&gt;)</code>.</td></tr>
+<tr><td>7 (Share dialog + indicators)</td>
+    <td>Dialog gains a roots list editor for subtree shares (add/remove roots).
+      <code>ShareBadge</code> renders on any block that's in <code>block_share_roots</code>.</td></tr>
+<tr><td>8 (Reference stubs + cleanup)</td>
+    <td>Unchanged.</td></tr>
+<tr><td><strong>9 (API tokens, new)</strong></td>
+    <td>Service-user creation edge function path; <code>create_api_token</code> / <code>revoke_api_token</code>
+      / <code>rotate_api_token</code> / <code>list_my_api_tokens</code> RPCs;
+      <code>api-token-exchange</code> edge function; Settings &rarr; API tokens UI.</td></tr>
+<tr><td><strong>10 (Agent ergonomics, new, optional)</strong></td>
+    <td><code>yarn agent</code> remote mode; <code>/functions/v1/api/&hellip;</code> high-level endpoints
+      (subtree fetch, property search); an MCP server wrapping the same.</td></tr>
+</table>
+
+<h2>10. Open questions</h2>
+
+<ol class="tight">
+  <li><strong>Service-user audit identity.</strong> Should <code>blocks.created_by</code> /
+    <code>updated_by</code> store the service user's id, or the issuing user's id with a side reference
+    to the token? Storing the service-user id is simpler and means the audit trail naturally reflects
+    &ldquo;this token did this&rdquo; (linkable via <code>share_links.service_user_id</code>). Recommended.</li>
+  <li><strong>Token prefix scheme.</strong> Proposing <code>km_live_</code> for production,
+    <code>km_test_</code> for any future dev/scratch instance. Trivial to extend.</li>
+  <li><strong>Per-token rate limits.</strong> Probably enforce in the exchange edge function (deny if
+    last 100 exchanges were within 60s) rather than at PostgREST. Out of scope for v1 but worth a
+    column on <code>share_links</code> if cheap.</li>
+  <li><strong>Workspace-scope human shares.</strong> Locked off in v1 by the
+    <code>workspace_scope_is_api_only</code> constraint. Re-open if a real use case shows up &mdash;
+    the RLS predicate is already ready.</li>
+  <li><strong>Snapshot RPC for workspace scope.</strong> <code>get_shared_subtree</code> works
+    naturally for subtree shares; the workspace-scope equivalent returns potentially the whole
+    workspace. Add pagination (<code>p_after_id</code>, <code>p_limit</code>) before exposing it.</li>
+  <li><strong>Token revocation lag.</strong> Issued JWTs live 15 min; an attacker with a stolen JWT
+    keeps access for that window even after token revocation. Acceptable for v1; if not, the exchange
+    function can mint shorter JWTs or we can move to a check-on-every-request model with a custom
+    PostgREST GUC. Default: live with 15 min.</li>
+</ol>
+
+<h2>11. What this doc is <em>not</em> changing</h2>
+
+<p>All of the following from <a href="./subtree-sharing.md">subtree-sharing.md</a> remain authoritative
+  and untouched by this proposal:</p>
+
+<ul class="tight">
+  <li>&sect;3.5 <strong>Role monotonicity</strong> &mdash; same rule, applied identically to API token
+    grants (you can't lower a service user's role by re-issuing a lower-role token; you have to
+    revoke).</li>
+  <li>&sect;3.7 <strong>Token isolation</strong> &mdash; same <code>share_link_secrets</code> table,
+    same RLS, same hash storage. Tokens never appear in any sync stream.</li>
+  <li>&sect;3.8 <strong>Presentation root clipping</strong> &mdash; generalized to a set instead of a
+    single id, but the principle is unchanged.</li>
+  <li>&sect;3.9 <strong>Single write chokepoint</strong> &mdash; all writes still go through
+    <code>Repo</code> client-side, all server writes still go through SECURITY DEFINER RPCs or
+    RLS-protected PostgREST.</li>
+  <li>&sect;5.2-5.3 <strong>Concurrency + cross-row insert order</strong> &mdash; advisory lock + the
+    &ldquo;parent's insert fixes orphaned children&rdquo; trick are unchanged.</li>
+  <li>&sect;11 <strong>Test plan</strong> &mdash; reused wholesale; add four new tests:
+    <ul class="tight">
+      <li>Multi-root recompute: a share with roots {R1, R2}; descendants under either are reachable;
+        revoking the share clears both subtrees.</li>
+      <li>Workspace-scope share: every block in W is visible to the recipient; blocks in a different
+        workspace are not.</li>
+      <li>API token exchange: token &rarr; JWT &rarr; PostgREST read/write succeeds within scope, fails
+        outside it.</li>
+      <li>Token rotation: old token stops working immediately; new token works.</li>
+    </ul>
+  </li>
+  <li>&sect;13 <strong>Guardrails</strong> &mdash; all 14 still apply; #1 (role monotonicity), #2
+    (token isolation), #7 (<code>effectiveShareIds</code> immutability), and #12 (idempotent redeem)
+    are load-bearing for API tokens.</li>
+</ul>
+
+<h2>12. Summary</h2>
+
+<div class="verdict">
+The sharing design and the API-access design are the same design. By generalizing
+<code>block_shares</code> to multi-root + scope-kind, and treating API tokens as
+<code>share_links</code> bound to per-token service users, we get:
+<ul class="tight">
+  <li><strong>One RLS predicate</strong> for humans-in-workspace, humans-via-subtree-share,
+    agents-via-workspace-token, and agents-via-subtree-token.</li>
+  <li><strong>One token-storage table</strong> with the same isolation invariants.</li>
+  <li><strong>One exchange RPC family</strong> &mdash; <code>redeem_share_link</code> for humans,
+    <code>api_token_exchange</code> for agents &mdash; sharing the same validation logic.</li>
+  <li><strong>One sync stream</strong> serving every human share recipient regardless of scope.</li>
+  <li><strong>Multi-root shares for free</strong> via the junction table; ergonomically valuable on the
+    human side too.</li>
+</ul>
+The cost on top of the existing sharing doc is small: one column (<code>scope</code>), one
+constraint, one junction table, one new edge function, one new UI surface. The big-ticket items
+(<code>effective_share_ids</code> materialization, the recompute, RLS, token isolation, presentation
+clipping) carry over unchanged.
+</div>
+
+</body>
+</html>

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -364,6 +364,16 @@ would add ambiguity (which mode are they in?) for no real win. Enforce:
   add constraint workspace_scope_is_api_only
   check (scope = 'subtree' or purpose = 'api');</code></pre>
 
+<strong>Where this is enforced, in decreasing order of authority:</strong>
+<ol class="tight">
+  <li><strong>Database <code>check</code> constraint</strong> above &mdash; the canonical boundary.
+    Holds regardless of which code path tries to violate it. Any drift in higher layers fails loudly
+    at <code>INSERT</code>.</li>
+  <li><strong><code>create_api_token</code> / future <code>create_block_share</code> RPCs</strong>
+    pre-validate scope + purpose and return a clean error message before the constraint fires.</li>
+  <li><strong>Settings UI</strong> filters the scope picker to "subtree only" for human shares so the
+    invalid combination isn't offered.</li>
+</ol>
 Drop the constraint if a real human use case for workspace-wide guest access appears. RLS already
 supports it.
 </div>
@@ -869,9 +879,15 @@ service_role inside the function and never on the client is the security boundar
   <li>Bumps <code>last_used_at</code> / <code>last_used_ip</code>.</li>
   <li>Mints a Supabase JWT signed with the project secret. Claims:
     <code>sub = service_user_id</code>, <code>role = 'authenticated'</code>,
-    <code>aud = 'authenticated'</code>, TTL 15 minutes.</li>
+    <code>aud = 'authenticated'</code>, TTL set by env (see below).</li>
   <li>Returns the JWT plus a small <code>share</code> stanza so the client knows scope/workspace.</li>
 </ol>
+
+<p><strong>TTL is a deployment-level setting</strong>, read from
+  <code>API_TOKEN_JWT_TTL_SECONDS</code> in the edge function's environment. Default: 900 (15 minutes).
+  Higher-security deployments can lower it (e.g. 60s &mdash; effectively per-request); the cost is one
+  extra exchange round-trip per API call. v1 keeps it global; per-token override is a future
+  addition (column on <code>share_links</code>) if the use case appears.</p>
 
 <h3>8.4 What 3rd parties use the JWT for</h3>
 
@@ -908,10 +924,11 @@ list_my_api_tokens() returns table (... no token, no hash ...);
   -- For settings UI.</code></pre>
 
 <div class="warn">
-<strong>Revocation lag.</strong> Issued JWTs live 15 minutes. Revoking a token does not invalidate an
-already-issued JWT until it expires. Acceptable for v1; if a strict revocation requirement appears,
-shorten the TTL or add a per-request check against <code>share_links.revoked_at</code> in an
-RLS-callable function.
+<strong>Revocation lag.</strong> Issued JWTs live for the configured TTL (default 15 minutes &mdash;
+see &sect;8.3). Revoking a token does not invalidate an already-issued JWT until it expires.
+Acceptable for v1; lower <code>API_TOKEN_JWT_TTL_SECONDS</code> for strict-revocation deployments, or
+add a per-request check against <code>share_links.revoked_at</code> in an RLS-callable function for
+near-zero-lag revocation at the cost of one extra row read per request.
 </div>
 
 <h2>9. UI surface</h2>
@@ -926,6 +943,14 @@ RLS-callable function.
   <li>Per-token: rotate, revoke.</li>
   <li>Subtree picker is the same component that will later back the share dialog &mdash; build it
     once.</li>
+  <li><strong>Expiration reminders.</strong> Rows for tokens within 14 days of expiry show a warning
+    badge in the list and surface an in-app notification on app load. Rows past expiry show a
+    distinct "expired" badge and stop being usable (the exchange function already refuses them; the
+    UI just makes the state visible so a token doesn't silently lock out an integration). Email
+    reminders are a follow-up &mdash; in-app is enough for v1.</li>
+  <li><strong>Last-used telemetry</strong> from <code>share_links.last_used_at</code> /
+    <code>last_used_ip</code> is shown per row, so the user can spot unused tokens to revoke and
+    notice unexpected activity.</li>
 </ul>
 
 <p>Human subtree-sharing UX (share dialog on a block bullet, invite by email, redeemable link URLs,

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -450,12 +450,35 @@ create table public.share_link_secrets (
 );
 create index idx_share_link_secrets_token_hash on public.share_link_secrets(token_hash);</code></pre>
 
-<h3>4.5 PowerSync publication</h3>
+<h3>4.5 Coverage junction (for sync rules)</h3>
+
+<p>PowerSync stream JOINs only accept simple equality predicates &mdash; <code>ON a.col = b.col</code>.
+  Neither <code>OR</code> nor <code>x = ANY(array)</code> are allowed in a stream JOIN. To express
+  "this block is covered by one of my subtree shares" we maintain a flat <code>(block_id, share_id)</code>
+  junction alongside <code>effective_share_ids</code>:</p>
+
+<pre><code>create table public.block_share_coverage (
+  block_id      text not null references public.blocks(id)       on delete cascade,
+  share_id      text not null references public.block_shares(id) on delete cascade,
+  workspace_id  text not null,
+  primary key (block_id, share_id)
+);
+create index idx_block_share_coverage_share on public.block_share_coverage(share_id);
+-- block_id is the leading PK column so per-block lookups are also cheap.</code></pre>
+
+<p>The recompute function (&sect;6.1) maintains this table as a side-effect: whenever a block's
+  <code>effective_share_ids</code> changes, the corresponding rows in
+  <code>block_share_coverage</code> are inserted/deleted in the same transaction. The array stays
+  canonical for RLS (which supports <code>ANY(array)</code> just fine); the junction is the
+  flattened view PowerSync needs.</p>
+
+<h3>4.6 PowerSync publication</h3>
 
 <pre><code>alter publication powersync add table
   public.block_shares,
   public.block_share_roots,
   public.block_share_members,
+  public.block_share_coverage,
   public.share_links;</code></pre>
 
 <p><code>share_link_secrets</code> is intentionally NOT published. Tokens never appear in any sync
@@ -609,7 +632,11 @@ already indexed.
 
 <p>One function, one recursive CTE. Walks descendants from a root, unioning each block's existing
   <code>effective_share_ids</code> contribution from the parent with any new share ids anchored at
-  the block itself. The result is an O(subtree-size) <code>UPDATE</code> on <code>public.blocks</code>.</p>
+  the block itself. The result is an O(subtree-size) <code>UPDATE</code> on <code>public.blocks</code>.
+  In the same transaction it also keeps <code>block_share_coverage</code> (&sect;4.5) in sync &mdash;
+  delete rows whose <code>share_id</code> is no longer in the array, insert rows for share ids that
+  are now present. The advisory lock at the top of the function serializes both writes against
+  concurrent recomputes on the same root.</p>
 
 <pre><code>create or replace function public.recompute_share_ids_subtree(p_root_block_id text)
 returns void
@@ -714,20 +741,33 @@ property test from &sect;11 to catch divergence.
   <a href="../powersync/sync-config.yaml">powersync/sync-config.yaml</a> via
   <a href="../scripts/gen-sync-config.ts">scripts/gen-sync-config.ts</a>:</p>
 
+<p>One stream with <strong>two query entries</strong> &mdash; one for each scope kind. Each uses only
+  equality predicates and <code>IN parameter_cte</code> filters, which PowerSync supports natively:</p>
+
 <pre><code>shared_blocks:
   auto_subscribe: true
   with:
-    user_share_grants: |
-      SELECT
-        block_share_members.share_id,
-        block_shares.workspace_id,
-        block_shares.scope
+    # Workspaces I have a workspace-scope share on (typically empty for humans;
+    # populated for API token service users with workspace scope).
+    workspace_share_workspace_ids: |
+      SELECT block_shares.workspace_id
       FROM public.block_share_members
       JOIN public.block_shares
         ON block_shares.id = block_share_members.share_id
+       AND block_shares.scope = 'workspace'
+       AND block_shares.revoked_at IS NULL
+      WHERE block_share_members.user_id = auth.user_id()
+    # Subtree-scope share ids I'm a member of.
+    subtree_share_ids: |
+      SELECT block_share_members.share_id
+      FROM public.block_share_members
+      JOIN public.block_shares
+        ON block_shares.id = block_share_members.share_id
+       AND block_shares.scope = 'subtree'
        AND block_shares.revoked_at IS NULL
       WHERE block_share_members.user_id = auth.user_id()
   queries:
+    # 1. Workspace-scope shares -> every block in the workspace.
     - |
       SELECT blocks.id, blocks.workspace_id, blocks.parent_id,
              blocks.order_key, blocks.content,
@@ -736,17 +776,28 @@ property test from &sect;11 to catch divergence.
              blocks.created_by, blocks.updated_by,
              blocks.deleted, blocks.effective_share_ids
       FROM public.blocks
-      JOIN user_share_grants g
-        ON (g.scope = 'workspace' AND g.workspace_id = blocks.workspace_id)
-        OR (g.scope = 'subtree'   AND g.share_id   = ANY(blocks.effective_share_ids))</code></pre>
+      WHERE blocks.workspace_id IN workspace_share_workspace_ids
+    # 2. Subtree-scope shares -> blocks the share covers, via the junction.
+    #    Equality JOIN on block_id; share_id filtered through the parameter CTE.
+    - |
+      SELECT blocks.id, blocks.workspace_id, blocks.parent_id,
+             blocks.order_key, blocks.content,
+             blocks.properties_json, blocks.references_json,
+             blocks.created_at, blocks.updated_at,
+             blocks.created_by, blocks.updated_by,
+             blocks.deleted, blocks.effective_share_ids
+      FROM public.blocks
+      JOIN public.block_share_coverage c ON c.block_id = blocks.id
+      WHERE c.share_id IN subtree_share_ids</code></pre>
 
 <p>And add <code>effective_share_ids</code> to the existing <code>workspace_data</code> stream's
   blocks SELECT, so members see it for share-badge UI.</p>
 
-<div class="warn">
-Verify <code>ANY(array)</code> support in PowerSync stream queries before merging. If unsupported,
-fall back to a junction table <code>block_share_coverage(block_id, share_id)</code> maintained by
-the same triggers; only the storage shape changes, all RLS / RPC logic carries over unchanged.
+<div class="note">
+The two query entries fan into the same client-side <code>blocks</code> table; PowerSync deduplicates
+on primary key, so a row covered by both a workspace share and a subtree share isn't synced twice.
+RLS continues to use <code>= ANY(blocks.effective_share_ids)</code> directly (RLS predicates accept
+that operator); only stream JOINs need the flattened junction.
 </div>
 
 <h2>8. API tokens</h2>
@@ -845,54 +896,86 @@ the same triggers; only the storage shape changes, all RLS / RPC logic carries o
 
 <h3>8.2 Creation</h3>
 
-<p>One server-side RPC, called from the in-app settings UI:</p>
+<p>Creation runs entirely inside one edge function,
+  <code>supabase/functions/create-api-token</code>. The edge function holds
+  <code>service_role</code> (needed for creating service users), generates the token plaintext (so
+  it never enters Postgres), and then calls a database RPC with only the token <em>hash</em>. The
+  plaintext lives in a single response back to the caller and is never persisted anywhere.</p>
 
-<pre><code>create_api_token(
-  p_scope         text,           -- 'workspace' | 'subtree'
-  p_workspace_id  text,           -- required
-  p_roots         text[],         -- required for subtree; empty for workspace
-  p_role          text,           -- 'viewer' | 'editor'
-  p_name          text,           -- human label
-  p_expires_at    bigint          -- ms epoch, null = never
+<h4>Edge-function contract (called by the in-app client)</h4>
+
+<pre><code>POST /functions/v1/create-api-token
+Authorization: Bearer &lt;caller's Supabase JWT&gt;
+{
+  "scope":        "workspace" | "subtree",
+  "workspace_id": "&lt;ws&gt;",
+  "roots":        ["&lt;block&gt;", ...],     // required for subtree; empty for workspace
+  "role":         "viewer" | "editor",
+  "name":         "Claude on laptop",
+  "expires_at":   1730000000000          // ms epoch; null = never
+}
+
+200 OK
+{
+  "share":       { ... block_shares row ... },
+  "link":        { ... share_links row (no token, no hash) ... },
+  "token_plain": "km_live_..."           // shown exactly once; never persisted
+}</code></pre>
+
+<h4>Database RPC contract (called from inside the edge function only)</h4>
+
+<pre><code>_create_api_token_records(
+  p_caller_user_id   text,    -- issuing user, already verified by the edge function
+  p_scope            text,
+  p_workspace_id     text,
+  p_roots            text[],
+  p_role             text,
+  p_name             text,
+  p_expires_at       bigint,
+  p_service_user_id  text,    -- service user already created by the edge function
+  p_token_hash       bytea    -- sha256(plaintext); plaintext is NEVER passed in
 ) returns table (
-  share        public.block_shares,
-  link         public.share_links,
-  token_plain  text                -- shown exactly once
+  share  public.block_shares,
+  link   public.share_links   -- metadata only; no token columns
 )
 language plpgsql security definer set search_path = public</code></pre>
 
-<p>Inside the RPC:</p>
+<p>Edge-function flow:</p>
 
 <ol class="tight">
-  <li>Verify caller is a workspace writer for <code>p_workspace_id</code>.</li>
-  <li>For subtree scope, verify caller can write each root block.</li>
-  <li>Insert <code>block_shares</code> + <code>block_share_roots</code> rows. Recompute trigger
-    stamps <code>effective_share_ids</code> for subtree case.</li>
-  <li><strong>Service user creation</strong> is the one step that needs
-    <code>service_role</code>: call out to
-    <code>POST /auth/v1/admin/users</code> via a Supabase Edge Function wrapping this RPC, or
-    register an extension. The service user gets an opaque generated email
+  <li>Verify the caller's Supabase JWT and pull out their <code>user_id</code>.</li>
+  <li>Verify the caller is a workspace writer for <code>workspace_id</code> (and, for subtree scope,
+    that they can write each requested root block).</li>
+  <li>Create the service user via <code>POST /auth/v1/admin/users</code>. Opaque generated email
     (<code>svc-&lt;random&gt;@knowledge-medium.local</code>) and a random unrecoverable password.</li>
-  <li>Insert <code>block_share_members(share_id, user_id = service_user_id, role, source='api_token')</code>.</li>
-  <li>Generate the token <strong>in the edge function</strong> (not in SQL &mdash; Postgres'
-    <code>encode()</code> only supports <code>'base64' | 'hex' | 'escape'</code>, not
-    <code>'base64url'</code>, and keeping plaintext out of the database avoids it appearing in
-    <code>pg_stat_statements</code> or replication logs):
+  <li>Generate the token in the edge function. Plaintext stays in this function's memory only:
 <pre><code>const plaintext = 'km_live_' + crypto.randomBytes(32).toString('base64url')
 const hash      = crypto.createHash('sha256').update(plaintext).digest()</code></pre>
   </li>
-  <li>Pass only <code>hash</code> into the SQL RPC; insert <code>share_links</code> +
-    <code>share_link_secrets(token_hash = hash)</code>.</li>
-  <li>Return <code>plaintext</code> from the edge function to the caller, once. Postgres never sees
-    the plaintext.</li>
+  <li>Call <code>_create_api_token_records(..., p_service_user_id, p_token_hash = hash)</code>.
+    Inside that RPC, in one transaction:
+    <ul class="tight">
+      <li>Insert <code>block_shares</code> + <code>block_share_roots</code> rows. Recompute trigger
+        stamps <code>effective_share_ids</code> and <code>block_share_coverage</code> for the
+        subtree case.</li>
+      <li>Insert <code>block_share_members(share_id, user_id = p_service_user_id, role,
+        source='api_token')</code>.</li>
+      <li>Insert <code>share_links</code> + <code>share_link_secrets(token_hash = p_token_hash)</code>.</li>
+      <li>Return <code>(share, link)</code>. The RPC's signature does not contain a plaintext
+        column &mdash; there's no SQL code path that could return one.</li>
+    </ul>
+  </li>
+  <li>Return <code>{ share, link, token_plain: plaintext }</code> from the edge function to the
+    caller, once.</li>
 </ol>
 
 <div class="note">
-<strong>Practical packaging.</strong> Because step 4 needs <code>service_role</code>, the cleanest
-shape is a single Edge Function <code>supabase/functions/create-api-token</code> that the in-app
-client calls. The function authenticates the caller (their Supabase JWT), validates with RLS-style
-SECURITY DEFINER helpers, creates the service user, and then runs the rest of the RPC. Keeping
-service_role inside the function and never on the client is the security boundary.
+<strong>The security boundary.</strong> Plaintext exists only in the edge function's request memory
+and the single HTTP response back to the caller. The SQL RPC contract takes a <code>bytea</code>
+hash and returns no token-shaped column, so plaintext cannot appear in
+<code>pg_stat_statements</code>, replication, or any audit log on the database side. Rotation
+(&sect;8.5) generates a fresh plaintext/hash pair in the edge function the same way and updates
+<code>share_link_secrets.token_hash</code> via a parallel hash-only RPC.
 </div>
 
 <h3>8.3 Exchange (every API call)</h3>

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -697,11 +697,20 @@ end $$;</code></pre>
 
 <table>
 <tr><th>Trigger</th><th>Behavior</th></tr>
+<tr><td><code>blocks BEFORE INSERT</code></td>
+    <td>Set <code>NEW.effective_share_ids := coalesce(parent.effective_share_ids, '{}')</code>.
+      <strong>Must be BEFORE, not AFTER:</strong> RLS <code>WITH CHECK</code> on
+      <code>blocks_write</code> is evaluated against <code>NEW</code> immediately after row-level
+      triggers but before statement-level ones, and an AFTER trigger can't modify the row anyway. A
+      subtree-scoped editor inserting a child block needs the array populated <em>before</em> the
+      policy check so the share-membership branch can match. (Workspace writers pass the policy
+      regardless.)</td></tr>
 <tr><td><code>blocks AFTER INSERT</code></td>
-    <td>Set <code>NEW.effective_share_ids</code> to <code>parent.effective_share_ids</code> (or
-      <code>'{}'</code> if no parent). One-row update, no recursion. Also fire a fix-up for
-      pre-existing children of <code>NEW</code> whose array is empty &mdash; handles PowerSync
-      uploading child rows before their parent.</td></tr>
+    <td>Fix-up: if the inserted row has any pre-existing children whose
+      <code>effective_share_ids</code> is empty, recompute the subtree from <code>NEW.id</code>.
+      Handles the PowerSync replay case where a child arrives before its parent &mdash; the child's
+      BEFORE trigger saw no parent and stamped <code>'{}'</code>; this AFTER trigger backfills once
+      the parent lands.</td></tr>
 <tr><td><code>blocks AFTER UPDATE OF parent_id</code></td>
     <td>Call <code>recompute_share_ids_subtree(NEW.id)</code>. The moved subtree gets reconsidered
       against its new ancestor chain.</td></tr>
@@ -924,7 +933,7 @@ Authorization: Bearer &lt;caller's Supabase JWT&gt;
 
 <h4>Database RPC contract (called from inside the edge function only)</h4>
 
-<pre><code>_create_api_token_records(
+<pre><code>private.create_api_token_records(
   p_caller_user_id   text,    -- issuing user, already verified by the edge function
   p_scope            text,
   p_workspace_id     text,
@@ -938,7 +947,22 @@ Authorization: Bearer &lt;caller's Supabase JWT&gt;
   share  public.block_shares,
   link   public.share_links   -- metadata only; no token columns
 )
-language plpgsql security definer set search_path = public</code></pre>
+language plpgsql security definer set search_path = public, private;
+
+-- Belt-and-braces: even though `private` schema is not exposed via PostgREST by
+-- default, explicitly deny client roles from calling this function.
+revoke execute on function private.create_api_token_records(
+  text, text, text, text[], text, text, bigint, text, bytea
+) from public, anon, authenticated;</code></pre>
+
+<p>The RPC lives in the <code>private</code> schema (alongside <code>private.is_workspace_member</code>,
+  <code>private.is_workspace_writer</code>, and the new <code>private.role_max</code>). Supabase's
+  PostgREST only exposes the <code>public</code> schema, so client roles cannot reach this function
+  via REST at all. The explicit <code>REVOKE</code> is there as a second line of defense: if the
+  schema-exposure setting is ever changed, the function still rejects calls from
+  <code>anon</code> / <code>authenticated</code>. Only the edge function (running with
+  <code>service_role</code>) can invoke it. This is the boundary that prevents a workspace viewer
+  from minting themselves an editor token by calling the RPC directly.</p>
 
 <p>Edge-function flow:</p>
 
@@ -952,7 +976,7 @@ language plpgsql security definer set search_path = public</code></pre>
 <pre><code>const plaintext = 'km_live_' + crypto.randomBytes(32).toString('base64url')
 const hash      = crypto.createHash('sha256').update(plaintext).digest()</code></pre>
   </li>
-  <li>Call <code>_create_api_token_records(..., p_service_user_id, p_token_hash = hash)</code>.
+  <li>Call <code>private.create_api_token_records(..., p_service_user_id, p_token_hash = hash)</code>.
     Inside that RPC, in one transaction:
     <ul class="tight">
       <li>Insert <code>block_shares</code> + <code>block_share_roots</code> rows. Recompute trigger
@@ -1023,15 +1047,21 @@ build it speculatively.
 
 <h3>8.5 Revocation, rotation, list</h3>
 
-<pre><code>revoke_api_token(p_link_id text) returns void;
+<pre><code>-- Public, authenticated-callable.
+public.revoke_api_token(p_link_id text) returns void;
   -- Sets share_links.revoked_at and block_shares.revoked_at.
-  -- Service user is NOT deleted -- preserves audit trail for past writes.
+  -- Authorization: caller must be the link creator OR a workspace writer for the share's
+  -- workspace. Service user is NOT deleted -- preserves audit trail for past writes.
 
-rotate_api_token(p_link_id text) returns text;
-  -- New plaintext token; updates share_link_secrets.token_hash; old token stops working.
+public.list_my_api_tokens() returns table (... no token, no hash ...);
+  -- For settings UI.
 
-list_my_api_tokens() returns table (... no token, no hash ...);
-  -- For settings UI.</code></pre>
+-- Rotation goes through the edge function (same boundary as creation in 8.2):
+-- the edge function generates new plaintext + hash, then calls a private hash-only RPC.
+private.rotate_api_token_hash(p_link_id text, p_new_token_hash bytea) returns void;
+  -- Updates share_link_secrets.token_hash for the link. Authorization is done in the
+  -- edge function (caller must own the link); execute is REVOKEd from anon/authenticated.
+  -- Returns void: plaintext is in the edge function's HTTP response only.</code></pre>
 
 <div class="warn">
 <strong>Revocation lag.</strong> Issued JWTs live for the configured TTL (default 15 minutes &mdash;

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -394,9 +394,28 @@ supports it.
 create index idx_block_share_members_user_id  on public.block_share_members(user_id);
 create index idx_block_share_members_share_id on public.block_share_members(share_id);</code></pre>
 
-<p>Inserts use <code>GREATEST(existing.role, new.role)</code> semantics on the unique constraint &mdash;
-  granting the same share at a lower role does not silently demote. The one place that may lower a
-  role is the explicit <code>update_share_member_role</code> RPC.</p>
+<p>Inserts use <strong>explicit role precedence</strong> on upsert so a re-grant at a lower role
+  cannot silently demote. Roles are stored as <code>text</code>, so the natural lexicographic order
+  is <em>wrong</em> (<code>'editor' &lt; 'viewer'</code>); we encode the precedence directly:</p>
+
+<pre><code>-- One helper, used everywhere a role merge happens (RPCs, redeem, accept).
+create or replace function private.role_max(a text, b text) returns text
+  language sql immutable as $$
+    select case
+      when a = 'editor' or b = 'editor' then 'editor'
+      else 'viewer'
+    end
+  $$;
+
+-- Upsert pattern:
+insert into public.block_share_members (share_id, user_id, role, ...)
+values (...)
+on conflict (share_id, user_id) do update
+  set role = private.role_max(public.block_share_members.role, excluded.role);</code></pre>
+
+<p>The one place that may lower a role is the explicit <code>update_share_member_role</code> RPC,
+  which sets the role unconditionally after authorization checks. If a third role
+  (<code>'admin'</code>, future) is ever added, <code>role_max</code> is the one site to update.</p>
 
 <h3>4.4 Credential surface</h3>
 

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Shares + API tokens — unified access model</title>
+<title>Shares + API tokens — design</title>
 <style>
   body { font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
          max-width: 1040px; margin: 2rem auto; padding: 0 1.25rem; color: #1f2328; }
@@ -20,577 +20,703 @@
   th { background: #f6f8fa; }
   .note { background: #fff8c5; border-left: 4px solid #d4a72c; padding: .6rem .85rem;
           border-radius: 4px; margin: 1rem 0; }
-  .delta { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
-           border-radius: 4px; margin: 1rem 0; }
+  .insight { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
+             border-radius: 4px; margin: 1rem 0; }
   .verdict { background: #dafbe1; border-left: 4px solid #1a7f37; padding: .75rem 1rem;
              border-radius: 4px; margin: 1.5rem 0; }
   .warn { background: #ffebe9; border-left: 4px solid #cf222e; padding: .6rem .85rem;
           border-radius: 4px; margin: 1rem 0; }
   small { color: #57606a; }
-  .kbd { background: #f6f8fa; border: 1px solid #d0d7de; border-bottom-width: 2px;
-         border-radius: 4px; padding: 0 .35em; font-size: 11.5px; }
   ul.tight li, ol.tight li { margin: .2rem 0; }
-  .colcompare { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
-  .colcompare > div { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
-                      padding: .6rem .8rem; }
-  .colcompare h4 { margin-top: 0; }
 </style>
 </head>
 <body>
 
-<h1>Shares + API tokens — unified access model</h1>
-<small>Supersedes the &ldquo;single-root subtree share&rdquo; framing in
-  <a href="./subtree-sharing.md">subtree-sharing.md</a>. Draft, 2026-05-15.</small>
+<h1>Shares + API tokens</h1>
+<small>Design for scoped programmatic access. 2026-05-15. Standalone — supersedes
+  <a href="./subtree-sharing.md">subtree-sharing.md</a> (historical reference only).</small>
 
-<h2>1. Why a new doc</h2>
+<h2>1. What we have today</h2>
 
-<p>The existing <a href="./subtree-sharing.md">subtree-sharing.md</a> nails the hard parts:
-  RLS unification via <code>blocks.effective_share_ids</code>, role monotonicity, token isolation,
-  trigger-maintained access materialization, and a single-mode-per-session bootstrap. We're keeping all
-  of that. What's changed since it was written:</p>
+<p>The current data model
+  (<a href="../supabase/migrations/20260510222352_consolidated_initial.sql">supabase/migrations/20260510222352_consolidated_initial.sql</a>):</p>
+
+<ul class="tight">
+  <li><code>public.blocks</code> with an immutable <code>workspace_id</code> on every row.</li>
+  <li><code>public.workspaces</code> + <code>public.workspace_members</code> (owner / editor / viewer).</li>
+  <li><code>public.workspace_invitations</code> (email-keyed).</li>
+  <li>RLS on <code>blocks</code> keys off membership via <code>private.is_workspace_member</code>
+    (read) and <code>private.is_workspace_writer</code> (write).</li>
+  <li>PowerSync streams scoped to "workspaces the user belongs to"
+    (<a href="../powersync/sync-config.yaml">powersync/sync-config.yaml</a>).</li>
+  <li>Read-only enforcement is a session-level flag on <code>Repo</code>
+    (<a href="../src/data/repo.ts">src/data/repo.ts</a> &mdash; <code>isReadOnly</code> at line 459,
+    <code>setReadOnly</code> at line 1014).</li>
+  <li>Local agent access today: a browser-paired relay,
+    <a href="../README.md">README.md</a> &sect;"Agent Runtime Access". Powerful (full JS eval
+    inside the running app) but requires the browser tab.</li>
+</ul>
+
+<p>What's not there: anything between "workspace member" (sees everything) and "stranger" (sees
+  nothing). No scoped credentials, no programmatic API, no subtree-level access.</p>
+
+<h2>2. What we're adding, and why</h2>
 
 <ol class="tight">
-  <li><strong>API access is now a first-class requirement.</strong> Programmatic agents and third-party
-    integrations need stable scoped access without a browser session. Treating an API token as a kind of
-    share grant collapses two designs into one.</li>
-  <li><strong>A single share should cover multiple subtrees</strong> &mdash; &ldquo;share these three
-    projects with my contractor&rdquo; or &ldquo;the agent gets read access to <em>this</em> page and
-    <em>that</em> page.&rdquo;</li>
-  <li><strong>Workspace-scoped tokens are valuable.</strong> Both for &ldquo;give my agent the whole
-    workspace&rdquo; and as the natural ceiling of the subtree model.</li>
+  <li><strong>API tokens</strong> &mdash; long-lived, revocable credentials for agents and third-party
+    integrations to read/write notes without a browser session. Each token is scoped at creation:
+    either an entire workspace or one-or-more subtrees.</li>
+  <li><strong>Shares as the underlying primitive</strong> &mdash; the same primitive that will later
+    back human "share this page" UX. Building it as the shared substrate now (even if only API uses
+    it in v1) means we don't fork the auth surface later.</li>
 </ol>
 
-<p>This doc is the diff against
-  <a href="./subtree-sharing.md">subtree-sharing.md</a>. Sections that aren't re-litigated here
-  (read-only snapshot RPC, presentation root clipping, advisory locks in the recompute, the
-  &ldquo;workspace member overrides share grant&rdquo; rule, the test plan, the guardrails) remain
-  authoritative in the original doc.</p>
-
-<h2>2. The unifying primitive</h2>
-
-<p>A <em>share</em> is the access primitive. Everything else &mdash; human invites, link URLs, API
-  tokens &mdash; is a way of putting some principal into a share's audience.</p>
-
-<pre><code>Share = {
-  workspace_id,                       // a share always lives inside one workspace
-  scope:    'workspace' | 'subtree',  // entire workspace, or a set of subtree roots
-  roots:    text[]                    // only meaningful for scope='subtree'; one or more block ids
-  role:     'viewer' | 'editor',      // default role for new audience members
-  purpose:  'human' | 'api',          // who this share is for; drives UI/listing only
-}
-
-ShareMember = (share_id, principal_id, role, source)
-  // principal_id is auth.users.id, whether human or API service user
-  // source is one of: 'invite' | 'link' | 'api_token'
-
-ShareLink = a redeemable URL fragment (one-shot per user) for humans
-ApiToken  = a long-lived credential (re-usable, single service principal) for integrations
-</code></pre>
-
-<p>The two are the same shape: an opaque secret stored in a tightest-RLS sidecar table, validated by a
-  SECURITY DEFINER RPC, which then upserts a row into <code>block_share_members</code> for the redeeming
-  principal. The differences are operational: lifecycle (one-shot human redeem vs. long-lived API
-  exchange), audit fields, and UI surface.</p>
-
-<div class="verdict">
-<strong>Mental model:</strong> a workspace member is just a built-in &ldquo;workspace-scope share with
-the user as a member.&rdquo; A subtree share is the same idea narrowed to N roots. An API token is a
-share whose audience is a per-token service user. <em>One RLS predicate handles all four cases.</em>
+<div class="insight">
+<strong>Scale constraint up front.</strong> A real workspace today is ~300k blocks (imported Roam
+graph). The design has to assume large workspaces from day one. That rules out any "walk parents at
+query time" RLS or sync predicate &mdash; access decisions on the read path must be O(1) per block.
 </div>
 
-<h2>3. Schema deltas vs. the existing doc</h2>
+<h2>3. The unifying primitive</h2>
 
-<p>Same migration posture as <a href="./subtree-sharing.md">subtree-sharing.md</a> &sect;1: existing
-  tables (<code>blocks</code>, <code>workspaces</code>, <code>workspace_members</code>,
-  <code>workspace_invitations</code>) are not touched destructively. The delta below changes only the
-  <em>new</em> tables introduced by the share design, plus one additional column on
-  <code>blocks</code>.</p>
+<p>A <em>share</em> is the access primitive. Everything else is a way of putting a principal into a
+  share's audience.</p>
 
-<h3>3.1 <code>block_shares</code> — multi-root + scope kind</h3>
+<pre><code>Share
+  workspace_id    text                          // always lives inside one workspace
+  scope           'workspace' | 'subtree'       // entire workspace, OR one-or-more subtree roots
+  roots           text[]                        // only for scope='subtree'; via junction table
+  default_role    'viewer' | 'editor'
+  purpose         'human' | 'api'               // drives UI/listing, not policy
 
-<table>
-<tr><th>Column</th><th>Original (subtree-sharing.md &sect;4.2)</th><th>New</th></tr>
-<tr><td><code>root_block_id</code></td>
-    <td>scalar <code>text</code>, immutable</td>
-    <td><strong>removed</strong> — moved to <code>block_share_roots</code></td></tr>
-<tr><td><code>scope</code></td>
-    <td>(implicit: always subtree)</td>
-    <td><strong>new:</strong> <code>text not null check (scope in ('workspace','subtree'))</code></td></tr>
-<tr><td><code>purpose</code></td>
-    <td>(not present)</td>
-    <td><strong>new:</strong> <code>text not null default 'human' check (purpose in ('human','api'))</code></td></tr>
-<tr><td><code>workspace_id</code></td>
-    <td>denormalized + stamped at insert, immutable</td>
-    <td>unchanged</td></tr>
-<tr><td><code>default_role</code>, <code>created_by_user_id</code>, <code>create_time</code>, <code>revoked_at</code></td>
-    <td>as before</td>
-    <td>unchanged</td></tr>
-</table>
+Audience member (block_share_members)
+  share_id, user_id (auth.users.id), role, source
+
+Credential surface (share_links + share_link_secrets)
+  link metadata (role, purpose, expiry, etc.)  // synced, no token
+  token         hashed, separate row            // never synced, creator-only SELECT</code></pre>
+
+<p>A human invitation, a redeemable link URL, and an API token are three flavors of the same shape:
+  an opaque secret &rarr; SECURITY DEFINER RPC that validates &rarr; row in
+  <code>block_share_members</code> for the redeeming principal &rarr; RLS does the rest.</p>
+
+<div class="verdict">
+The reason this is worth doing as one design rather than two: one RLS predicate covers workspace
+members, workspace-scope shares, subtree-scope shares, human invites, link redemptions, and API
+tokens. Adding a "future" share type (e.g. by-tag) doesn't disturb anything.
+</div>
+
+<h2>4. Schema</h2>
+
+<p>All additive. Existing tables and migrations are not touched destructively.</p>
+
+<h3>4.1 New column on <code>blocks</code></h3>
+
+<pre><code>alter table public.blocks
+  add column effective_share_ids text[] not null default '{}';
+
+create index idx_blocks_effective_share_ids
+  on public.blocks using gin (effective_share_ids);</code></pre>
+
+<p>For each block: the set of <em>subtree-scope</em> <code>block_shares.id</code>s whose root is the
+  block or an ancestor. Workspace-scope shares are NOT materialized here &mdash; they match by
+  <code>workspace_id</code> directly. Reasoning in &sect;6.</p>
+
+<h3>4.2 Shares + scope</h3>
 
 <pre><code>create table public.block_shares (
   id                   text primary key,
   workspace_id         text not null references public.workspaces(id) on delete cascade,
   scope                text not null check (scope in ('workspace','subtree')),
-  purpose              text not null default 'human' check (purpose in ('human','api')),
+  purpose              text not null default 'api' check (purpose in ('human','api')),
   default_role         text not null check (default_role in ('viewer','editor')),
   created_by_user_id   text not null,
   create_time          bigint not null,
   revoked_at           bigint
-);</code></pre>
+);
+create index idx_block_shares_workspace_id on public.block_shares(workspace_id);
 
-<h3>3.2 <code>block_share_roots</code> — new junction table</h3>
-
-<p>One row per (share, root) pair. Only populated for shares with <code>scope='subtree'</code>; enforced
-  by trigger.</p>
-
-<pre><code>create table public.block_share_roots (
+-- One row per (share, root). Only populated for scope='subtree'; enforced by trigger.
+create table public.block_share_roots (
   share_id       text not null references public.block_shares(id) on delete cascade,
   root_block_id  text not null references public.blocks(id)        on delete cascade,
-  workspace_id   text not null,  -- stamped + checked equal to block_shares.workspace_id and blocks.workspace_id
+  workspace_id   text not null,
   create_time    bigint not null,
   primary key (share_id, root_block_id)
 );
-create index idx_block_share_roots_root_block_id on public.block_share_roots(root_block_id);</code></pre>
+create index idx_block_share_roots_root_block_id on public.block_share_roots(root_block_id);
 
-<div class="delta">
-<strong>Why a junction table instead of <code>text[]</code> on <code>block_shares</code>:</strong>
-roots get added/removed over time, and we want a per-root foreign key with cascade-on-delete so
-deleting a block that's a share root cleanly removes that scope without leaving a dangling id in an
-array. The same reasoning that made <code>workspace_members</code> a table rather than an array on
-<code>workspaces</code> applies here.
-</div>
-
-<h3>3.3 <code>blocks.effective_share_ids</code> — unchanged shape, narrower scope</h3>
-
-<p>The column stays as designed in <a href="./subtree-sharing.md">subtree-sharing.md &sect;4.1</a>,
-  but with one rule change: <strong>it only carries <code>block_shares.id</code>s for shares with
-  <code>scope='subtree'</code>.</strong> Workspace-scope shares are matched by joining
-  <code>workspace_id</code> directly in RLS &mdash; cheaper than re-stamping every block in the
-  workspace whenever a workspace-scope share is created or revoked.</p>
-
-<p>This keeps the recompute function (<a href="./subtree-sharing.md">subtree-sharing.md &sect;5</a>)
-  unchanged: it still walks descendants from one root, unioning <code>block_share_roots</code> matches.
-  When a multi-root share is created, we just call <code>recompute_share_ids_subtree</code> once per
-  root. Adding/removing a root is one recompute on that root.</p>
-
-<h3>3.4 <code>share_links</code> — add <code>purpose</code> and audit fields</h3>
-
-<table>
-<tr><th>Column</th><th>Original</th><th>New</th></tr>
-<tr><td><code>purpose</code></td>
-    <td>n/a</td>
-    <td><strong>new:</strong> <code>text not null default 'human_link' check (purpose in ('human_link','api_token'))</code></td></tr>
-<tr><td><code>name</code></td>
-    <td>n/a</td>
-    <td><strong>new:</strong> <code>text</code> &mdash; human label for API tokens (&ldquo;laptop CLI&rdquo;, &ldquo;Readwise sync&rdquo;)</td></tr>
-<tr><td><code>last_used_at</code></td>
-    <td>n/a</td>
-    <td><strong>new:</strong> <code>bigint</code> &mdash; bumped on every exchange (API tokens) or redeem (human links)</td></tr>
-<tr><td><code>last_used_ip</code></td>
-    <td>n/a</td>
-    <td><strong>new:</strong> <code>text</code> &mdash; best-effort, may be null</td></tr>
-<tr><td><code>service_user_id</code></td>
-    <td>n/a</td>
-    <td><strong>new:</strong> <code>text</code> &mdash; for <code>purpose='api_token'</code>, the dedicated <code>auth.users</code> row that this token authenticates as. Null for human links. One-to-one with the link.</td></tr>
-<tr><td><code>expires_at</code>, <code>max_redemptions</code>, <code>redemption_count</code>, <code>revoked_at</code></td>
-    <td>as before</td>
-    <td>semantics unchanged; for API tokens, <code>redemption_count</code> increments on first exchange only (a single service user redeems once, then re-uses the JWT)</td></tr>
-</table>
-
-<h3>3.5 <code>share_link_secrets</code> — unchanged</h3>
-
-<p>Token storage table from <a href="./subtree-sharing.md">subtree-sharing.md &sect;4.2</a> is reused
-  as-is for both human links and API tokens. Same RLS (creator-only SELECT), same hash-not-plaintext
-  storage, same one-time-reveal-on-creation discipline.</p>
+-- Stamped + checked equal to block_shares.workspace_id and the block's workspace_id at insert.
+-- Prevents cross-workspace mistakes; share_root.workspace_id is immutable.</code></pre>
 
 <div class="note">
-For API tokens, we store the SHA-256 of the token in <code>share_link_secrets.token</code>. Human
-links can do the same (it was an open choice in the original doc); switching both to hashed storage
-makes the table genuinely &ldquo;a secret never escapes Postgres alive&rdquo;.
-</div>
-
-<h2>4. RLS — the unified <code>blocks</code> predicate</h2>
-
-<p>One read policy, one write policy, four cases covered:</p>
-
-<pre><code>create policy blocks_read on public.blocks
-for select using (
-  -- 1. Workspace member (existing behavior)
-  public.is_workspace_member(workspace_id, auth.uid()::text)
-
-  -- 2. Workspace-scope share recipient or API-token principal
-  or exists (
-    select 1
-    from public.block_share_members sm
-    join public.block_shares s on s.id = sm.share_id
-    where sm.user_id = auth.uid()::text
-      and s.revoked_at is null
-      and s.scope = 'workspace'
-      and s.workspace_id = blocks.workspace_id
-  )
-
-  -- 3. Subtree-scope share recipient or API-token principal
-  or exists (
-    select 1
-    from public.block_share_members sm
-    join public.block_shares s on s.id = sm.share_id
-    where sm.user_id = auth.uid()::text
-      and s.revoked_at is null
-      and s.scope = 'subtree'
-      and s.id = any (blocks.effective_share_ids)
-  )
-);</code></pre>
-
-<p>The <code>blocks_write</code> policy mirrors this with <code>sm.role = 'editor'</code> in both share
-  branches and a matching <code>with check</code>. (Same shape as
-  <a href="./subtree-sharing.md">subtree-sharing.md &sect;6.1</a>.)</p>
-
-<div class="delta">
-<strong>Notice what this buys us.</strong> An API token is just an <code>auth.uid()</code> with a
-<code>block_share_members</code> row. <em>The RLS predicate doesn't know it's an API call.</em> No
-&ldquo;is this a token request?&rdquo; branch in policy, no service-role bypass anywhere in the data
-path. PostgREST + Supabase auth handle it natively.
-</div>
-
-<h2>5. Recompute — what changes</h2>
-
-<p><a href="./subtree-sharing.md">subtree-sharing.md &sect;5.1</a>'s <code>recompute_share_ids_subtree(p_root_block_id)</code>
-  needs one small tweak: it currently joins <code>block_shares</code> on
-  <code>root_block_id = child.id</code>. With the junction table, that becomes:</p>
-
-<pre><code>-- inside the recursive CTE, replacing the existing join:
-coalesce((
-  select array_agg(s.id)
-  from public.block_share_roots r
-  join public.block_shares     s on s.id = r.share_id
-  where r.root_block_id = child.id
-    and s.scope = 'subtree'
-    and s.revoked_at is null
-), '{}'::text[])</code></pre>
-
-<p>Triggers calling the recompute (<a href="./subtree-sharing.md">subtree-sharing.md &sect;5.2</a>)
-  fan out one additional case:</p>
-
-<table>
-<tr><th>Trigger</th><th>Argument(s)</th></tr>
-<tr><td><code>blocks AFTER INSERT</code></td><td>parent's <code>effective_share_ids</code> (unchanged)</td></tr>
-<tr><td><code>blocks AFTER UPDATE OF parent_id</code></td><td><code>recompute(NEW.id)</code> (unchanged)</td></tr>
-<tr><td><code>block_share_roots AFTER INSERT or DELETE</code></td><td><code>recompute(NEW.root_block_id)</code> (or <code>OLD</code>)</td></tr>
-<tr><td><code>block_shares AFTER UPDATE OF revoked_at</code></td><td>for <code>scope='subtree'</code>: <code>recompute</code> on each root. For <code>scope='workspace'</code>: no recompute needed.</td></tr>
-</table>
-
-<p>Workspace-scope share creation/revocation does <em>not</em> trigger a recompute. It's RLS-only;
-  membership is checked against <code>blocks.workspace_id</code> directly.</p>
-
-<h2>6. PowerSync sync streams</h2>
-
-<p>Two changes to <a href="./subtree-sharing.md">subtree-sharing.md &sect;7</a>:</p>
-
-<h3>6.1 <code>shared_blocks</code> stream — multi-root, scope-aware</h3>
-
-<p>The original stream joins blocks via <code>block_share_members</code> &harr;
-  <code>effective_share_ids</code>. With workspace-scope shares, we union two predicates:</p>
-
-<pre><code>shared_blocks:
-  auto_subscribe: true
-  query: |
-    SELECT blocks.*
-    FROM public.blocks
-    JOIN public.block_share_members sm ON sm.user_id = auth.user_id()
-    JOIN public.block_shares          s ON s.id = sm.share_id AND s.revoked_at IS NULL
-    WHERE (
-      (s.scope = 'workspace' AND s.workspace_id = blocks.workspace_id)
-      OR (s.scope = 'subtree' AND s.id = ANY(blocks.effective_share_ids))
-    )</code></pre>
-
-<p>For API tokens this stream isn't reached because API consumers don't run PowerSync &mdash; they hit
-  PostgREST or a snapshot RPC. The stream exists for <em>human</em> share recipients. A workspace-scope
-  human share recipient (rare in v1 &mdash; see &sect;6.2) gets the entire workspace via this stream
-  without us having to put them in <code>workspace_members</code>.</p>
-
-<h3>6.2 V1 simplification: workspace-scope shares are API-only</h3>
-
-<div class="delta">
-For v1, <strong>only <code>purpose='api'</code> shares may have <code>scope='workspace'</code>.</strong>
-Human shares stay subtree-only. Rationale: the human flow for &ldquo;share my whole workspace with
-you&rdquo; is already covered by <code>invite_member_by_email</code> + workspace_members. Adding a
-parallel path for humans creates a fork in the share-mode bootstrap (which root do we land on?
-breadcrumbs to where?) for no real benefit.
-</div>
-
-<p>Enforced by check constraint:</p>
+<strong>v1 constraint: human shares are subtree-only.</strong> The natural way to give a human access
+to an entire workspace is already <code>workspace_members</code>; a parallel "workspace share" path
+would add ambiguity (which mode are they in?) for no real win. Enforce:
 
 <pre><code>alter table public.block_shares
   add constraint workspace_scope_is_api_only
   check (scope = 'subtree' or purpose = 'api');</code></pre>
 
-<p>If a real use case for &ldquo;guest with the whole workspace, not yet a member&rdquo; appears, drop
-  the constraint and finish the human bootstrap path. The RLS predicate already supports it.</p>
+Drop the constraint if a real human use case for workspace-wide guest access appears. RLS already
+supports it.
+</div>
 
-<h2>7. API token lifecycle</h2>
+<h3>4.3 Audience</h3>
 
-<h3>7.1 Creation (UI flow, in-app)</h3>
+<pre><code>create table public.block_share_members (
+  id                   text primary key,
+  share_id             text not null references public.block_shares(id) on delete cascade,
+  user_id              text not null,
+  role                 text not null check (role in ('viewer','editor')),
+  source               text not null check (source in ('invite','link','api_token')),
+  source_link_id       text,
+  granted_by_user_id   text,
+  create_time          bigint not null,
+  unique (share_id, user_id)
+);
+create index idx_block_share_members_user_id  on public.block_share_members(user_id);
+create index idx_block_share_members_share_id on public.block_share_members(share_id);</code></pre>
+
+<p>Inserts use <code>GREATEST(existing.role, new.role)</code> semantics on the unique constraint &mdash;
+  granting the same share at a lower role does not silently demote. The one place that may lower a
+  role is the explicit <code>update_share_member_role</code> RPC.</p>
+
+<h3>4.4 Credential surface</h3>
+
+<pre><code>-- Metadata. Sees the light of day; tokens are stored in share_link_secrets.
+create table public.share_links (
+  id                  text primary key,
+  share_id            text not null references public.block_shares(id) on delete cascade,
+  role                text not null check (role in ('viewer','editor')),
+  purpose             text not null default 'api_token'
+                        check (purpose in ('human_link','api_token')),
+  name                text,                       -- "Claude on laptop", "Readwise sync", etc.
+  service_user_id     text,                       -- for purpose='api_token'; null for human links
+  created_by_user_id  text not null,
+  create_time         bigint not null,
+  expires_at          bigint,
+  max_redemptions     integer,
+  redemption_count    integer not null default 0,
+  last_used_at        bigint,
+  last_used_ip        text,
+  revoked_at          bigint
+);
+create index idx_share_links_share_id        on public.share_links(share_id);
+create index idx_share_links_service_user_id on public.share_links(service_user_id);
+
+-- Token storage isolated from share_links so RLS on share_links can stay relaxed
+-- (workspace writers can list their own links' metadata) without leaking tokens.
+-- Stored hashed: token plaintext leaves Postgres exactly once, at creation.
+create table public.share_link_secrets (
+  link_id             text primary key references public.share_links(id) on delete cascade,
+  token_hash          bytea not null unique,       -- sha256(plaintext_token)
+  created_by_user_id  text not null
+);
+create index idx_share_link_secrets_token_hash on public.share_link_secrets(token_hash);</code></pre>
+
+<h3>4.5 PowerSync publication</h3>
+
+<pre><code>alter publication powersync add table
+  public.block_shares,
+  public.block_share_roots,
+  public.block_share_members,
+  public.share_links;</code></pre>
+
+<p><code>share_link_secrets</code> is intentionally NOT published. Tokens never appear in any sync
+  stream.</p>
+
+<h2>5. RLS — one read, one write</h2>
+
+<p>The single block-read policy covers all four cases (workspace member, workspace-scope share
+  recipient, subtree-scope share recipient, API service principal). Existing helpers
+  <code>private.is_workspace_member</code> / <code>private.is_workspace_writer</code> stay as-is.</p>
+
+<pre><code>drop policy if exists blocks_read  on public.blocks;
+drop policy if exists blocks_write on public.blocks;
+
+create policy blocks_read on public.blocks
+for select using (
+  -- 1. Workspace member (existing path)
+  private.is_workspace_member(workspace_id, (auth.uid())::text)
+
+  -- 2. Workspace-scope share / API token
+  or exists (
+    select 1
+    from public.block_share_members sm
+    join public.block_shares s on s.id = sm.share_id
+    where sm.user_id = (auth.uid())::text
+      and s.revoked_at is null
+      and s.scope = 'workspace'
+      and s.workspace_id = blocks.workspace_id
+  )
+
+  -- 3. Subtree-scope share / API token, via materialized array
+  or exists (
+    select 1
+    from public.block_share_members sm
+    join public.block_shares s on s.id = sm.share_id
+    where sm.user_id = (auth.uid())::text
+      and s.revoked_at is null
+      and s.scope = 'subtree'
+      and s.id = any (blocks.effective_share_ids)
+  )
+);
+
+create policy blocks_write on public.blocks
+for all
+  using       (/* same shape; sm.role = 'editor' in both share branches; is_workspace_writer for #1 */)
+  with check  (/* same as using */);</code></pre>
+
+<p>RLS on the new tables themselves:</p>
+
+<ul class="tight">
+  <li><code>block_shares</code>, <code>share_links</code>: readable by creator and workspace writers
+    (so the in-app UI can list). All mutations via security-definer RPCs.</li>
+  <li><code>block_share_members</code>: readable by the member themselves, the share creator, and
+    workspace writers (not plain members &mdash; workspace viewers should not enumerate API tokens).</li>
+  <li><code>block_share_roots</code>: readable by anyone who can read the parent share row.</li>
+  <li><code>share_link_secrets</code>: readable only by the link creator. The exchange RPC reads via
+    <code>security definer</code>.</li>
+</ul>
+
+<h2>6. Materialization — <code>effective_share_ids</code></h2>
+
+<div class="insight">
+<strong>Why this exists.</strong> With 300k blocks per workspace, RLS cannot afford to walk
+<code>parent_id</code> at query time. Sync rules especially are evaluated per row by PowerSync; a
+recursive predicate there is a non-starter. We pre-compute "which subtree-scope shares cover this
+block" and stamp it on the row.
+
+Workspace-scope shares deliberately don't materialize &mdash; they'd require a one-shot 300k-row
+update on every share create/revoke. The RLS branch on <code>workspace_id</code> is O(1) per block,
+already indexed.
+</div>
+
+<h3>6.1 Recompute function</h3>
+
+<pre><code>create or replace function public.recompute_share_ids_subtree(p_root_block_id text)
+returns void
+language plpgsql
+volatile
+as $$
+declare
+  v_lock_key bigint := hashtext('subtree:' || p_root_block_id);
+begin
+  -- Serialize concurrent recomputes touching this root. Released on commit/rollback.
+  perform pg_advisory_xact_lock(v_lock_key);
+
+  with recursive
+    parent_share_ids as (
+      select coalesce(parent.effective_share_ids, '{}'::text[]) as ids
+      from public.blocks self
+      left join public.blocks parent on parent.id = self.parent_id
+      where self.id = p_root_block_id
+    ),
+    walk(block_id, share_ids) as (
+      select
+        p_root_block_id,
+        (select ids from parent_share_ids)
+        || coalesce((
+          select array_agg(s.id)
+          from public.block_share_roots r
+          join public.block_shares     s on s.id = r.share_id
+          where r.root_block_id = p_root_block_id
+            and s.scope = 'subtree'
+            and s.revoked_at is null
+        ), '{}'::text[])
+      union all
+      select
+        child.id,
+        walk.share_ids
+        || coalesce((
+          select array_agg(s.id)
+          from public.block_share_roots r
+          join public.block_shares     s on s.id = r.share_id
+          where r.root_block_id = child.id
+            and s.scope = 'subtree'
+            and s.revoked_at is null
+        ), '{}'::text[])
+      from walk
+      join public.blocks child on child.parent_id = walk.block_id
+    )
+  update public.blocks
+  set effective_share_ids = (
+    select array(select distinct unnest(walk.share_ids) order by 1)
+    from walk
+    where walk.block_id = blocks.id
+  )
+  from walk
+  where blocks.id = walk.block_id;
+end $$;</code></pre>
+
+<h3>6.2 Triggers calling it</h3>
+
+<table>
+<tr><th>Trigger</th><th>Behavior</th></tr>
+<tr><td><code>blocks AFTER INSERT</code></td>
+    <td>Set <code>NEW.effective_share_ids</code> to <code>parent.effective_share_ids</code> (or
+      <code>'{}'</code> if no parent). One-row update, no recursion. Also fire a fix-up for
+      pre-existing children of <code>NEW</code> whose array is empty &mdash; handles PowerSync
+      uploading child rows before their parent.</td></tr>
+<tr><td><code>blocks AFTER UPDATE OF parent_id</code></td>
+    <td>Call <code>recompute_share_ids_subtree(NEW.id)</code>. The moved subtree gets reconsidered
+      against its new ancestor chain.</td></tr>
+<tr><td><code>block_share_roots AFTER INSERT</code></td>
+    <td>Call <code>recompute_share_ids_subtree(NEW.root_block_id)</code>. Stamps the share id onto
+      the root and all descendants.</td></tr>
+<tr><td><code>block_share_roots AFTER DELETE</code></td>
+    <td>Call <code>recompute_share_ids_subtree(OLD.root_block_id)</code>. Same walk; the deleted
+      share no longer appears in the array.</td></tr>
+<tr><td><code>block_shares AFTER UPDATE OF revoked_at</code></td>
+    <td>For <code>scope='subtree'</code>: recompute on each root in <code>block_share_roots</code>.
+      For <code>scope='workspace'</code>: no recompute needed.</td></tr>
+</table>
+
+<h3>6.3 Cost in practice</h3>
+
+<ul class="tight">
+  <li>Subtree share over a 5k-block region: a single <code>UPDATE</code> on ~5k rows. Postgres
+    handles this in low single-digit seconds even on Supabase's smaller tiers.</li>
+  <li>Workspace-scope share: zero block writes (matches via <code>workspace_id</code> at RLS time).</li>
+  <li>Re-parenting a 1k-block subtree: one recompute of 1k rows.</li>
+  <li>Day-to-day block edits inside a non-shared subtree: zero recompute work.</li>
+</ul>
+
+<div class="note">
+<strong>Concurrency, deliberately deferred.</strong> The advisory lock above prevents simultaneous
+recomputes on the same root. It does NOT serialize cross-root interactions (e.g. moving a subtree
+out of share A while simultaneously creating share B at an ancestor). If we hit racy outcomes in
+practice, the fix is either widening the lock key (e.g. lock on workspace_id) or driving recompute
+through a per-workspace job queue. Neither is needed in v1; ship the simple version and add the
+property test from &sect;11 to catch divergence.
+</div>
+
+<h2>7. PowerSync sync rules</h2>
+
+<p>One additional stream covers all share recipients regardless of scope. Add to
+  <a href="../powersync/sync-config.yaml">powersync/sync-config.yaml</a> via
+  <a href="../scripts/gen-sync-config.ts">scripts/gen-sync-config.ts</a>:</p>
+
+<pre><code>shared_blocks:
+  auto_subscribe: true
+  with:
+    user_share_grants: |
+      SELECT
+        block_share_members.share_id,
+        block_shares.workspace_id,
+        block_shares.scope
+      FROM public.block_share_members
+      JOIN public.block_shares
+        ON block_shares.id = block_share_members.share_id
+       AND block_shares.revoked_at IS NULL
+      WHERE block_share_members.user_id = auth.user_id()
+  queries:
+    - |
+      SELECT blocks.id, blocks.workspace_id, blocks.parent_id,
+             blocks.order_key, blocks.content,
+             blocks.properties_json, blocks.references_json,
+             blocks.created_at, blocks.updated_at,
+             blocks.created_by, blocks.updated_by,
+             blocks.deleted, blocks.effective_share_ids
+      FROM public.blocks
+      JOIN user_share_grants g
+        ON (g.scope = 'workspace' AND g.workspace_id = blocks.workspace_id)
+        OR (g.scope = 'subtree'   AND g.share_id   = ANY(blocks.effective_share_ids))</code></pre>
+
+<p>And add <code>effective_share_ids</code> to the existing <code>workspace_data</code> stream's
+  blocks SELECT, so members see it for share-badge UI.</p>
+
+<div class="warn">
+Verify <code>ANY(array)</code> support in PowerSync stream queries before merging. If unsupported,
+fall back to a junction table <code>block_share_coverage(block_id, share_id)</code> maintained by
+the same triggers; only the storage shape changes, all RLS / RPC logic carries over unchanged.
+</div>
+
+<h2>8. API tokens</h2>
+
+<h3>8.1 Why service-users-per-token</h3>
+
+<p>An API token authenticates as a dedicated <code>auth.users</code> row (a "service user") whose only
+  membership grant is the token's share. This makes RLS uniform &mdash; the policy in &sect;5 doesn't
+  need to know anything about tokens. It also gives clean audit: <code>blocks.updated_by</code> is
+  the service user's id, joinable to <code>share_links.service_user_id</code> to identify the
+  responsible token.</p>
+
+<p>Considered: minting a JWT with the issuing user's <code>sub</code> plus a custom
+  <code>api_token_scope</code> claim, and reading the claim inside RLS via
+  <code>current_setting('request.jwt.claims')</code>. This avoids creating perpetual
+  <code>auth.users</code> rows, but every RLS branch grows a claim check, and the audit story is
+  worse (writes attributed to the issuing user with a side-channel for "which token"). The
+  service-user approach is what we ship.</p>
+
+<h3>8.2 Creation</h3>
+
+<p>One server-side RPC, called from the in-app settings UI:</p>
+
+<pre><code>create_api_token(
+  p_scope         text,           -- 'workspace' | 'subtree'
+  p_workspace_id  text,           -- required
+  p_roots         text[],         -- required for subtree; empty for workspace
+  p_role          text,           -- 'viewer' | 'editor'
+  p_name          text,           -- human label
+  p_expires_at    bigint          -- ms epoch, null = never
+) returns table (
+  share        public.block_shares,
+  link         public.share_links,
+  token_plain  text                -- shown exactly once
+)
+language plpgsql security definer set search_path = public</code></pre>
+
+<p>Inside the RPC:</p>
 
 <ol class="tight">
-  <li>User opens <em>Settings &rarr; API tokens</em> in the app, or invokes &ldquo;Create API
-    token&rdquo; from the existing share dialog (when context is a specific block).</li>
-  <li>User chooses:
-    <ul class="tight">
-      <li><strong>Scope</strong>: this block + descendants / these blocks (multi-select) / entire workspace</li>
-      <li><strong>Role</strong>: viewer or editor</li>
-      <li><strong>Name</strong>: e.g. &ldquo;Claude on laptop&rdquo;</li>
-      <li><strong>Expiry</strong>: 30/90/365 days / never</li>
-    </ul>
-  </li>
-  <li>Client calls one RPC: <code>create_api_token(p_scope, p_roots, p_role, p_name, p_expires_at)</code>.
-    Server-side it:
-    <ol class="tight">
-      <li>Creates a <code>block_shares</code> row with <code>purpose='api'</code> and the chosen scope.</li>
-      <li>For subtree scope, inserts <code>block_share_roots</code> rows.</li>
-      <li>Creates a dedicated service user (<code>auth.admin.createUser</code> with a generated email
-        like <code>svc+&lt;random&gt;@knowledge-medium.local</code> and a random password; user is
-        never used for password sign-in &mdash; the token <em>is</em> the credential).</li>
-      <li>Inserts <code>block_share_members(share_id, user_id=service_user_id, role)</code>.</li>
-      <li>Generates the token (<code>encode(gen_random_bytes(32), 'base64url')</code> = 43 chars
-        prefixed with <code>km_</code>).</li>
-      <li>Inserts <code>share_links(purpose='api_token', service_user_id, ...)</code> +
-        <code>share_link_secrets(token=sha256(plaintext))</code>.</li>
-      <li>Returns the share + the plaintext token <strong>once</strong>.</li>
-    </ol>
-  </li>
-  <li>Client surfaces the plaintext token with copy-to-clipboard and a &ldquo;you won't see this
-    again&rdquo; warning, then stores nothing.</li>
+  <li>Verify caller is a workspace writer for <code>p_workspace_id</code>.</li>
+  <li>For subtree scope, verify caller can write each root block.</li>
+  <li>Insert <code>block_shares</code> + <code>block_share_roots</code> rows. Recompute trigger
+    stamps <code>effective_share_ids</code> for subtree case.</li>
+  <li><strong>Service user creation</strong> is the one step that needs
+    <code>service_role</code>: call out to
+    <code>POST /auth/v1/admin/users</code> via a Supabase Edge Function wrapping this RPC, or
+    register an extension. The service user gets an opaque generated email
+    (<code>svc-&lt;random&gt;@knowledge-medium.local</code>) and a random unrecoverable password.</li>
+  <li>Insert <code>block_share_members(share_id, user_id = service_user_id, role, source='api_token')</code>.</li>
+  <li>Generate token: <code>'km_live_' || encode(gen_random_bytes(32), 'base64url')</code>.</li>
+  <li>Insert <code>share_links</code> + <code>share_link_secrets(token_hash = sha256(token))</code>.</li>
+  <li>Return <code>token_plain</code> to the caller, once.</li>
 </ol>
 
 <div class="note">
-The service user creation step is the only piece that needs a Supabase Edge Function or a
-<code>service_role</code>-keyed RPC &mdash; <code>auth.admin.createUser</code> isn't callable from
-client SQL. Everything else stays as regular <code>SECURITY DEFINER</code> RPCs callable by
-authenticated clients.
+<strong>Practical packaging.</strong> Because step 4 needs <code>service_role</code>, the cleanest
+shape is a single Edge Function <code>supabase/functions/create-api-token</code> that the in-app
+client calls. The function authenticates the caller (their Supabase JWT), validates with RLS-style
+SECURITY DEFINER helpers, creates the service user, and then runs the rest of the RPC. Keeping
+service_role inside the function and never on the client is the security boundary.
 </div>
 
-<h3>7.2 Exchange (every API call)</h3>
+<h3>8.3 Exchange (every API call)</h3>
 
-<p>Third-party clients <code>POST</code> to a small edge function
-  <code>/functions/v1/api-token-exchange</code>:</p>
+<p>Third parties hit an edge function <code>supabase/functions/api-token-exchange</code> with the
+  token in <code>Authorization: Bearer</code>. It:</p>
 
-<pre><code>POST /functions/v1/api-token-exchange
-Authorization: Bearer km_&lt;43 chars&gt;
-
-200 OK
-{
-  "access_token": "&lt;short-lived Supabase JWT, sub=service_user_id&gt;",
-  "expires_in": 900,
-  "share": { "id": "...", "scope": "subtree", "workspace_id": "..." }
-}</code></pre>
-
-<p>The edge function:</p>
 <ol class="tight">
-  <li>Hashes the bearer token, looks it up in <code>share_link_secrets</code>.</li>
+  <li>Hashes the bearer, looks up <code>share_link_secrets</code> by hash.</li>
   <li>Validates: link not revoked, not past <code>expires_at</code>, share not revoked.</li>
-  <li>Bumps <code>last_used_at</code>, <code>last_used_ip</code> on <code>share_links</code>.</li>
-  <li>Signs a JWT with the project JWT secret claiming <code>sub = service_user_id</code>,
-    <code>role = 'authenticated'</code>, <code>aud = 'authenticated'</code>, short TTL (15 min).</li>
-  <li>Returns the JWT.</li>
+  <li>Bumps <code>last_used_at</code> / <code>last_used_ip</code>.</li>
+  <li>Mints a Supabase JWT signed with the project secret. Claims:
+    <code>sub = service_user_id</code>, <code>role = 'authenticated'</code>,
+    <code>aud = 'authenticated'</code>, TTL 15 minutes.</li>
+  <li>Returns the JWT plus a small <code>share</code> stanza so the client knows scope/workspace.</li>
 </ol>
 
-<p>The client now uses the JWT against PostgREST exactly like any Supabase client. RLS resolves
-  through the <code>block_share_members</code> row attached to the service user.</p>
+<h3>8.4 What 3rd parties use the JWT for</h3>
 
-<h3>7.3 What 3rd parties get for free</h3>
+<p>Direct PostgREST, talking to the same Supabase URL the app uses. Examples:</p>
 
-<ul class="tight">
-  <li><code>GET /rest/v1/blocks?workspace_id=eq.&lt;id&gt;&amp;deleted=eq.false</code></li>
-  <li><code>GET /rest/v1/blocks?parent_id=eq.&lt;id&gt;&amp;order=order_key.asc</code></li>
-  <li><code>POST /rest/v1/blocks</code> (editor role only; <code>workspace_id</code> trigger enforces
-    immutability, RLS enforces scope match)</li>
-  <li><code>PATCH /rest/v1/blocks?id=eq.&lt;id&gt;</code></li>
-</ul>
+<pre><code>GET  /rest/v1/blocks?workspace_id=eq.&lt;ws&gt;&amp;deleted=eq.false&amp;select=id,content,properties_json
+GET  /rest/v1/blocks?parent_id=eq.&lt;id&gt;&amp;order=order_key.asc
+POST /rest/v1/blocks                              -- editor only
+PATCH /rest/v1/blocks?id=eq.&lt;id&gt;             -- editor only
+POST /rest/v1/rpc/&lt;some_rpc&gt;</code></pre>
 
-<p>For ergonomic agent surfaces (subtree fetch in one round trip, search across
-  <code>properties_json</code>, batch tree creation), a separate <code>/functions/v1/api/&hellip;</code>
-  edge function exposes high-level endpoints over the same JWT. These wrap RPCs and are the layer that
-  shields third parties from schema churn. v1 can ship without this and rely on PostgREST; the
-  high-level surface is a follow-up.</p>
+<p>The same JWT works against any RPC the service user is allowed to call. RLS in &sect;5 enforces
+  scope automatically.</p>
 
-<div class="delta">
-<strong>Read-only fast path.</strong> For tokens with <code>role='viewer'</code> the existing
-<a href="./subtree-sharing.md">subtree-sharing.md &sect;8.4</a> <code>get_shared_subtree(token)</code>
-RPC is already a perfectly good zero-state read endpoint. It validates the token, returns a flat
-snapshot, doesn't need the service user round-trip. <em>This is the v1 &ldquo;public read&rdquo;
-endpoint already designed.</em> Extend it to accept multi-root subtree shares and workspace shares
-(returns paginated blocks for workspace scope).
+<div class="insight">
+<strong>v1 stance: raw PostgREST is the API.</strong> We accept the coupling to column names
+(including the JSON-encoded-string <code>properties_json</code> / <code>references_json</code>
+shape, which is mid-evolution &mdash; see
+<a href="./properties-model-evolution.md">properties-model-evolution.md</a>). If the schema needs to
+break compatibly later, we add a <code>/api/v1/&hellip;</code> Edge Function layer at that point. Don't
+build it speculatively.
 </div>
 
-<h3>7.4 Revocation, rotation, list</h3>
+<h3>8.5 Revocation, rotation, list</h3>
+
+<pre><code>revoke_api_token(p_link_id text) returns void;
+  -- Sets share_links.revoked_at and block_shares.revoked_at.
+  -- Service user is NOT deleted -- preserves audit trail for past writes.
+
+rotate_api_token(p_link_id text) returns text;
+  -- New plaintext token; updates share_link_secrets.token_hash; old token stops working.
+
+list_my_api_tokens() returns table (... no token, no hash ...);
+  -- For settings UI.</code></pre>
+
+<div class="warn">
+<strong>Revocation lag.</strong> Issued JWTs live 15 minutes. Revoking a token does not invalidate an
+already-issued JWT until it expires. Acceptable for v1; if a strict revocation requirement appears,
+shorten the TTL or add a per-request check against <code>share_links.revoked_at</code> in an
+RLS-callable function.
+</div>
+
+<h2>9. UI surface</h2>
+
+<p>One new screen in v1: <strong>Settings &rarr; API tokens</strong>.</p>
 
 <ul class="tight">
-  <li><code>revoke_api_token(p_link_id)</code> &rarr; sets <code>share_links.revoked_at</code> and
-    revokes the share (cascades to membership). Service user kept around for audit (so blocks updated
-    by the token still resolve).</li>
-  <li><code>rotate_api_token(p_link_id)</code> &rarr; generates a new token, updates the secret row,
-    returns the new plaintext once. Old token stops working immediately.</li>
-  <li><code>list_my_api_tokens()</code> &rarr; returns rows with everything <em>except</em> the token.</li>
+  <li>List existing tokens with name, scope summary ("entire workspace W" / "subtree of B + 2 more"),
+    role, last used, expiry.</li>
+  <li>"Create token" dialog: scope picker (workspace toggle, or a block multi-picker), role, name,
+    expiry. Returns the plaintext token in a copy-once panel.</li>
+  <li>Per-token: rotate, revoke.</li>
+  <li>Subtree picker is the same component that will later back the share dialog &mdash; build it
+    once.</li>
 </ul>
 
-<h2>8. Where this lands in the existing codebase</h2>
+<p>Human subtree-sharing UX (share dialog on a block bullet, invite by email, redeemable link URLs,
+  share-mode bootstrap, presentation root clipping) is the follow-up. Schema and RLS already support
+  it; only the client routing, dialog, and snapshot RPC for read-only links remain.</p>
+
+<h2>10. Phased plan</h2>
 
 <table>
-<tr><th>Concern</th><th>Touches</th></tr>
-<tr><td>Schema migration</td>
-    <td>new <code>supabase/migrations/&lt;ts&gt;_shares_and_api_tokens.sql</code>, alongside the original
-      sharing migration. (If the sharing work has not landed yet, fold both into one migration.)</td></tr>
-<tr><td>Sync rules</td>
-    <td><a href="../powersync/sync-config.yaml">powersync/sync-config.yaml</a> &mdash; one new stream
-      <code>shared_blocks</code> (replaces the original doc's version), plus
-      <code>block_shares</code>, <code>block_share_members</code>, <code>block_share_roots</code>,
-      <code>share_links</code>. Regenerate via <code>yarn gen:sync-config</code>.</td></tr>
-<tr><td>Client schema</td>
-    <td><a href="../src/data/blockSchema.ts">src/data/blockSchema.ts</a> adds
-      <code>effective_share_ids</code>; new <code>src/data/shareSchema.ts</code> covers the new tables;
-      <a href="../src/data/repoInstance.ts">src/data/repoInstance.ts</a> registers them.</td></tr>
-<tr><td>Repo guards</td>
-    <td><a href="../src/data/repo.ts">src/data/repo.ts:271</a> &mdash; add immutability guard for
-      <code>effectiveShareIds</code> next to the existing <code>workspace_id</code> one.</td></tr>
-<tr><td>Routing</td>
-    <td><a href="../src/utils/routing.ts">src/utils/routing.ts</a> &mdash; gains the
-      <code>#share/&lt;token&gt;</code> branch from the original doc; no change for API tokens (no
-      hash route).</td></tr>
-<tr><td>Share dialog</td>
-    <td>new <code>src/components/share/ShareDialog.tsx</code> with three tabs:
-      <em>People</em>, <em>Link</em>, <em>API tokens</em>. (Original doc had two tabs; we add the
-      third.) For workspace-scope tokens, surface from <em>Settings &rarr; API tokens</em>.</td></tr>
-<tr><td>Token exchange</td>
-    <td>new <code>supabase/functions/api-token-exchange/index.ts</code> &mdash; the only new edge
-      function for v1.</td></tr>
-<tr><td>Agent runtime bridge</td>
-    <td><a href="../README.md">README.md</a> &sect;&ldquo;Agent Runtime Access&rdquo; today uses a
-      local relay paired with the running browser. With API tokens, an agent that doesn't need a
-      browser can use <code>yarn agent</code> against the remote API instead. Add a
-      <code>yarn agent login-token &lt;km_&hellip;&gt;</code> command + a <code>--remote</code> mode that
-      hits the exchange endpoint and calls PostgREST/RPCs directly. Existing local-bridge path stays
-      intact.</td></tr>
+<tr><th>Phase</th><th>Scope</th><th>Files</th></tr>
+<tr><td>1 &mdash; schema + RLS</td>
+    <td>New migration: <code>effective_share_ids</code> column + index, the five new tables, the
+      <code>workspace_scope_is_api_only</code> constraint, the unified <code>blocks_read</code>
+      / <code>blocks_write</code> policies, RLS on the new tables. Publication additions.</td>
+    <td>new <code>supabase/migrations/&lt;ts&gt;_shares.sql</code></td></tr>
+<tr><td>2 &mdash; recompute + triggers</td>
+    <td><code>recompute_share_ids_subtree</code> + five triggers from &sect;6.2. SQL property test
+      against an inline oracle CTE.</td>
+    <td>same migration; new <code>supabase/tests/share_recompute.sql</code></td></tr>
+<tr><td>3 &mdash; sync rules</td>
+    <td>Add <code>shared_blocks</code> stream; add <code>effective_share_ids</code> to the existing
+      <code>workspace_data</code> stream. Verify <code>ANY(array)</code> support; otherwise switch
+      to junction-table fallback.</td>
+    <td><a href="../powersync/sync-config.yaml">powersync/sync-config.yaml</a>,
+      <a href="../src/data/blockSchema.ts">src/data/blockSchema.ts</a></td></tr>
+<tr><td>4 &mdash; client schema</td>
+    <td>Add <code>effective_share_ids</code> to <code>BLOCK_STORAGE_COLUMNS</code> + parser. New
+      <code>src/data/shareSchema.ts</code> for the share-related raw tables. Register on
+      <code>appSchema.withRawTables</code>. Add immutability guard in <code>Repo.applyBlockChange</code>
+      for <code>effectiveShareIds</code>.</td>
+    <td><a href="../src/data/repo.ts">src/data/repo.ts</a>,
+      <a href="../src/data/blockSchema.ts">src/data/blockSchema.ts</a>, new
+      <code>src/data/shareSchema.ts</code></td></tr>
+<tr><td>5 &mdash; token RPCs + edge functions</td>
+    <td><code>create_api_token</code> (wrapped in
+      <code>supabase/functions/create-api-token</code> for service_role access),
+      <code>api-token-exchange</code> edge function, <code>revoke_api_token</code>,
+      <code>rotate_api_token</code>, <code>list_my_api_tokens</code>.</td>
+    <td>new <code>supabase/functions/*</code>, migration follow-up for the RPCs</td></tr>
+<tr><td>6 &mdash; UI</td>
+    <td>Settings &rarr; API tokens screen. Subtree picker component (reusable).</td>
+    <td><code>src/components/settings/ApiTokensPanel.tsx</code> (new),
+      <code>src/components/share/SubtreePicker.tsx</code> (new)</td></tr>
+<tr><td>7 &mdash; agent CLI ergonomics</td>
+    <td>Extend <code>yarn agent</code> with a <code>--remote</code> mode that takes an API token,
+      runs the exchange, and uses PostgREST directly. Existing local-bridge path unchanged.</td>
+    <td><code>agent-extensions/*</code>, CLI under <code>scripts/agent</code> (or wherever the CLI
+      lives).</td></tr>
+<tr><td><em>Follow-up &mdash; human subtree sharing</em></td>
+    <td>Share dialog (People + Link tabs), <code>create_block_share</code> /
+      <code>invite_share_member_by_email</code> / <code>accept_share_invitation</code> /
+      <code>redeem_share_link</code> / <code>get_shared_subtree</code> RPCs (read-only snapshot path).
+      Share-mode bootstrap (<code>#share/&lt;token&gt;</code> route), presentation root clipping in
+      <code>getRootBlock</code> / breadcrumbs. Pending share invitations alongside workspace ones.</td>
+    <td>new <code>src/components/share/ShareDialog.tsx</code>, edits to
+      <a href="../src/utils/routing.ts">src/utils/routing.ts</a>,
+      <a href="../src/App.tsx">src/App.tsx</a>, traversal helpers.</td></tr>
+<tr><td><em>Follow-up &mdash; MCP server</em></td>
+    <td>Thin separate package exposing <code>/rest/v1/&hellip;</code> as MCP tools (list_workspaces,
+      get_subtree, create_block, search_notes). Reuses an API token. Lives outside this repo.</td>
+    <td>n/a</td></tr>
+<tr><td><em>Follow-up (only if measured) &mdash; ergonomic <code>/api/v1/</code></em></td>
+    <td>Edge function with stable high-level endpoints if/when schema churn (property model
+      migration) forces decoupling from PostgREST column names.</td>
+    <td>new <code>supabase/functions/api/*</code></td></tr>
 </table>
 
-<h2>9. Phased plan (rolled into the original 8 phases)</h2>
+<h2>11. Test plan</h2>
 
-<p>Phases 1&ndash;8 from <a href="./subtree-sharing.md">subtree-sharing.md &sect;10</a> stay, with the
-  deltas below folded in. Phase 9&ndash;10 are new.</p>
-
-<table>
-<tr><th>Phase</th><th>Delta vs. original</th></tr>
-<tr><td>1 (Schema + recompute + RLS)</td>
-    <td>Drop <code>block_shares.root_block_id</code>, add <code>scope</code> + <code>purpose</code>;
-      add <code>block_share_roots</code> table; tweak recompute to join through it; widen the
-      <code>blocks_read/write</code> policies with the workspace-scope branch.</td></tr>
-<tr><td>2 (RPCs)</td>
-    <td><code>create_block_share</code> now accepts <code>p_roots text[]</code> instead of a scalar;
-      <code>add_share_root</code> / <code>remove_share_root</code> are new; rest unchanged.</td></tr>
-<tr><td>3 (PowerSync rules)</td>
-    <td><code>shared_blocks</code> query changes to the union form. <code>block_share_roots</code>
-      added to publication; secrets table still not published.</td></tr>
-<tr><td>4 (Client schema/types)</td>
-    <td><code>BlockShare</code> type loses <code>rootBlockId</code>, gains <code>scope</code> /
-      <code>purpose</code>; new <code>BlockShareRoot</code> type; raw table registered.</td></tr>
-<tr><td>5 (Routing + share-mode bootstrap)</td>
-    <td>Bootstrap into a multi-root subtree share picks the first root for the initial
-      <code>activeBlockId</code> (or honors the optional <code>#share/&lt;token&gt;/&lt;blockId&gt;</code>
-      suffix). Presentation root clipping (&sect;6 of original) accepts <code>clipAt: Set&lt;string&gt;</code>
-      &mdash; the walk stops at any member of the set.</td></tr>
-<tr><td>6 (Presentation clipping)</td>
-    <td>Same as above &mdash; <code>getRootBlock(blockId, clipAt?: Set&lt;string&gt;)</code>.</td></tr>
-<tr><td>7 (Share dialog + indicators)</td>
-    <td>Dialog gains a roots list editor for subtree shares (add/remove roots).
-      <code>ShareBadge</code> renders on any block that's in <code>block_share_roots</code>.</td></tr>
-<tr><td>8 (Reference stubs + cleanup)</td>
-    <td>Unchanged.</td></tr>
-<tr><td><strong>9 (API tokens, new)</strong></td>
-    <td>Service-user creation edge function path; <code>create_api_token</code> / <code>revoke_api_token</code>
-      / <code>rotate_api_token</code> / <code>list_my_api_tokens</code> RPCs;
-      <code>api-token-exchange</code> edge function; Settings &rarr; API tokens UI.</td></tr>
-<tr><td><strong>10 (Agent ergonomics, new, optional)</strong></td>
-    <td><code>yarn agent</code> remote mode; <code>/functions/v1/api/&hellip;</code> high-level endpoints
-      (subtree fetch, property search); an MCP server wrapping the same.</td></tr>
-</table>
-
-<h2>10. Open questions</h2>
+<p>The materialization is the load-bearing piece &mdash; if <code>effective_share_ids</code> is wrong,
+  RLS and sync silently leak or hide blocks. Build the property test first:</p>
 
 <ol class="tight">
-  <li><strong>Service-user audit identity.</strong> Should <code>blocks.created_by</code> /
-    <code>updated_by</code> store the service user's id, or the issuing user's id with a side reference
-    to the token? Storing the service-user id is simpler and means the audit trail naturally reflects
-    &ldquo;this token did this&rdquo; (linkable via <code>share_links.service_user_id</code>). Recommended.</li>
-  <li><strong>Token prefix scheme.</strong> Proposing <code>km_live_</code> for production,
-    <code>km_test_</code> for any future dev/scratch instance. Trivial to extend.</li>
-  <li><strong>Per-token rate limits.</strong> Probably enforce in the exchange edge function (deny if
-    last 100 exchanges were within 60s) rather than at PostgREST. Out of scope for v1 but worth a
-    column on <code>share_links</code> if cheap.</li>
-  <li><strong>Workspace-scope human shares.</strong> Locked off in v1 by the
-    <code>workspace_scope_is_api_only</code> constraint. Re-open if a real use case shows up &mdash;
-    the RLS predicate is already ready.</li>
-  <li><strong>Snapshot RPC for workspace scope.</strong> <code>get_shared_subtree</code> works
-    naturally for subtree shares; the workspace-scope equivalent returns potentially the whole
-    workspace. Add pagination (<code>p_after_id</code>, <code>p_limit</code>) before exposing it.</li>
-  <li><strong>Token revocation lag.</strong> Issued JWTs live 15 min; an attacker with a stolen JWT
-    keeps access for that window even after token revocation. Acceptable for v1; if not, the exchange
-    function can mint shorter JWTs or we can move to a check-on-every-request model with a custom
-    PostgREST GUC. Default: live with 15 min.</li>
+  <li><strong>Recompute property test.</strong> Random sequence of
+    <code>(create_share | revoke_share | add_root | remove_root | move_block | insert_block | delete_block)</code>.
+    After each op, every block's <code>effective_share_ids</code> must equal an oracle computed
+    inline (recursive CTE walking <code>parent_id</code> upward, unioning
+    <code>block_share_roots</code> matches for non-revoked subtree shares). ≥1000 random sequences.</li>
+  <li><strong>RLS matrix.</strong> Two workspace users + two service-user tokens (one workspace,
+    one subtree). Assert SELECT/INSERT/UPDATE/DELETE on <code>blocks</code> match the expected
+    success/fail matrix.</li>
+  <li><strong>Token isolation.</strong> Querying <code>share_link_secrets</code> as a non-creator
+    returns zero rows. No row of <code>share_links</code>, <code>block_shares</code>, or
+    <code>block_share_members</code> ever carries a token in any column or sync stream.</li>
+  <li><strong>Exchange round-trip.</strong> Create a token; exchange; use the JWT against
+    <code>/rest/v1/blocks</code> and confirm scope is enforced; revoke; subsequent exchanges fail;
+    the previously-issued JWT continues working until TTL expiry (documented behavior).</li>
+  <li><strong>Rotation.</strong> Rotate a token; old hash gone; old plaintext rejected; new plaintext
+    succeeds.</li>
+  <li><strong>Cross-row insert order (PowerSync replay).</strong> Insert a child before its parent in
+    a transaction; verify the after-insert trigger fixup catches the child once the parent lands
+    (&sect;6.2 row 1).</li>
+  <li><strong>Concurrent move + share-mutation.</strong> One transaction creates a share at root R;
+    another moves a subtree of R out from under it. Both commit. Final
+    <code>effective_share_ids</code> matches the oracle. (This is the case the advisory lock
+    handles for overlapping subtrees; widen the lock or fix via queue if oracle disagrees.)</li>
 </ol>
 
-<h2>11. What this doc is <em>not</em> changing</h2>
+<h2>12. Tradeoffs we're accepting (and where they lead)</h2>
 
-<p>All of the following from <a href="./subtree-sharing.md">subtree-sharing.md</a> remain authoritative
-  and untouched by this proposal:</p>
+<table>
+<tr><th>Choice</th><th>Cost</th><th>Mitigation / exit</th></tr>
+<tr><td>Raw PostgREST as the v1 API surface</td>
+    <td>Column names (<code>properties_json</code>, <code>references_json</code>) become a
+      quasi-public contract; schema evolution constrained.</td>
+    <td>Add a thin <code>/api/v1/</code> Edge Function layer when forced; PostgREST remains for
+      in-app use. Don't pre-build.</td></tr>
+<tr><td>Materialized <code>effective_share_ids</code></td>
+    <td>Trigger complexity; subtree-share creation cost is O(subtree size); concurrent moves +
+      share-mutations need property test coverage.</td>
+    <td>Property test in CI. Lock-widening or job-queue if races appear.</td></tr>
+<tr><td>Service users per API token</td>
+    <td>Perpetual <code>auth.users</code> rows; service_role required (in an Edge Function) to
+      create them.</td>
+    <td>Acceptable. Audit trail is the win.</td></tr>
+<tr><td>15-minute JWT TTL after exchange</td>
+    <td>Revoking a token doesn't kill in-flight JWTs for up to 15 min.</td>
+    <td>Shorten TTL or add an explicit revoke check in RLS if needed.</td></tr>
+<tr><td>Workspace-scope shares are API-only in v1</td>
+    <td>No "guest with whole-workspace read access" for humans.</td>
+    <td>Drop the check constraint; finish the human bootstrap path. RLS already supports it.</td></tr>
+<tr><td>Single advisory lock per root in recompute</td>
+    <td>Cross-root races (move out of A while creating B at an ancestor) not serialized.</td>
+    <td>Property test will surface; widen lock to workspace_id or use a per-workspace job queue.</td></tr>
+</table>
+
+<h2>13. Explicitly out of scope</h2>
 
 <ul class="tight">
-  <li>&sect;3.5 <strong>Role monotonicity</strong> &mdash; same rule, applied identically to API token
-    grants (you can't lower a service user's role by re-issuing a lower-role token; you have to
-    revoke).</li>
-  <li>&sect;3.7 <strong>Token isolation</strong> &mdash; same <code>share_link_secrets</code> table,
-    same RLS, same hash storage. Tokens never appear in any sync stream.</li>
-  <li>&sect;3.8 <strong>Presentation root clipping</strong> &mdash; generalized to a set instead of a
-    single id, but the principle is unchanged.</li>
-  <li>&sect;3.9 <strong>Single write chokepoint</strong> &mdash; all writes still go through
-    <code>Repo</code> client-side, all server writes still go through SECURITY DEFINER RPCs or
-    RLS-protected PostgREST.</li>
-  <li>&sect;5.2-5.3 <strong>Concurrency + cross-row insert order</strong> &mdash; advisory lock + the
-    &ldquo;parent's insert fixes orphaned children&rdquo; trick are unchanged.</li>
-  <li>&sect;11 <strong>Test plan</strong> &mdash; reused wholesale; add four new tests:
-    <ul class="tight">
-      <li>Multi-root recompute: a share with roots {R1, R2}; descendants under either are reachable;
-        revoking the share clears both subtrees.</li>
-      <li>Workspace-scope share: every block in W is visible to the recipient; blocks in a different
-        workspace are not.</li>
-      <li>API token exchange: token &rarr; JWT &rarr; PostgREST read/write succeeds within scope, fails
-        outside it.</li>
-      <li>Token rotation: old token stops working immediately; new token works.</li>
-    </ul>
-  </li>
-  <li>&sect;13 <strong>Guardrails</strong> &mdash; all 14 still apply; #1 (role monotonicity), #2
-    (token isolation), #7 (<code>effectiveShareIds</code> immutability), and #12 (idempotent redeem)
-    are load-bearing for API tokens.</li>
+  <li>Per-block or per-property granularity (read this block but not this property).</li>
+  <li>Append-only / comments-only roles.</li>
+  <li>Tag-based shares ("everything tagged #public").</li>
+  <li>Mixed-mode permission resolution for users with both workspace membership and overlapping share
+    grants. When human sharing lands, a workspace member who is also a share recipient uses their
+    workspace role.</li>
+  <li>Anonymous-user redemption (for human "open a link without an account" UX). Deferred to the
+    human-sharing follow-up phase.</li>
+  <li>Service-user garbage collection. Revoked tokens leave their service user around for audit.</li>
+  <li>Cross-workspace block moves &mdash; still rejected by the existing immutability rule.</li>
+  <li>Audit log of share grants/revocations beyond the timestamps already on the row.</li>
+  <li>Realtime updates to read-only snapshot consumers; v1 read-only snapshots (if/when added)
+    require re-fetch.</li>
 </ul>
 
-<h2>12. Summary</h2>
+<h2>14. Summary</h2>
 
 <div class="verdict">
-The sharing design and the API-access design are the same design. By generalizing
-<code>block_shares</code> to multi-root + scope-kind, and treating API tokens as
-<code>share_links</code> bound to per-token service users, we get:
-<ul class="tight">
-  <li><strong>One RLS predicate</strong> for humans-in-workspace, humans-via-subtree-share,
-    agents-via-workspace-token, and agents-via-subtree-token.</li>
-  <li><strong>One token-storage table</strong> with the same isolation invariants.</li>
-  <li><strong>One exchange RPC family</strong> &mdash; <code>redeem_share_link</code> for humans,
-    <code>api_token_exchange</code> for agents &mdash; sharing the same validation logic.</li>
-  <li><strong>One sync stream</strong> serving every human share recipient regardless of scope.</li>
-  <li><strong>Multi-root shares for free</strong> via the junction table; ergonomically valuable on the
-    human side too.</li>
-</ul>
-The cost on top of the existing sharing doc is small: one column (<code>scope</code>), one
-constraint, one junction table, one new edge function, one new UI surface. The big-ticket items
-(<code>effective_share_ids</code> materialization, the recompute, RLS, token isolation, presentation
-clipping) carry over unchanged.
+The unification is the design: API tokens are shares whose audience is a per-token service user.
+One RLS predicate, one materialization column, one credential surface. v1 ships only the API-token
+flavor; human subtree sharing drops onto the same schema as a follow-up with no rework.
+<br><br>
+The 300k-block workspace constraint is what forces materialization despite the trigger complexity
+&mdash; recursive RLS isn't viable at that scale. Workspace-scope shares dodge the cost entirely by
+matching on <code>workspace_id</code> directly. PostgREST stays the API surface in v1; we accept the
+column-name coupling and reserve <code>/api/v1/</code> for the day schema churn demands it.
 </div>
 
 </body>

--- a/docs/shares-and-api-tokens.html
+++ b/docs/shares-and-api-tokens.html
@@ -1004,34 +1004,45 @@ grant execute on function private.create_api_token_records(
   <code>service_role</code>) can invoke it. This is the boundary that prevents a workspace viewer
   from minting themselves an editor token by calling the RPC directly.</p>
 
-<p>Edge-function flow:</p>
+<p>Edge-function flow. The order matters &mdash; service user creation comes <strong>after</strong>
+  the SQL transaction so a downstream failure can't orphan an <code>auth.users</code> row:</p>
 
 <ol class="tight">
   <li>Verify the caller's Supabase JWT and pull out their <code>user_id</code>.</li>
   <li>Verify the caller is a workspace writer for <code>workspace_id</code> (and, for subtree scope,
     that they can write each requested root block).</li>
-  <li>Create the service user via <code>POST /auth/v1/admin/users</code>. Opaque generated email
-    (<code>svc-&lt;random&gt;@knowledge-medium.local</code>) and a random unrecoverable password.</li>
   <li>Generate the token in the edge function. Plaintext stays in this function's memory only:
 <pre><code>const plaintext = 'km_live_' + crypto.randomBytes(32).toString('base64url')
 const hash      = crypto.createHash('sha256').update(plaintext).digest()</code></pre>
   </li>
-  <li>Call <code>private.create_api_token_records(..., p_service_user_id, p_token_hash = hash)</code>.
-    Inside that RPC, in one transaction:
-    <ul class="tight">
-      <li>Insert <code>block_shares</code> + <code>block_share_roots</code> rows. Recompute trigger
-        stamps <code>effective_share_ids</code> and <code>block_share_coverage</code> for the
-        subtree case.</li>
-      <li>Insert <code>block_share_members(share_id, user_id = p_service_user_id, role,
-        source='api_token')</code>.</li>
-      <li>Insert <code>share_links</code> + <code>share_link_secrets(token_hash = p_token_hash)</code>.</li>
-      <li>Return <code>(share, link)</code>. The RPC's signature does not contain a plaintext
-        column &mdash; there's no SQL code path that could return one.</li>
-    </ul>
-  </li>
+  <li>Call <code>private.create_api_token_records_phase1(..., p_token_hash = hash)</code>.
+    In one transaction: insert <code>block_shares</code> + <code>block_share_roots</code> rows
+    (recompute trigger stamps <code>effective_share_ids</code> / <code>block_share_coverage</code>),
+    insert <code>share_links</code> + <code>share_link_secrets(token_hash = p_token_hash)</code>.
+    <strong>No <code>block_share_members</code> row yet</strong> &mdash; that needs the service
+    user id. Returns <code>(share_id, link_id)</code>.</li>
+  <li>Create the service user via <code>POST /auth/v1/admin/users</code>. Opaque generated email
+    (<code>svc-&lt;random&gt;@knowledge-medium.local</code>) and a random unrecoverable password.
+    <strong>On failure:</strong> call <code>private.delete_api_token_records(share_id)</code>
+    (cascades to <code>block_share_roots</code>, <code>share_links</code>,
+    <code>share_link_secrets</code>). Return error to caller.</li>
+  <li>Call <code>private.create_api_token_records_phase2(share_id, p_service_user_id)</code>:
+    insert <code>block_share_members(share_id, user_id = p_service_user_id, role,
+    source='api_token')</code>. <strong>On failure:</strong> delete the service user via auth
+    admin AND call <code>private.delete_api_token_records(share_id)</code>. Return error.</li>
   <li>Return <code>{ share, link, token_plain: plaintext }</code> from the edge function to the
     caller, once.</li>
 </ol>
+
+<div class="note">
+<strong>Why two phases rather than one.</strong> The SQL RPC can't create the service user
+(needs service_role at the Supabase auth level, not just Postgres). The service user creation
+can't be inside the SQL transaction. Splitting the SQL work into "phase 1: everything that
+doesn't need the service user" + "phase 2: the membership row" gives a clean compensation point:
+service user creation sits between two SQL transactions, and a failure in either step has a
+defined cleanup. The same <code>delete_api_token_records</code> helper is also what
+<code>revoke_api_token</code> in &sect;8.5 calls when the user explicitly revokes.
+</div>
 
 <div class="note">
 <strong>The security boundary.</strong> Plaintext exists only in the edge function's request memory


### PR DESCRIPTION
## Summary

This PR adds a comprehensive design document for implementing scoped programmatic access to workspaces through API tokens and the underlying shares primitive.

## Changes

- **New design document** (`docs/shares-and-api-tokens.html`): A detailed specification covering:
  - Current data model and access control architecture
  - Unified shares primitive for both API tokens and future human subtree sharing
  - Complete schema design with five new tables: `block_shares`, `block_share_roots`, `block_share_members`, `share_links`, and `share_link_secrets`
  - Materialized `effective_share_ids` column on blocks for O(1) RLS evaluation at scale (300k+ blocks per workspace)
  - Recompute function and trigger logic for maintaining share coverage across block hierarchies
  - PowerSync sync rules for share recipients
  - API token creation, exchange, and revocation flows using per-token service users
  - RLS policies covering workspace members, workspace-scope shares, and subtree-scope shares
  - Phased implementation plan across 7 phases plus follow-up work
  - Comprehensive test plan including property tests for materialization correctness
  - Tradeoffs and explicitly out-of-scope items

## Key Design Decisions

- **Unified primitive**: API tokens and future human shares use the same `block_shares` + `block_share_members` foundation, avoiding schema bifurcation
- **Service users per token**: Each API token authenticates as a dedicated `auth.users` row, enabling clean audit trails and uniform RLS
- **Materialized coverage**: `effective_share_ids` array on blocks enables O(1) RLS checks and sync predicates, necessary for large workspaces
- **Workspace-scope shares are API-only in v1**: Constraint enforced; can be lifted when human sharing UX lands
- **Raw PostgREST as v1 API**: Direct access to `/rest/v1/blocks` and other tables; higher-level `/api/v1/` layer deferred until schema churn requires it

## Implementation Scope

This document is the specification for phases 1–7 (schema through agent CLI ergonomics) and identifies follow-up work (human subtree sharing, MCP server, stable API layer).

https://claude.ai/code/session_01812b9tgB4PbSMpp5Lx8oD4