### PR TITLE
Pad panel scroll bottom on mobile so content clears the bottom nav

### DIFF
--- a/src/components/renderer/PanelRenderer.tsx
+++ b/src/components/renderer/PanelRenderer.tsx
@@ -173,7 +173,7 @@ export function PanelRenderer({block}: BlockRendererProps) {
       </div>
       <div
         ref={scrollRef}
-        className={stackedPanel ? 'overflow-visible' : 'flex-grow overflow-y-auto scrollbar-none'}
+        className={stackedPanel ? 'overflow-visible' : 'flex-grow overflow-y-auto scrollbar-none pb-[calc(env(safe-area-inset-bottom)+4rem)] md:pb-0'}
         onScroll={scheduleScrollTopWrite}
       >
         <NestedBlockContextProvider overrides={{layoutBoundary: false}}>


### PR DESCRIPTION
The mobile bottom nav is fixed-positioned with z-40, so when a panel was
scrolled to the very bottom its last items sat under the nav and were
untappable — notably the collapsed backlinks section header. Adds a
bottom padding equal to the nav height (h-16) plus the safe-area inset
to the panel's scroll container, dropped back to 0 at md+ where the
nav is hidden.