### PR TITLE
Add live-updates toggle to grouped backlinks view

### DIFF
--- a/src/plugins/grouped-backlinks/GroupedLinkedReferences.tsx
+++ b/src/plugins/grouped-backlinks/GroupedLinkedReferences.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
 import { Filter, Pause, Play } from 'lucide-react'
 import type { BlockRendererProps } from '@/types.ts'
 import { Block } from '@/data/block'
@@ -17,7 +17,11 @@ import { useAppRuntime } from '@/extensions/runtimeContext.ts'
 import type { GroupedBacklinkGroup } from './grouping.ts'
 import { useGroupedBacklinksConfig } from './useGroupedBacklinksConfig.ts'
 import { useGroupedBacklinks } from './useGroupedBacklinks.ts'
-import type { GroupedBacklinksResult } from './query.ts'
+import type { GroupedBacklinksConfig } from './config.ts'
+import {
+  GROUPED_BACKLINKS_FOR_BLOCK_QUERY,
+  type GroupedBacklinksResult,
+} from './query.ts'
 import { groupedBacklinksGroupHeaderControlsFacet } from './facet.ts'
 
 interface GroupedBacklinksSnapshot {
@@ -25,6 +29,32 @@ interface GroupedBacklinksSnapshot {
   grouped: GroupedBacklinksResult
   initialParentsByBacklinkId: ReadonlyMap<string, Block[]>
 }
+
+interface GroupedQueryArgs {
+  workspaceId: string
+  id: string
+  groupingConfig: GroupedBacklinksConfig
+  filter?: BacklinksFilter
+}
+
+interface SnapshotState {
+  data: GroupedBacklinksSnapshot
+  queryKey: string
+}
+
+const buildGroupedQueryArgs = (
+  workspaceId: string,
+  blockId: string,
+  groupingConfig: GroupedBacklinksConfig,
+  effectiveFilter: BacklinksFilter,
+): GroupedQueryArgs => ({
+  workspaceId,
+  id: blockId,
+  groupingConfig,
+  ...(hasBacklinksFilter(effectiveFilter) ? {filter: effectiveFilter} : {}),
+})
+
+const EMPTY_GROUPED_BACKLINKS_RESULT: GroupedBacklinksResult = {groups: [], total: 0}
 
 const GroupItems = ({
   targetBlock,
@@ -128,6 +158,20 @@ export function GroupedLinkedReferences({block}: BlockRendererProps) {
   )
 }
 
+interface SharedViewProps {
+  block: Block
+  workspaceId: string
+  open: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+  filter: BacklinksFilter
+  defaultFilter: BacklinksFilter
+  filterActive: boolean
+  filtersOpen: boolean
+  setFiltersOpenOverride: Dispatch<SetStateAction<boolean | null>>
+  setFilter: (next: BacklinksFilter) => void
+  openDefaultFilterConfig: () => void
+}
+
 function GroupedLinkedReferencesInner({
   block,
   workspaceId,
@@ -144,7 +188,103 @@ function GroupedLinkedReferencesInner({
   } = useBacklinkFilterState(block)
   const navigateFromGlobalCommand = useNavigateFromGlobalCommand()
   const filterActive = hasBacklinksFilter(effectiveFilter)
+  // `groupingConfig` lives in the parent so the paused body can compare
+  // it against the snapshot's captured args and trigger a one-shot
+  // recompute when it (or the filter) changes.
   const groupingConfig = useGroupedBacklinksConfig(block)
+  const [open, setOpen] = useState(true)
+  const [filtersOpenOverride, setFiltersOpenOverride] = useState<boolean | null>(null)
+  const filtersOpen = filtersOpenOverride ?? filterActive
+  const [liveUpdates, setLiveUpdates] = useState(true)
+  const [snapshot, setSnapshot] = useState<SnapshotState | null>(null)
+
+  const groupedArgs = useMemo(
+    () => buildGroupedQueryArgs(workspaceId, block.id, groupingConfig, effectiveFilter),
+    [workspaceId, block.id, groupingConfig, effectiveFilter],
+  )
+  // Stable string identity of the grouped-query args. The snapshot
+  // carries the key of the args it was captured under; whenever the
+  // current key drifts (filter or config change while paused), the
+  // frozen body fires a one-shot `handle.load()` to refresh just the
+  // `grouped` field — no subscription, so unrelated row edits still
+  // don't trigger work.
+  const currentQueryKey = useMemo(() => JSON.stringify(groupedArgs), [groupedArgs])
+
+  const setFilter = useCallback((next: BacklinksFilter) => {
+    setStoredFilter(next)
+    if (hasBacklinksFilter(next)) setFiltersOpenOverride(true)
+  }, [setStoredFilter])
+  const openDefaultFilterConfig = useCallback(() => {
+    navigateFromGlobalCommand({blockId: defaultFilterConfigBlock.id, workspaceId})
+  }, [defaultFilterConfigBlock.id, navigateFromGlobalCommand, workspaceId])
+
+  const handlePause = useCallback((data: GroupedBacklinksSnapshot) => {
+    setSnapshot({data, queryKey: currentQueryKey})
+    setLiveUpdates(false)
+  }, [currentQueryKey])
+  const handleResume = useCallback(() => {
+    setSnapshot(null)
+    setLiveUpdates(true)
+  }, [])
+  const handleSnapshotRefreshed = useCallback(
+    (grouped: GroupedBacklinksResult, queryKey: string) => {
+      setSnapshot(prev => (prev ? {data: {...prev.data, grouped}, queryKey} : prev))
+    },
+    [],
+  )
+
+  const shared: SharedViewProps = {
+    block,
+    workspaceId,
+    open,
+    setOpen,
+    filter,
+    defaultFilter,
+    filterActive,
+    filtersOpen,
+    setFiltersOpenOverride,
+    setFilter,
+    openDefaultFilterConfig,
+  }
+
+  // While paused, mount the frozen body — the live body (which is what
+  // subscribes to the grouped-backlinks query, the backlinks list, and
+  // the manyAncestors prefetch) is unmounted, so those handles lose
+  // their subscribers and the underlying queries stop recomputing on
+  // edits the user makes while inspecting the snapshot.
+  if (liveUpdates) {
+    return (
+      <LiveGroupedReferencesBody
+        {...shared}
+        effectiveFilter={effectiveFilter}
+        groupingConfig={groupingConfig}
+        onPause={handlePause}
+      />
+    )
+  }
+  return (
+    <FrozenGroupedReferencesBody
+      {...shared}
+      snapshot={snapshot!}
+      groupedArgs={groupedArgs}
+      currentQueryKey={currentQueryKey}
+      onResume={handleResume}
+      onSnapshotRefreshed={handleSnapshotRefreshed}
+    />
+  )
+}
+
+function LiveGroupedReferencesBody({
+  effectiveFilter,
+  groupingConfig,
+  onPause,
+  ...shared
+}: SharedViewProps & {
+  effectiveFilter: BacklinksFilter
+  groupingConfig: GroupedBacklinksConfig
+  onPause: (data: GroupedBacklinksSnapshot) => void
+}) {
+  const {block, workspaceId, filterActive} = shared
   const unfilteredBacklinks = useBacklinks(block, workspaceId)
   const grouped = useGroupedBacklinks(
     block,
@@ -158,37 +298,98 @@ function GroupedLinkedReferencesInner({
   // the seed list so the prefetch handle is stable across filter
   // toggles.
   const initialParentsByBacklinkId = useManyParents(unfilteredBacklinks)
-  const [open, setOpen] = useState(true)
-  const [filtersOpenOverride, setFiltersOpenOverride] = useState<boolean | null>(null)
-  const filtersOpen = filtersOpenOverride ?? filterActive
-  const [liveUpdates, setLiveUpdates] = useState(true)
-  const [snapshot, setSnapshot] = useState<GroupedBacklinksSnapshot | null>(null)
 
-  const setFilter = useCallback((next: BacklinksFilter) => {
-    setStoredFilter(next)
-    if (hasBacklinksFilter(next)) setFiltersOpenOverride(true)
-  }, [setStoredFilter])
-  const openDefaultFilterConfig = useCallback(() => {
-    navigateFromGlobalCommand({blockId: defaultFilterConfigBlock.id, workspaceId})
-  }, [defaultFilterConfigBlock.id, navigateFromGlobalCommand, workspaceId])
+  const data = useMemo<GroupedBacklinksSnapshot>(
+    () => ({unfilteredBacklinks, grouped, initialParentsByBacklinkId}),
+    [unfilteredBacklinks, grouped, initialParentsByBacklinkId],
+  )
 
-  const toggleLiveUpdates = useCallback(() => {
-    if (liveUpdates) {
-      setSnapshot({unfilteredBacklinks, grouped, initialParentsByBacklinkId})
-      setLiveUpdates(false)
-    } else {
-      setSnapshot(null)
-      setLiveUpdates(true)
-    }
-  }, [liveUpdates, unfilteredBacklinks, grouped, initialParentsByBacklinkId])
+  const handleTogglePause = useCallback(() => onPause(data), [onPause, data])
 
-  const displayed = snapshot ?? {unfilteredBacklinks, grouped, initialParentsByBacklinkId}
+  return (
+    <GroupedReferencesView
+      {...shared}
+      data={data}
+      liveUpdates
+      onToggleLiveUpdates={handleTogglePause}
+    />
+  )
+}
 
-  if (displayed.unfilteredBacklinks.length === 0) return null
+function FrozenGroupedReferencesBody({
+  snapshot,
+  groupedArgs,
+  currentQueryKey,
+  onResume,
+  onSnapshotRefreshed,
+  ...shared
+}: SharedViewProps & {
+  snapshot: SnapshotState
+  groupedArgs: GroupedQueryArgs
+  currentQueryKey: string
+  onResume: () => void
+  onSnapshotRefreshed: (grouped: GroupedBacklinksResult, queryKey: string) => void
+}) {
+  const {block} = shared
+  const repo = block.repo
+  const stale = snapshot.queryKey !== currentQueryKey
+
+  // One-shot refresh when the user adjusts the filter or grouping
+  // config while paused. Uses `handle.load()` directly rather than
+  // `useHandle(...)` so we never subscribe — unrelated row edits won't
+  // wake the handle, and once the load resolves the new result lands
+  // in the snapshot and we settle back into the frozen view.
+  useEffect(() => {
+    if (!stale) return
+    let cancelled = false
+    const handle = repo.query[GROUPED_BACKLINKS_FOR_BLOCK_QUERY](groupedArgs)
+    handle.load().then(
+      result => {
+        if (cancelled) return
+        onSnapshotRefreshed(result ?? EMPTY_GROUPED_BACKLINKS_RESULT, currentQueryKey)
+      },
+      () => {/* error is stored on the handle */},
+    )
+    return () => { cancelled = true }
+  }, [stale, repo, groupedArgs, currentQueryKey, onSnapshotRefreshed])
+
+  return (
+    <GroupedReferencesView
+      {...shared}
+      data={snapshot.data}
+      liveUpdates={false}
+      onToggleLiveUpdates={onResume}
+    />
+  )
+}
+
+function GroupedReferencesView({
+  block,
+  workspaceId,
+  data,
+  liveUpdates,
+  onToggleLiveUpdates,
+  open,
+  setOpen,
+  filter,
+  defaultFilter,
+  filterActive,
+  filtersOpen,
+  setFiltersOpenOverride,
+  setFilter,
+  openDefaultFilterConfig,
+}: SharedViewProps & {
+  data: GroupedBacklinksSnapshot
+  liveUpdates: boolean
+  onToggleLiveUpdates: () => void
+}) {
+  const {unfilteredBacklinks, grouped, initialParentsByBacklinkId} = data
+
+  if (unfilteredBacklinks.length === 0) return null
 
   const countLabel = filterActive
-    ? `${displayed.grouped.total} / ${displayed.unfilteredBacklinks.length}`
-    : String(displayed.grouped.total)
+    ? `${grouped.total} / ${unfilteredBacklinks.length}`
+    : String(grouped.total)
 
   return (
     <div className="mt-4 pt-3 border-t border-border">
@@ -205,7 +406,7 @@ function GroupedLinkedReferencesInner({
         <div className="flex shrink-0 items-center gap-0.5">
           <button
             type="button"
-            onClick={toggleLiveUpdates}
+            onClick={onToggleLiveUpdates}
             className={`rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
               !liveUpdates ? 'bg-accent text-foreground' : ''
             }`}
@@ -243,19 +444,19 @@ function GroupedLinkedReferencesInner({
               onChange={setFilter}
             />
           )}
-          {displayed.grouped.total === 0 ? (
+          {grouped.total === 0 ? (
             <div className="mt-3 text-xs text-muted-foreground">
               No matching references.
             </div>
           ) : (
             <div className="mt-3 flex flex-col gap-4">
-              {displayed.grouped.groups.map(group => (
+              {grouped.groups.map(group => (
                 <GroupedReferencesGroup
                   key={group.groupId}
                   targetBlock={block}
                   workspaceId={workspaceId}
                   group={group}
-                  parentsBySourceId={displayed.initialParentsByBacklinkId}
+                  parentsBySourceId={initialParentsByBacklinkId}
                 />
               ))}
             </div>

--- a/src/plugins/grouped-backlinks/GroupedLinkedReferences.tsx
+++ b/src/plugins/grouped-backlinks/GroupedLinkedReferences.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { Filter } from 'lucide-react'
+import { Filter, Pause, Play } from 'lucide-react'
 import type { BlockRendererProps } from '@/types.ts'
 import { Block } from '@/data/block'
 import { useManyParents, useWorkspaceId } from '@/hooks/block.ts'
@@ -17,7 +17,14 @@ import { useAppRuntime } from '@/extensions/runtimeContext.ts'
 import type { GroupedBacklinkGroup } from './grouping.ts'
 import { useGroupedBacklinksConfig } from './useGroupedBacklinksConfig.ts'
 import { useGroupedBacklinks } from './useGroupedBacklinks.ts'
+import type { GroupedBacklinksResult } from './query.ts'
 import { groupedBacklinksGroupHeaderControlsFacet } from './facet.ts'
+
+interface GroupedBacklinksSnapshot {
+  unfilteredBacklinks: Block[]
+  grouped: GroupedBacklinksResult
+  initialParentsByBacklinkId: ReadonlyMap<string, Block[]>
+}
 
 const GroupItems = ({
   targetBlock,
@@ -154,6 +161,8 @@ function GroupedLinkedReferencesInner({
   const [open, setOpen] = useState(true)
   const [filtersOpenOverride, setFiltersOpenOverride] = useState<boolean | null>(null)
   const filtersOpen = filtersOpenOverride ?? filterActive
+  const [liveUpdates, setLiveUpdates] = useState(true)
+  const [snapshot, setSnapshot] = useState<GroupedBacklinksSnapshot | null>(null)
 
   const setFilter = useCallback((next: BacklinksFilter) => {
     setStoredFilter(next)
@@ -163,11 +172,23 @@ function GroupedLinkedReferencesInner({
     navigateFromGlobalCommand({blockId: defaultFilterConfigBlock.id, workspaceId})
   }, [defaultFilterConfigBlock.id, navigateFromGlobalCommand, workspaceId])
 
-  if (unfilteredBacklinks.length === 0) return null
+  const toggleLiveUpdates = useCallback(() => {
+    if (liveUpdates) {
+      setSnapshot({unfilteredBacklinks, grouped, initialParentsByBacklinkId})
+      setLiveUpdates(false)
+    } else {
+      setSnapshot(null)
+      setLiveUpdates(true)
+    }
+  }, [liveUpdates, unfilteredBacklinks, grouped, initialParentsByBacklinkId])
+
+  const displayed = snapshot ?? {unfilteredBacklinks, grouped, initialParentsByBacklinkId}
+
+  if (displayed.unfilteredBacklinks.length === 0) return null
 
   const countLabel = filterActive
-    ? `${grouped.total} / ${unfilteredBacklinks.length}`
-    : String(grouped.total)
+    ? `${displayed.grouped.total} / ${displayed.unfilteredBacklinks.length}`
+    : String(displayed.grouped.total)
 
   return (
     <div className="mt-4 pt-3 border-t border-border">
@@ -181,18 +202,32 @@ function GroupedLinkedReferencesInner({
           <span>Grouped References</span>
           <span className="text-xs text-muted-foreground/70">{countLabel}</span>
         </button>
-        <button
-          type="button"
-          onClick={() => setFiltersOpenOverride(prev => !(prev ?? filterActive))}
-          className={`rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-            filterActive ? 'bg-accent text-foreground' : ''
-          }`}
-          title="Filters"
-          aria-label="Filters"
-          aria-pressed={filtersOpen}
-        >
-          <Filter className="h-4 w-4" />
-        </button>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <button
+            type="button"
+            onClick={toggleLiveUpdates}
+            className={`rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+              !liveUpdates ? 'bg-accent text-foreground' : ''
+            }`}
+            title={liveUpdates ? 'Pause live updates' : 'Resume live updates'}
+            aria-label={liveUpdates ? 'Pause live updates' : 'Resume live updates'}
+            aria-pressed={!liveUpdates}
+          >
+            {liveUpdates ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+          </button>
+          <button
+            type="button"
+            onClick={() => setFiltersOpenOverride(prev => !(prev ?? filterActive))}
+            className={`rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+              filterActive ? 'bg-accent text-foreground' : ''
+            }`}
+            title="Filters"
+            aria-label="Filters"
+            aria-pressed={filtersOpen}
+          >
+            <Filter className="h-4 w-4" />
+          </button>
+        </div>
       </div>
 
       {open && (
@@ -208,19 +243,19 @@ function GroupedLinkedReferencesInner({
               onChange={setFilter}
             />
           )}
-          {grouped.total === 0 ? (
+          {displayed.grouped.total === 0 ? (
             <div className="mt-3 text-xs text-muted-foreground">
               No matching references.
             </div>
           ) : (
             <div className="mt-3 flex flex-col gap-4">
-              {grouped.groups.map(group => (
+              {displayed.grouped.groups.map(group => (
                 <GroupedReferencesGroup
                   key={group.groupId}
                   targetBlock={block}
                   workspaceId={workspaceId}
                   group={group}
-                  parentsBySourceId={initialParentsByBacklinkId}
+                  parentsBySourceId={displayed.initialParentsByBacklinkId}
                 />
               ))}
             </div>


### PR DESCRIPTION
Sometimes you want to make edits that affect filterability (toggling
tags, tweaking the filter rules) without the grouped list reshuffling
under you. Add a pause/play button next to the filter toggle: when
paused, the current `unfilteredBacklinks` / `grouped` /
`initialParentsByBacklinkId` triple is captured into local state and
rendered in place of the live values. Clicking again clears the
snapshot and resumes live rendering.

The underlying `useGroupedBacklinks` / `useBacklinks` /
`useManyParents` subscriptions stay active while paused, so the
SQL keeps running in the background. Going further (unmounting a
sub-tree on pause to drop the subscriptions) is doable but would
introduce a brief loading flicker on resume once the handles GC,
which felt worse than the wasted compute for the typical
short-pause workflow.

State is component-local — a fresh mount always starts live.

https://claude.ai/code/session_019WE3s5tMHFpig3KCPXJkd7