### PR TITLE
Fix reschedule picker scrub: label & highlight actual today

### DIFF
--- a/src/plugins/daily-notes/ReschedulePicker.tsx
+++ b/src/plugins/daily-notes/ReschedulePicker.tsx
@@ -326,7 +326,7 @@ export const ReschedulePicker = () => {
                     isSelected
                       ? 'border-primary bg-primary text-primary-foreground'
                       : cell.isToday
-                        ? 'border-primary/40 bg-background text-primary'
+                        ? 'border-primary bg-primary/10 text-primary'
                         : 'border-border bg-background text-foreground hover:bg-muted',
                   )}
                 >
@@ -337,11 +337,13 @@ export const ReschedulePicker = () => {
                     {cell.date.getDate()}
                   </span>
                   <span className="text-[9px] opacity-60">
-                    {cell.offsetDays === 0
+                    {cell.isToday
                       ? 'today'
-                      : cell.offsetDays > 0
-                        ? `+${cell.offsetDays}d`
-                        : `${cell.offsetDays}d`}
+                      : cell.offsetDays === 0
+                        ? 'original'
+                        : cell.offsetDays > 0
+                          ? `+${cell.offsetDays}d`
+                          : `${cell.offsetDays}d`}
                   </span>
                 </button>
               )


### PR DESCRIPTION
The scrub strip was labelling the anchor cell (the date the item is
being rescheduled from) as "today" — that label belongs on the actual
calendar-today cell. The today cell did have a faint primary-text
highlight, but the wrong label made it unnoticeable.

Move the "today" label to the cell where iso === todayIso(), tag the
anchor cell as "original", and strengthen the today cell's border and
background so it reads as highlighted even when a different date is
selected.