### PR TITLE
Center reschedule toast on mobile viewports

### DIFF
--- a/src/plugins/srs-rescheduling/RescheduleToast.tsx
+++ b/src/plugins/srs-rescheduling/RescheduleToast.tsx
@@ -31,7 +31,7 @@ export const RescheduleToast = ({toastId, message, txId, repo}: RescheduleToastP
   }
 
   return (
-    <div className="flex w-[var(--width)] min-w-[260px] items-center gap-3 rounded-md border bg-background px-4 py-3 text-sm shadow-lg">
+    <div className="flex w-full min-w-[260px] items-center gap-3 rounded-md border bg-background px-4 py-3 text-sm shadow-lg">
       <span className="flex-1">{message}</span>
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- Reschedule toast was hard-coded to `w-[var(--width)]` (sonner's desktop default = 356px). On mobile (≤600px) sonner stretches the outer `[data-sonner-toast]` wrapper to viewport width but our inner div stayed 356px, so it sat left-aligned inside the now-wide wrapper.
- Switched to `w-full` so the inner div tracks the wrapper in either viewport.

## Notes
Diagnosed from sonner's CSS — `[data-sonner-toaster]` becomes full-width at `max-width: 600px` and removes the centering transform; the inner toast wrapper is sized to `calc(100% - var(--mobile-offset-left) * 2)`. Our `w-[var(--width)]` was overriding that for the body we render via `showCustom`.

## Test plan
- [ ] Tested locally — running in a remote sandbox without browser access, so the fix is unverified in a live mobile viewport. Worth eyeballing on a real phone (or DevTools mobile emulation at 375px) before merging.
- [x] `vitest run src/plugins/srs-rescheduling` — 52/52 pass
- [x] `tsc -b` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtqixEULXVmKvxrUBN2Lrk)_