### PR TITLE
Add undo button to mobile bottom nav

### DIFF
--- a/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
+++ b/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
@@ -1,7 +1,6 @@
 import { useIsMobile } from '@/utils/react.tsx'
 import { useAppRuntime } from '@/extensions/runtimeContext.ts'
-import { useActiveContextsState } from '@/shortcuts/ActiveContexts.tsx'
-import { useRunAction } from '@/shortcuts/runAction.ts'
+import { useActiveContextsState, type ActiveContextsMap } from '@/shortcuts/ActiveContexts.tsx'
 import { actionRuntimeKey, getEffectiveActions } from '@/shortcuts/effectiveActions.ts'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types.ts'
 import { mobileBottomNavItemsFacet } from './facet.ts'
@@ -9,15 +8,18 @@ import { MobileBottomNavButton } from './Button.tsx'
 
 function MobileBottomNavActionButton({
   action,
+  activeContexts,
   disabled,
 }: {
   action: ActionConfig
+  activeContexts: ActiveContextsMap
   disabled: boolean
 }) {
-  const runAction = useRunAction()
   const handleClick = () => {
-    void runAction(
-      action.id,
+    const deps = activeContexts.get(action.context)
+    if (!deps) return
+    void action.handler(
+      deps as never,
       new CustomEvent('mobile-bottom-nav-action', {detail: {actionId: action.id}}),
     )
   }
@@ -61,6 +63,7 @@ function MobileBottomNavSurface() {
             <MobileBottomNavActionButton
               key={id}
               action={action}
+              activeContexts={activeContexts}
               disabled={!activeContexts.has(action.context)}
             />
           )

--- a/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
+++ b/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
@@ -2,7 +2,7 @@ import { useIsMobile } from '@/utils/react.tsx'
 import { useAppRuntime } from '@/extensions/runtimeContext.ts'
 import { useActiveContextsState } from '@/shortcuts/ActiveContexts.tsx'
 import { useRunAction } from '@/shortcuts/runAction.ts'
-import { getEffectiveActions } from '@/shortcuts/effectiveActions.ts'
+import { actionRuntimeKey, getEffectiveActions } from '@/shortcuts/effectiveActions.ts'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types.ts'
 import { mobileBottomNavItemsFacet } from './facet.ts'
 import { MobileBottomNavButton } from './Button.tsx'
@@ -37,10 +37,8 @@ function MobileBottomNavActionButton({
 function MobileBottomNavSurface() {
   const runtime = useAppRuntime()
   const items = runtime.read(mobileBottomNavItemsFacet)
-  const actionsById = new Map(
-    getEffectiveActions(runtime)
-      .filter(action => action.context === ActionContextTypes.GLOBAL)
-      .map(action => [action.id, action]),
+  const actionsByKey = new Map(
+    getEffectiveActions(runtime).map(action => [actionRuntimeKey(action), action]),
   )
   const activeContexts = useActiveContextsState()
 
@@ -54,8 +52,10 @@ function MobileBottomNavSurface() {
       data-block-interaction="ignore"
     >
       <div className="mx-auto flex h-16 max-w-md items-center justify-around">
-        {items.map(({id, actionId}) => {
-          const action = actionsById.get(actionId)
+        {items.map(({id, actionId, context}) => {
+          const action = actionsByKey.get(
+            actionRuntimeKey({id: actionId, context: context ?? ActionContextTypes.GLOBAL}),
+          )
           if (!action) return null
           return (
             <MobileBottomNavActionButton

--- a/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
+++ b/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
@@ -37,7 +37,11 @@ function MobileBottomNavActionButton({
 function MobileBottomNavSurface() {
   const runtime = useAppRuntime()
   const items = runtime.read(mobileBottomNavItemsFacet)
-  const actionsById = new Map(getEffectiveActions(runtime).map(action => [action.id, action]))
+  const actionsById = new Map(
+    getEffectiveActions(runtime)
+      .filter(action => action.context === ActionContextTypes.GLOBAL)
+      .map(action => [action.id, action]),
+  )
   const activeContexts = useActiveContextsState()
 
   if (items.length === 0) return null

--- a/src/plugins/mobile-bottom-nav/defaultItems.ts
+++ b/src/plugins/mobile-bottom-nav/defaultItems.ts
@@ -39,3 +39,8 @@ export const commandPaletteBottomNavItem: MobileBottomNavItemContribution = {
   id: 'mobile-bottom-nav.command-palette',
   actionId: COMMAND_PALETTE_ACTION_ID,
 }
+
+export const undoBottomNavItem: MobileBottomNavItemContribution = {
+  id: 'mobile-bottom-nav.undo',
+  actionId: 'undo',
+}

--- a/src/plugins/mobile-bottom-nav/facet.ts
+++ b/src/plugins/mobile-bottom-nav/facet.ts
@@ -1,8 +1,13 @@
 import { defineFacet } from '@/extensions/facet.ts'
+import type { ActionContextType } from '@/shortcuts/types.ts'
 
 export interface MobileBottomNavItemContribution {
   id: string
   actionId: string
+  /** Disambiguates action lookup when the same `actionId` is registered
+   *  in multiple contexts (e.g. `undo` is registered both globally and
+   *  in `normal-mode`). Defaults to GLOBAL. */
+  context?: ActionContextType
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -13,7 +18,8 @@ export const isMobileBottomNavItemContribution = (
 ): value is MobileBottomNavItemContribution =>
   isRecord(value) &&
   typeof value.id === 'string' &&
-  typeof value.actionId === 'string'
+  typeof value.actionId === 'string' &&
+  (value.context === undefined || typeof value.context === 'string')
 
 export const mobileBottomNavItemsFacet = defineFacet<
   MobileBottomNavItemContribution,

--- a/src/plugins/mobile-bottom-nav/index.ts
+++ b/src/plugins/mobile-bottom-nav/index.ts
@@ -9,6 +9,7 @@ import {
   openSidebarBottomNavItem,
   searchBottomNavItem,
   todayBottomNavItem,
+  undoBottomNavItem,
 } from './defaultItems.ts'
 
 export { MobileBottomNav } from './MobileBottomNav.tsx'
@@ -24,6 +25,7 @@ export {
   openSidebarBottomNavItem,
   searchBottomNavItem,
   todayBottomNavItem,
+  undoBottomNavItem,
 } from './defaultItems.ts'
 
 export const mobileBottomNavMount: AppMountContribution = {
@@ -52,6 +54,10 @@ export const mobileBottomNavPlugin: AppExtension = [
   mobileBottomNavItemsFacet.of(searchBottomNavItem, {
     source: 'mobile-bottom-nav',
     precedence: -10,
+  }),
+  mobileBottomNavItemsFacet.of(undoBottomNavItem, {
+    source: 'mobile-bottom-nav',
+    precedence: -5,
   }),
   mobileBottomNavItemsFacet.of(commandPaletteBottomNavItem, {
     source: 'mobile-bottom-nav',

--- a/src/plugins/mobile-bottom-nav/test/plugin.test.ts
+++ b/src/plugins/mobile-bottom-nav/test/plugin.test.ts
@@ -12,6 +12,7 @@ import {
   openSidebarBottomNavItem,
   searchBottomNavItem,
   todayBottomNavItem,
+  undoBottomNavItem,
 } from '../index.ts'
 
 describe('mobileBottomNavPlugin', () => {
@@ -31,6 +32,7 @@ describe('mobileBottomNavPlugin', () => {
       appendTodayDailyBlockBottomNavItem,
       todayBottomNavItem,
       searchBottomNavItem,
+      undoBottomNavItem,
       commandPaletteBottomNavItem,
     ])
   })

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -1,4 +1,4 @@
-import { PanelRightOpen, Plus, ZoomIn } from 'lucide-react'
+import { PanelRightOpen, Plus, Undo2, ZoomIn } from 'lucide-react'
 import { defaultActionContextConfigs } from './defaultContexts.ts'
 import {
   ActionContextTypes,
@@ -262,6 +262,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       id: 'undo',
       description: 'Undo',
       context: ActionContextTypes.GLOBAL,
+      icon: Undo2,
       handler: async () => { await repo.undo() },
       defaultBinding: {
         keys: ['cmd+z', 'ctrl+z'],


### PR DESCRIPTION
Surfaces undo on the non-edit-mode mobile bar (the keyboard toolbar
already had its own undo for edit mode). The button sits just before
command palette and reuses the existing global undo action.

https://claude.ai/code/session_01Tct8hJMghC3z56XsWALpZU