### PR TITLE
Trim swipe quick-actions for block date edits

### DIFF
--- a/src/plugins/daily-notes/index.ts
+++ b/src/plugins/daily-notes/index.ts
@@ -51,18 +51,9 @@ import { blockContentSurfacePropsFacet } from '@/extensions/blockInteraction.ts'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types.ts'
 import { parseAppHash } from '@/utils/routing.ts'
 import { CalendarDays } from 'lucide-react'
-import {
-  quickActionItemsFacet,
-  type QuickActionItem,
-} from '@/plugins/swipe-quick-actions'
+import { quickActionItemsFacet } from '@/plugins/swipe-quick-actions'
 import { dailyNotesActions, resolveCurrentDailyNoteIso } from './actions.ts'
-import {
-  DATE_SHIFT_BACKWARD_DAY_ACTION_ID,
-  DATE_SHIFT_BACKWARD_WEEK_ACTION_ID,
-  DATE_SHIFT_FORWARD_DAY_ACTION_ID,
-  DATE_SHIFT_FORWARD_WEEK_ACTION_ID,
-  dateReferenceShiftActions,
-} from './dateShift.ts'
+import { dateReferenceShiftActions } from './dateShift.ts'
 import { dailyNotesDataExtension } from './dataExtension.ts'
 import { DailyNotePicker } from './DailyNotePicker.tsx'
 import { DailyNotePickerHeaderItem } from './HeaderItem.tsx'
@@ -136,23 +127,6 @@ export const openDailyNotePickerAction = (
   },
 })
 
-/** Date-shift quick actions on a dedicated row. Order matches a reading
- *  number line: oldest-first → newest-last. Each entry references its
- *  NORMAL_MODE shortcut action (the swipe menu prefers the first match,
- *  and the NORMAL_MODE variants are registered before the EDIT_MODE_CM
- *  ones in `dateReferenceShiftActions`). Visibility is gated by the
- *  action's `canRun` — the base predicate requires content with a single
- *  date reference (unwrapped), and the `srs-rescheduling` decorator
- *  extends it to SRS blocks with a resolvable next-review date
- *  (wrapped). */
-export const dateShiftQuickActions: readonly QuickActionItem[] = [
-  {actionId: DATE_SHIFT_BACKWARD_WEEK_ACTION_ID, label: '-1w', row: 3},
-  {actionId: DATE_SHIFT_BACKWARD_DAY_ACTION_ID, label: '-1d', row: 3},
-  {actionId: DATE_SHIFT_FORWARD_DAY_ACTION_ID, label: '+1d', row: 3},
-  {actionId: DATE_SHIFT_FORWARD_WEEK_ACTION_ID, label: '+1w', row: 3},
-  rescheduleQuickActionItem,
-]
-
 // Factory rather than a const because the action handlers close over
 // `repo` (they call `repo.activeWorkspaceId` and `getOrCreateDailyNote`
 // without going through React context). Same shape as
@@ -179,9 +153,7 @@ export const dailyNotesPlugin = ({repo}: {repo: Repo}): AppExtension => [
     actionsFacet.of(action, {source: 'daily-notes'}),
   ),
   actionsFacet.of(rescheduleBlockDateAction, {source: 'daily-notes'}),
-  dateShiftQuickActions.map(item =>
-    quickActionItemsFacet.of(item, {source: 'daily-notes'}),
-  ),
+  quickActionItemsFacet.of(rescheduleQuickActionItem, {source: 'daily-notes'}),
   blockDateAdapterFacet.of(referenceDateAdapter, {source: 'daily-notes'}),
   blockContentSurfacePropsFacet.of(dateScrubContentSurface, {source: 'daily-notes'}),
   actionsFacet.of(openDailyNotePickerAction({repo}), {source: 'daily-notes'}),

--- a/src/plugins/daily-notes/rescheduleAction.ts
+++ b/src/plugins/daily-notes/rescheduleAction.ts
@@ -38,5 +38,4 @@ export const rescheduleBlockDateAction: ActionConfig<typeof ActionContextTypes.N
 export const rescheduleQuickActionItem: QuickActionItem = {
   actionId: RESCHEDULE_BLOCK_DATE_ACTION_ID,
   label: 'Reschedule',
-  row: 3,
 }

--- a/src/plugins/daily-notes/test/plugin.test.ts
+++ b/src/plugins/daily-notes/test/plugin.test.ts
@@ -5,16 +5,11 @@ import { typesFacet } from '@/data/facets.ts'
 import { quickActionItemsFacet } from '@/plugins/swipe-quick-actions'
 import {
   DAILY_NOTE_TYPE,
-  DATE_SHIFT_BACKWARD_DAY_ACTION_ID,
-  DATE_SHIFT_BACKWARD_WEEK_ACTION_ID,
-  DATE_SHIFT_FORWARD_DAY_ACTION_ID,
-  DATE_SHIFT_FORWARD_WEEK_ACTION_ID,
   OPEN_DAILY_NOTE_PICKER_ACTION_ID,
   RESCHEDULE_BLOCK_DATE_ACTION_ID,
   dailyNotePickerHeaderItem,
   dailyNotePickerMount,
   dailyNotesPlugin,
-  dateShiftQuickActions,
   openDailyNotePickerAction,
 } from '../index.ts'
 
@@ -48,18 +43,13 @@ describe('dailyNotesPlugin', () => {
     expect(openDailyNotePickerAction({repo: fakeRepo}).id).toBe(OPEN_DAILY_NOTE_PICKER_ACTION_ID)
   })
 
-  it('contributes a row-3 quick-action set for the date-shift actions plus reschedule', () => {
+  it('contributes the Reschedule quick action on the primary row', () => {
     const fakeRepo = {} as Parameters<typeof dailyNotesPlugin>[0]['repo']
     const runtime = resolveFacetRuntimeSync(dailyNotesPlugin({repo: fakeRepo}))
     const items = runtime.read(quickActionItemsFacet)
 
-    expect(items).toEqual(dateShiftQuickActions)
     expect(items.map(item => [item.actionId, item.row, item.label])).toEqual([
-      [DATE_SHIFT_BACKWARD_WEEK_ACTION_ID, 3, '-1w'],
-      [DATE_SHIFT_BACKWARD_DAY_ACTION_ID, 3, '-1d'],
-      [DATE_SHIFT_FORWARD_DAY_ACTION_ID, 3, '+1d'],
-      [DATE_SHIFT_FORWARD_WEEK_ACTION_ID, 3, '+1w'],
-      [RESCHEDULE_BLOCK_DATE_ACTION_ID, 3, 'Reschedule'],
+      [RESCHEDULE_BLOCK_DATE_ACTION_ID, undefined, 'Reschedule'],
     ])
   })
 })

--- a/src/plugins/srs-rescheduling/index.ts
+++ b/src/plugins/srs-rescheduling/index.ts
@@ -247,11 +247,15 @@ export const srsReschedulingActions: readonly ActionConfig[] = [
   srsPasteAction,
 ]
 
-const srsQuickActionItems = srsSignals.map(signal => ({
-  actionId: `srs.reschedule.${signalName(signal).toLowerCase()}`,
-  label: signalName(signal),
-  row: 2 as const,
-}))
+// SOONER is intentionally omitted from the swipe strip — the
+// keyboard shortcut and command-palette entry remain for power users.
+const srsQuickActionItems = srsSignals
+  .filter(signal => signal !== SrsSignal.SOONER)
+  .map(signal => ({
+    actionId: `srs.reschedule.${signalName(signal).toLowerCase()}`,
+    label: signalName(signal),
+    row: 2 as const,
+  }))
 
 // Overflow keeps them out of the primary strip — these are rarer than
 // reschedule. Visibility (cut only on SRS blocks; paste only when

--- a/src/plugins/srs-rescheduling/test/plugin.test.ts
+++ b/src/plugins/srs-rescheduling/test/plugin.test.ts
@@ -117,12 +117,11 @@ describe('srsReschedulingPlugin', () => {
       'srs.reschedule.hard',
       'srs.reschedule.good',
       'srs.reschedule.easy',
-      'srs.reschedule.sooner',
       'srs.cut',
       'srs.paste',
     ])
-    expect(items.slice(0, 5).every(item => item.row === 2 && !item.overflow)).toBe(true)
-    expect(items.slice(5).every(item => item.overflow === true)).toBe(true)
+    expect(items.slice(0, 4).every(item => item.row === 2 && !item.overflow)).toBe(true)
+    expect(items.slice(4).every(item => item.overflow === true)).toBe(true)
 
     const actions = runtime.read(actionsFacet)
     const cutAction = actions.find(it => it.id === 'srs.cut')


### PR DESCRIPTION
Now that the Reschedule sheet and date-scrub gesture cover ad-hoc
date moves, the +/-1d, +/-1w, and SRS Sooner buttons on the swipe
strip are redundant. Remove them and promote Reschedule (calendar
icon) to the primary row. The underlying keyboard shortcuts and
command-palette entries stay registered.

https://claude.ai/code/session_01XSfBpRfJgH6KW27Ef6gtbB