### PR TITLE
Fix embed-of-focal-block inheriting top-level affordances

### DIFF
--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -92,6 +92,19 @@ Apply uniformly across every name-keyed facet — the convention should be consi
 
 Fix shape: when `rendererKey` is set but absent from the registry, `console.warn` with the offending id + the available ids, and either (a) render `MissingDataRenderer`-style "renderer not found" placeholder so the lost override is visible, or (b) fall through with the warning. Pick (b) for now — less disruptive — but at least surface it. Independent of any larger renderer-resolution redesign; cheap fix.
 
+## Tighten render-surface model — enum + ideas from `renderer-resolution.md`
+
+The current render-surface model on `BlockContextType` ([src/types.ts:79](src/types.ts:79)) is an open flag bag: `isNestedSurface` (umbrella) + specific descriptors `isEmbedded` / `isBacklink` / `isBreadcrumb`, set by each non-document mount and consulted via `useIsFocalRender(block)` / `isFocalRender(ctx)` ([src/hooks/useIsFocalRender.ts](src/hooks/useIsFocalRender.ts)). This shape was picked as the smaller initial fix for the embed-of-focal-block bug ([docs/render-surface-vs-flags.html](render-surface-vs-flags.html) Option D + C) — it composes in nested cases, doesn't require a closed union, and adding a new surface only means setting the umbrella.
+
+Tighter shape worth considering when a third surface lands or when the open flag bag bites: replace the umbrella+descriptor flags with a single `renderSurface: 'document' | 'embed' | 'backlink' | 'breadcrumb'` enum (Option B in the design doc). Pros: real type-system enforcement on the surface set, mutually-exclusive states modeled as mutually exclusive, surfaces discoverable by reading a union rather than greping setters. Cons: closed set requires amending the union when a new surface lands, and nested cases (a backlink containing an embed) collapse to innermost-wins rather than composing. The composition concern is theoretical today — none of the five focal-affordance sites discriminates outer surface.
+
+[docs/renderer-resolution.md](renderer-resolution.md) is currently *not* on the roadmap, but it has adjacent ideas worth pulling in if/when this gets revisited:
+- The **mount site already knows** insight — `BlockEmbed` deciding "I'm an embed" at the mount site is the same shape as the doc's `frame` prop on `BlockComponent`. If the enum migration happens, passing `renderSurface` (or a frame slot) as an explicit `BlockComponent` prop is more honest than the current context-override sandwich.
+- **Separating dispatch metadata from React component identity** — the static-field `canRender` / `priority` shape on renderer components ([TopLevelRenderer.canRender](src/components/renderer/TopLevelRenderer.tsx), etc.) is the same legibility problem this redesign solves at the context-flag layer. Worth doing together if either gets touched.
+- **Explainability / reason chains** — orthogonal to surfaces but cheap to bolt on once dispatch metadata is structured.
+
+Trigger to revisit: a fourth render surface shows up (preview pane, sidebar peek), OR the flag-bag's open-set ergonomics produces a real bug (someone forgets to set `isNestedSurface` on a new mount).
+
 ## Block facade soft-delete contract drift between `peek` / `data` / `load`
 
 `Block`'s three read surfaces disagree on what a soft-deleted (`deleted: true`) row means:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -373,7 +373,7 @@ const App = () => {
   }, [activeRole, repo])
 
   return (
-    <BlockContextProvider initialValue={{topLevel: true, safeMode}}>
+    <BlockContextProvider initialValue={{layoutBoundary: true, safeMode}}>
       <AppRuntimeProvider safeMode={safeMode}>
         <BlockComponent blockId={layoutSessionBlock.id}/>
       </AppRuntimeProvider>

--- a/src/components/references/BlockEmbed.tsx
+++ b/src/components/references/BlockEmbed.tsx
@@ -1,8 +1,11 @@
 import { BlockComponent } from '@/components/BlockComponent'
+import { NestedBlockContextProvider } from '@/context/block.tsx'
 import { useRepo } from '@/context/repo'
 import { useBlockExists } from '@/hooks/block'
 import { BlockRefAncestorsProvider } from './cycleGuard'
 import { useBlockRefAncestors } from './useBlockRefAncestors'
+
+const EMBED_CONTEXT_OVERRIDES = {isNestedSurface: true, isEmbedded: true}
 
 export function BlockEmbed({blockId}: {blockId: string}) {
   const repo = useRepo()
@@ -31,7 +34,9 @@ export function BlockEmbed({blockId}: {blockId: string}) {
   return (
     <BlockRefAncestorsProvider ancestor={blockId}>
       <div className="blockembed border-l-2 border-muted pl-2 my-1 bg-muted/30 rounded-r">
-        <BlockComponent blockId={blockId}/>
+        <NestedBlockContextProvider overrides={EMBED_CONTEXT_OVERRIDES}>
+          <BlockComponent blockId={blockId}/>
+        </NestedBlockContextProvider>
       </div>
     </BlockRefAncestorsProvider>
   )

--- a/src/components/renderer/DefaultBlockRenderer.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.tsx
@@ -40,6 +40,7 @@ import {
 import { useBlockContext } from '@/context/block.tsx'
 import { isElementProperlyVisible } from '@/utils/dom.ts'
 import { useHasChildren, usePropertyValue } from '@/hooks/block.ts'
+import { useIsFocalRender } from '@/hooks/useIsFocalRender.ts'
 import { useAppRuntime } from '@/extensions/runtimeContext.ts'
 import {
   blockChildrenFooterFacet,
@@ -242,8 +243,7 @@ export const DefaultBlockLayout: BlockLayout = ({
 }) => {
   const inFocus = useInFocus(block.id)
   const isSelected = useIsSelected(block.id)
-  const [topLevelBlockId] = useUIStateProperty(topLevelBlockIdProp)
-  const isTopLevel = topLevelBlockId === block.id
+  const isTopLevel = useIsFocalRender(block)
   const [isCollapsed] = usePropertyValue(block, isCollapsedProp)
 
   return (
@@ -292,7 +292,7 @@ export function DefaultBlockRenderer(
   const [topLevelBlockId] = useUIStateProperty(topLevelBlockIdProp)
   const shellRef = useRef<HTMLDivElement | null>(null)
   const contentContainerRef = useRef<HTMLDivElement | null>(null)
-  const isTopLevel = block.id === topLevelBlockId
+  const isTopLevel = useIsFocalRender(block)
 
   // Scroll-into-view on focus (effect below). The `data-editing` attr
   // on shellProps wants `inEditMode`. Other reactive state is read by
@@ -485,11 +485,11 @@ export function DefaultBlockRenderer(
   // because mobile screens don't have desktop's horizontal real estate).
   const ControlsSlot = useMemo<ComponentType>(() => {
     return function BlockControlsSlot() {
-      const [topLevelBlockId] = useUIStateProperty(topLevelBlockIdProp)
+      const isFocal = useIsFocalRender(block)
       const isMobile = useIsMobile()
       const hasChildren = useHasChildren(block)
 
-      if (topLevelBlockId === block.id) return null
+      if (isFocal) return null
 
       return (
         <>

--- a/src/components/renderer/LayoutRenderer.tsx
+++ b/src/components/renderer/LayoutRenderer.tsx
@@ -71,7 +71,7 @@ function PanelSlotView({
 
   return (
     <NestedBlockContextProvider
-      overrides={{topLevel: true, panelId: slot.id, canClosePanel, stackedPanel: stacked}}
+      overrides={{layoutBoundary: true, panelId: slot.id, canClosePanel, stackedPanel: stacked}}
       key={slot.id}
     >
       <div
@@ -175,5 +175,5 @@ export function LayoutRenderer({block}: BlockRendererProps) {
 }
 
 LayoutRenderer.canRender = ({context}: BlockRendererProps) =>
-  !!(context && !context.topLevel && !context.panelId)
+  !!(context && !context.layoutBoundary && !context.panelId)
 LayoutRenderer.priority = () => 20

--- a/src/components/renderer/PanelRenderer.tsx
+++ b/src/components/renderer/PanelRenderer.tsx
@@ -176,7 +176,7 @@ export function PanelRenderer({block}: BlockRendererProps) {
         className={stackedPanel ? 'overflow-visible' : 'flex-grow overflow-y-auto scrollbar-none'}
         onScroll={scheduleScrollTopWrite}
       >
-        <NestedBlockContextProvider overrides={{topLevel: false}}>
+        <NestedBlockContextProvider overrides={{layoutBoundary: false}}>
           <BlockComponent blockId={topLevelBlockId}/>
         </NestedBlockContextProvider>
       </div>
@@ -195,5 +195,5 @@ export function PanelRenderer({block}: BlockRendererProps) {
   )
 }
 
-PanelRenderer.canRender = ({context}: BlockRendererProps) => !!(context?.topLevel && context.panelId)
+PanelRenderer.canRender = ({context}: BlockRendererProps) => !!(context?.layoutBoundary && context.panelId)
 PanelRenderer.priority = () => 5

--- a/src/components/renderer/TopLevelRenderer.tsx
+++ b/src/components/renderer/TopLevelRenderer.tsx
@@ -9,7 +9,7 @@ import { ActionContextTypes } from '@/shortcuts/types.ts'
  * This is like this to avoid re-rending on context changing bc of new object creation
  * Plausibly over-optimizing, but wanted to keep an example/reminder on this.
  */
-const CONTEXT_OVERRIDE = {topLevel: false}
+const CONTEXT_OVERRIDE = {layoutBoundary: false}
 
 export function TopLevelRenderer({block}: BlockRendererProps) {
   /**
@@ -40,5 +40,5 @@ export function TopLevelRenderer({block}: BlockRendererProps) {
   )
 }
 
-TopLevelRenderer.canRender = ({context}: BlockRendererProps) => !!(context && context.topLevel && !context.panelId)
+TopLevelRenderer.canRender = ({context}: BlockRendererProps) => !!(context && context.layoutBoundary && !context.panelId)
 TopLevelRenderer.priority = () => 20

--- a/src/extensions/blockInteraction.ts
+++ b/src/extensions/blockInteraction.ts
@@ -53,6 +53,11 @@ export interface BlockResolveContext {
   uiStateBlock: Block
   types: readonly string[]
   topLevelBlockId?: string
+  /** Focal-on-document — `block.id === topLevelBlockId` AND the current
+   *  mount is the document surface (not an embed, backlink entry, or
+   *  breadcrumb preview). Populated by `useIsFocalRender(block)`; the
+   *  pure helper `isFocalRender(ctx)` answers the same question for
+   *  facet contributions that receive a `BlockResolveContext`. */
   isTopLevel: boolean
   blockContext?: BlockContextType
   contentRenderers?: readonly BlockContentRendererSlot[]

--- a/src/extensions/useShortcutSurfaceActivations.ts
+++ b/src/extensions/useShortcutSurfaceActivations.ts
@@ -64,7 +64,7 @@ export function useShortcutSurfaceActivations(
       uiStateBlock,
       types,
       topLevelBlockId,
-      isTopLevel: block.id === topLevelBlockId,
+      isTopLevel: block.id === topLevelBlockId && !blockContext.isNestedSurface,
       blockContext,
       inFocus,
       inEditMode,

--- a/src/hooks/useIsFocalRender.ts
+++ b/src/hooks/useIsFocalRender.ts
@@ -1,0 +1,33 @@
+import type { Block } from '@/data/block.ts'
+import { useBlockContext } from '@/context/block.tsx'
+import { useUIStateProperty } from '@/data/globalState.ts'
+import { topLevelBlockIdProp } from '@/data/properties.ts'
+import type { BlockResolveContext } from '@/extensions/blockInteraction.ts'
+
+/**
+ * "Is this block being rendered as the document body of its panel?" —
+ * the question the five top-level affordances (force-open, hide-bullet,
+ * top-level CSS, breadcrumbs header, backlinks footer) all want to
+ * answer.
+ *
+ * Two axes are tangled in the naive `block.id === topLevelBlockId`
+ * check: focal-block identity (correct) and render surface (missing).
+ * An embed of the focal block, or a backlink entry whose shown block
+ * happens to equal the focal block, both pass the id check but should
+ * not inherit the focal affordances.
+ *
+ * Render surface is encoded as flags on `BlockContextType` set by every
+ * non-document mount (`BlockEmbed`, `BacklinkEntry`, breadcrumb list).
+ * The umbrella `isNestedSurface` is what this hook consults, so a new
+ * surface only has to set the umbrella to be excluded automatically.
+ */
+export const useIsFocalRender = (block: Block): boolean => {
+  const [topLevelBlockId] = useUIStateProperty(topLevelBlockIdProp)
+  const {isNestedSurface} = useBlockContext()
+  return block.id === topLevelBlockId && !isNestedSurface
+}
+
+/** Non-hook variant for facet contributions that receive a
+ *  `BlockResolveContext`. Same policy as `useIsFocalRender`. */
+export const isFocalRender = (ctx: BlockResolveContext): boolean =>
+  ctx.isTopLevel && !ctx.blockContext?.isNestedSurface

--- a/src/plugins/backlinks/BacklinkEntry.tsx
+++ b/src/plugins/backlinks/BacklinkEntry.tsx
@@ -9,7 +9,7 @@ import type { LazyViewportPlaceholderProps } from '@/components/util/LazyViewpor
 import { useParents } from '@/hooks/block.ts'
 import { useRepo } from '@/context/repo.tsx'
 
-const NESTED_OVERRIDES = {topLevel: false, isBacklink: true}
+const NESTED_OVERRIDES = {layoutBoundary: false, isNestedSurface: true, isBacklink: true}
 const BREADCRUMB_OVERRIDES = {...NESTED_OVERRIDES, isBreadcrumb: true}
 const BACKLINK_ESTIMATED_HEIGHT_PX = 96
 const BACKLINK_OVERSCAN_PX = 600

--- a/src/plugins/breadcrumbs/Breadcrumbs.tsx
+++ b/src/plugins/breadcrumbs/Breadcrumbs.tsx
@@ -6,7 +6,7 @@ import { useBlockContext } from '@/context/block.tsx'
 import { useNavigate } from '@/utils/navigation.ts'
 import { BreadcrumbList } from './BreadcrumbList.tsx'
 
-const OVERRIDES = {isBreadcrumb: true}
+const OVERRIDES = {isNestedSurface: true, isBreadcrumb: true}
 
 export const Breadcrumbs = ({block}: { block: Block }) => {
   const repo = useRepo()

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,13 +77,32 @@ export interface RendererRegistry {
 export type { EditorSelectionState } from '@/data/properties'
 
 export interface BlockContextType {
-    topLevel?: boolean
+    /** Layout-dispatch boundary — gates which top-level renderer fires
+     *  (`TopLevelRenderer` / `LayoutRenderer` / `PanelRenderer`). Reset
+     *  by every layout boundary as it descends, so by the time
+     *  `DefaultBlockRenderer` runs this is always `false`. Orthogonal
+     *  to focal-block identity (`block.id === topLevelBlockId`) and to
+     *  render surface (`isNestedSurface` and friends below). */
+    layoutBoundary?: boolean
     safeMode?: boolean
     user?: {
         id: string
         name: string
     }
     panelId?: string
+    /** Umbrella surface flag — set by every non-document mount
+     *  (`BlockEmbed`, `BacklinkEntry`, breadcrumb list). Consulted by
+     *  `useIsFocalRender` / `isFocalRender` so a new surface only has
+     *  to set the umbrella to be excluded from focal affordances. */
+    isNestedSurface?: boolean
+    /** Specific descriptors — set alongside `isNestedSurface` so
+     *  consumers that need to discriminate the surface (e.g. a future
+     *  embed-only header decoration) can ask the specific question.
+     *  Composes in nested cases (a backlink containing an embed has
+     *  both `isBacklink` and `isEmbedded` true). */
+    isEmbedded?: boolean
+    isBacklink?: boolean
+    isBreadcrumb?: boolean
     [key: string]: unknown
 }
 


### PR DESCRIPTION
A block embed pointing at the panel's focal block hit the naive
`block.id === topLevelBlockId` check at five sites — backlinks footer,
breadcrumbs header, force-open, top-level CSS hook, hide-bullet —
because `BlockEmbed` didn't override the render context. The same id
collision is latent in any other surface that inherits parent context.

Introduce a render-surface umbrella flag `isNestedSurface` on
`BlockContextType`, set by every non-document mount (`BlockEmbed`,
`BacklinkEntry`, breadcrumb list), alongside specific descriptors
(`isEmbedded`, `isBacklink`, `isBreadcrumb`). Centralize the focal-on-
document check in `useIsFocalRender(block)` and the pure helper
`isFocalRender(ctx)`, both consulting the umbrella. The five sites
inherit changes automatically through the hook (used directly in
`DefaultBlockRenderer`) or through `resolveContext.isTopLevel` (which
the hook now feeds).

Also rename `BlockContextType.topLevel` → `layoutBoundary` to disentangle
the layout-dispatch axis from focal-block identity. The old name read
like "is this the focal block" but meant "this mount is a layout-
dispatch boundary"; future readers will no longer trip over the
mismatch.

Follow-up note added covering a tighter `renderSurface` enum and ideas
from the (currently off-roadmap) renderer-resolution.md worth pulling
in when this gets revisited.

https://claude.ai/code/session_01QYfPxTEKYGQZMesnfbjS8Y