### PR TITLE
Live-track swipe gestures so the toolbar follows the finger

### DIFF
--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -295,7 +295,12 @@ export const SwipeActionMenu = () => {
     }, SETTLE_DURATION_MS)
   }, [])
 
-  useEffect(() => () => clearSettleTimer(), [clearSettleTimer])
+  // Clear any in-flight settle on unmount AND on panel navigation.
+  // Without the topLevelBlockId dependency, a settle scheduled in the
+  // previous panel scope could fire after the user has opened a fresh
+  // menu in the new scope and reset `activeBlockId`, closing the new
+  // menu unexpectedly.
+  useEffect(() => () => clearSettleTimer(), [clearSettleTimer, topLevelBlockId])
 
   const dismiss = useCallback((): void => {
     clearSettleTimer()

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -15,8 +15,10 @@ import {
 import {
   isSwipeQuickActionRunEvent,
   isSwipeQuickActionMenuEvent,
+  isSwipeQuickActionProgressEvent,
   SWIPE_QUICK_ACTION_CLOSE_EVENT,
   SWIPE_QUICK_ACTION_OPEN_EVENT,
+  SWIPE_QUICK_ACTION_PROGRESS_EVENT,
   SWIPE_QUICK_ACTION_RUN_EVENT,
 } from './events.ts'
 import {
@@ -108,6 +110,28 @@ interface ResolvedQuickAction {
 }
 
 const TOOLBAR_ROW_HEIGHT_PX = 28
+
+/** Drag distance at which the toolbar is fully revealed during a
+ *  preview. Intentionally larger than `SWIPE_TRIGGER_PX` so releasing
+ *  at the commit threshold still has room for a satisfying "complete
+ *  the appearance" snap (think the Workflowy left-swipe pull-out). */
+const PREVIEW_FULL_REVEAL_PX = 100
+
+/** Duration of the snap-to-resting-state animation after the finger
+ *  lifts. Long enough to read, short enough to feel responsive. */
+const SETTLE_DURATION_MS = 200
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value))
+
+/** Map an opening-drag delta (dx ≤ 0) to the toolbar's hide percent —
+ *  0 = fully visible, 100 = parked off-screen right. */
+const computeOpenHidePercent = (dx: number): number =>
+  clamp(100 + (dx / PREVIEW_FULL_REVEAL_PX) * 100, 0, 100)
+
+/** Same mapping for a close-drag on an already-open menu (dx ≥ 0). */
+const computeCloseHidePercent = (dx: number): number =>
+  clamp((dx / PREVIEW_FULL_REVEAL_PX) * 100, 0, 100)
 
 /** Build a render-ready view for the toolbar from `(items, registry)`,
  *  so the JSX below stays focused on layout. */
@@ -208,16 +232,78 @@ export const SwipeActionMenu = () => {
     setPanelRoot(inlineAnchorRef.current?.closest<HTMLElement>('.panel') ?? null)
   }, [])
 
+  // Block currently being "previewed" — i.e. the user has started a
+  // leftward swipe and the toolbar is following the finger but the
+  // gesture hasn't committed yet. Set independently of activeBlockId so
+  // we can anchor and render the toolbar before commit.
+  const [previewBlockId, setPreviewBlockId] = useState<string | null>(null)
+  // Live hide percent (0..100). `null` means "use the resting position
+  // for the current activeBlockId" — i.e. 0 if open, 100 if not. While
+  // a drag is in flight or the menu is settling, this carries the
+  // intermediate value so the toolbar can track the finger / animate.
+  const [dragOffsetPercent, setDragOffsetPercent] = useState<number | null>(null)
+  // True while the toolbar is animating to its resting position
+  // (released without commit, committed mid-preview, dismissing). The
+  // CSS transition is gated on this flag — during the drag itself it
+  // must be off so the transform tracks the finger exactly.
+  const [isSettling, setIsSettling] = useState(false)
+  const settleTimerRef = useRef<number | null>(null)
+  // Tracked for the settle timer: if the timer fires while still
+  // pointed at 'closed', we need to drop activeBlockId.
+  const settleTargetRef = useRef<'open' | 'closed' | null>(null)
+
+  // Anchor to the previewed block before commit so the toolbar lines
+  // up with the row the user is dragging on; fall through to the
+  // committed activeBlockId once the gesture lands.
+  const anchorBlockId = previewBlockId ?? activeBlockId
   const anchor = useAnchorRect(
     isMobile ? panelRoot : null,
-    isMobile ? activeBlockId : undefined,
+    isMobile ? anchorBlockId : undefined,
   )
   const [showOverflow, setShowOverflow] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
   const menuTouchStartRef = useRef<MenuTouchStart | null>(null)
-  const dismiss = useCallback((): void => {
-    setActiveBlockId(undefined)
+
+  const clearSettleTimer = useCallback((): void => {
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current)
+      settleTimerRef.current = null
+    }
+    settleTargetRef.current = null
   }, [])
+
+  // Kick off a settle animation toward the given resting state. On
+  // timer end we tear down preview state and, for 'closed', drop the
+  // active block so the menu unmounts.
+  const startSettle = useCallback((target: 'open' | 'closed'): void => {
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current)
+    }
+    settleTargetRef.current = target
+    setIsSettling(true)
+    setDragOffsetPercent(target === 'open' ? 0 : 100)
+    settleTimerRef.current = window.setTimeout(() => {
+      settleTimerRef.current = null
+      const finalTarget = settleTargetRef.current
+      settleTargetRef.current = null
+      setIsSettling(false)
+      setPreviewBlockId(null)
+      setDragOffsetPercent(null)
+      if (finalTarget === 'closed') {
+        setActiveBlockId(undefined)
+      }
+    }, SETTLE_DURATION_MS)
+  }, [])
+
+  useEffect(() => () => clearSettleTimer(), [clearSettleTimer])
+
+  const dismiss = useCallback((): void => {
+    clearSettleTimer()
+    setActiveBlockId(undefined)
+    setPreviewBlockId(null)
+    setDragOffsetPercent(null)
+    setIsSettling(false)
+  }, [clearSettleTimer])
 
   // Resolve action metadata once per runtime — the registries are stable
   // across renders so this is effectively a one-time lookup that lets
@@ -242,8 +328,11 @@ export const SwipeActionMenu = () => {
   // isn't registered fall through so the missing-action error is still
   // visible on click.
   const visibleItems = useMemo(() => {
-    if (!activeBlockId) return actionItems
-    const block = repo.block(activeBlockId)
+    // Filter against the previewed block too so the buttons that slide
+    // in during the drag match the ones that'll be there after commit.
+    const blockId = activeBlockId ?? previewBlockId
+    if (!blockId) return actionItems
+    const block = repo.block(blockId)
     if (!block.peek()) return actionItems
     return actionItems.filter(item => {
       const action = allActions.find(a => a.id === item.actionId)
@@ -251,7 +340,7 @@ export const SwipeActionMenu = () => {
       if (!action.canRun) return true
       return action.canRun({block, uiStateBlock})
     })
-  }, [actionItems, allActions, activeBlockId, repo, uiStateBlock])
+  }, [actionItems, allActions, activeBlockId, previewBlockId, repo, uiStateBlock])
   const [primaryRows, overflowItems] = useMemo(() => {
     const rows = new Map<number, QuickActionItem[]>()
     const overflow: QuickActionItem[] = []
@@ -291,7 +380,15 @@ export const SwipeActionMenu = () => {
   const [trackedTopLevelBlockId, setTrackedTopLevelBlockId] = useState(topLevelBlockId)
   if (trackedTopLevelBlockId !== topLevelBlockId) {
     setTrackedTopLevelBlockId(topLevelBlockId)
+    // Panel navigated mid-gesture: drop visible state synchronously
+    // (we don't want a leftover preview rendering against an unrelated
+    // block in the new panel scope). A pending settle timer will still
+    // fire but its setState calls are no-ops once everything is
+    // already cleared, so we don't reach into the ref from render.
     if (activeBlockId) setActiveBlockId(undefined)
+    if (previewBlockId !== null) setPreviewBlockId(null)
+    if (dragOffsetPercent !== null) setDragOffsetPercent(null)
+    if (isSettling) setIsSettling(false)
   }
 
   useEffect(() => {
@@ -300,14 +397,28 @@ export const SwipeActionMenu = () => {
     const handleOpen = (event: Event): void => {
       if (!isSwipeQuickActionMenuEvent(event)) return
       event.preventDefault()
-      setActiveBlockId(event.detail.blockId)
+      const blockId = event.detail.blockId
+      setActiveBlockId(blockId)
+      // If the open came after a preview of the same block, animate
+      // the toolbar's remaining offset to fully visible — the
+      // "completes appearing" snap. Otherwise no animation is needed:
+      // either we weren't previewing or we were previewing a different
+      // block (rare), and the menu should just appear at rest.
+      if (previewBlockId === blockId && dragOffsetPercent !== null) {
+        startSettle('open')
+      } else {
+        clearSettleTimer()
+        setPreviewBlockId(null)
+        setDragOffsetPercent(null)
+        setIsSettling(false)
+      }
     }
 
     const handleClose = (event: Event): void => {
       if (!isSwipeQuickActionMenuEvent(event)) return
       if (event.detail.blockId !== activeBlockId) return
       event.preventDefault()
-      setActiveBlockId(undefined)
+      startSettle('closed')
     }
 
     const handleRun = (event: Event): void => {
@@ -316,15 +427,33 @@ export const SwipeActionMenu = () => {
       event.preventDefault()
     }
 
+    const handleProgress = (event: Event): void => {
+      if (!isSwipeQuickActionProgressEvent(event)) return
+      const {blockId, dx, phase} = event.detail
+      if (phase === 'active') {
+        // Drag still in flight — follow the finger without animation.
+        // Re-grabbing a different block mid-gesture just retargets.
+        clearSettleTimer()
+        setIsSettling(false)
+        setPreviewBlockId(blockId)
+        setDragOffsetPercent(computeOpenHidePercent(dx))
+      } else if (phase === 'cancel' && previewBlockId === blockId) {
+        // Released without commit — animate the toolbar back to hidden.
+        startSettle('closed')
+      }
+    }
+
     panelRoot.addEventListener(SWIPE_QUICK_ACTION_OPEN_EVENT, handleOpen)
     panelRoot.addEventListener(SWIPE_QUICK_ACTION_CLOSE_EVENT, handleClose)
     panelRoot.addEventListener(SWIPE_QUICK_ACTION_RUN_EVENT, handleRun)
+    panelRoot.addEventListener(SWIPE_QUICK_ACTION_PROGRESS_EVENT, handleProgress)
     return () => {
       panelRoot.removeEventListener(SWIPE_QUICK_ACTION_OPEN_EVENT, handleOpen)
       panelRoot.removeEventListener(SWIPE_QUICK_ACTION_CLOSE_EVENT, handleClose)
       panelRoot.removeEventListener(SWIPE_QUICK_ACTION_RUN_EVENT, handleRun)
+      panelRoot.removeEventListener(SWIPE_QUICK_ACTION_PROGRESS_EVENT, handleProgress)
     }
-  }, [activeBlockId, panelRoot, runBlockAction])
+  }, [activeBlockId, dragOffsetPercent, panelRoot, previewBlockId, runBlockAction, startSettle, clearSettleTimer])
 
   useEffect(() => {
     if (!activeBlockId || !isMobile || !panelRoot) return
@@ -378,11 +507,17 @@ export const SwipeActionMenu = () => {
     <div ref={inlineAnchorRef} className="swipe-action-menu-anchor" aria-hidden="true"/>
   )
 
-  if (!isMobile || !activeBlockId || !anchor) return inlineAnchor
+  // Render whenever the menu is committed OR a swipe preview is in
+  // flight. The preview branch lets the toolbar slide in tracking the
+  // finger before commit, matching the Workflowy-style pull-out.
+  const renderedBlockId = activeBlockId ?? previewBlockId
+  if (!isMobile || !renderedBlockId || !anchor) return inlineAnchor
 
   // The block whose handler we'll dispatch lives in this panel; resolve
-  // it from the active id via the same repo that owns uiStateBlock.
-  const block = repo.block(activeBlockId)
+  // it via the same repo that owns uiStateBlock. Buttons only become
+  // tappable once activeBlockId is set, so a preview can safely
+  // reference a block that might disappear between drag and commit.
+  const block = repo.block(renderedBlockId)
   if (!block.peek()) return inlineAnchor
 
   /** Dispatch the resolved action's handler with our block-level deps.
@@ -432,6 +567,22 @@ export const SwipeActionMenu = () => {
 
   const handleMenuTouchMove = (event: TouchEvent) => {
     event.stopPropagation()
+    const touch = trackedMenuTouch(event)
+    const start = menuTouchStartRef.current
+    if (!touch || !start) return
+
+    const dx = touch.clientX - start.x
+    const dy = touch.clientY - start.y
+
+    // Live-track the close-drag: as the finger moves right we slide
+    // the menu out proportionally. Only kick in once the gesture is
+    // clearly horizontal-rightward, otherwise vertical scroll-like
+    // micromotion would jitter the offset.
+    if (dx > 0 && Math.abs(dx) > Math.abs(dy)) {
+      clearSettleTimer()
+      setIsSettling(false)
+      setDragOffsetPercent(computeCloseHidePercent(dx))
+    }
   }
 
   const handleMenuTouchEnd = (event: TouchEvent) => {
@@ -443,15 +594,26 @@ export const SwipeActionMenu = () => {
     menuTouchStartRef.current = null
     const dx = touch.clientX - start.x
     const dy = touch.clientY - start.y
-    if (dx < SWIPE_TRIGGER_PX || Math.abs(dx) <= Math.abs(dy)) return
 
-    event.preventDefault()
-    dismiss()
+    // Past commit threshold and clearly horizontal → animate fully out
+    // and dismiss. Below threshold but with a live drag offset → snap
+    // back to fully open. Otherwise the touch was a tap / scroll and
+    // we leave the menu as-is.
+    if (dx >= SWIPE_TRIGGER_PX && Math.abs(dx) > Math.abs(dy)) {
+      event.preventDefault()
+      startSettle('closed')
+    } else if (dragOffsetPercent !== null) {
+      startSettle('open')
+    }
   }
 
   const handleMenuTouchCancel = (event: TouchEvent) => {
     event.stopPropagation()
-    if (trackedMenuTouch(event)) menuTouchStartRef.current = null
+    if (trackedMenuTouch(event)) {
+      menuTouchStartRef.current = null
+      // If the drag put the menu mid-way out, recover to fully open.
+      if (dragOffsetPercent !== null) startSettle('open')
+    }
   }
 
   // Align the strip's vertical center to the swiped row's center so it
@@ -464,14 +626,32 @@ export const SwipeActionMenu = () => {
     window.innerHeight - toolbarHeight / 2,
   )
 
+  // Compose translateY(-50%) for vertical-row centering with translateX
+  // for the swipe reveal. The hide percent is 0 when the menu is at
+  // rest open, 100 when fully parked off-screen right, and a live value
+  // in between while dragging or settling.
+  const hidePercent = dragOffsetPercent ?? (activeBlockId ? 0 : 100)
+  const toolbarTransform = `translate(${hidePercent}%, -50%)`
+  const toolbarTransition = isSettling
+    ? `transform ${SETTLE_DURATION_MS}ms ease-out`
+    : undefined
+
   return (
     <>
       {inlineAnchor}
       {createPortal(
         <div
           ref={containerRef}
-          className="swipe-action-menu fixed left-0 right-0 z-50 -translate-y-1/2"
-          style={{top: `${toolbarTop}px`}}
+          className="swipe-action-menu fixed left-0 right-0 z-50"
+          style={{
+            top: `${toolbarTop}px`,
+            transform: toolbarTransform,
+            transition: toolbarTransition,
+            // Hint the compositor while a drag is in flight; once
+            // settled we drop the hint so the browser can recycle the
+            // layer.
+            willChange: dragOffsetPercent !== null ? 'transform' : undefined,
+          }}
           data-block-interaction="ignore"
           onTouchStart={handleMenuTouchStart}
           onTouchMove={handleMenuTouchMove}

--- a/src/plugins/swipe-quick-actions/events.ts
+++ b/src/plugins/swipe-quick-actions/events.ts
@@ -6,12 +6,26 @@ export interface SwipeQuickActionRunEventDetail extends SwipeQuickActionMenuEven
   actionId: string
 }
 
+/** Streamed during an in-flight horizontal swipe so SwipeActionMenu can
+ *  render the toolbar tracking the finger. `dx` is the horizontal delta
+ *  from the gesture's starting point — negative while dragging left to
+ *  open. Phase `active` fires on every touchmove past the direction
+ *  lock; `cancel` fires once on release when the swipe didn't commit,
+ *  so the menu can animate back to hidden. Commits dispatch the OPEN
+ *  event instead and the menu treats that as its settle target. */
+export interface SwipeQuickActionProgressEventDetail extends SwipeQuickActionMenuEventDetail {
+  dx: number
+  phase: 'active' | 'cancel'
+}
+
 export type SwipeQuickActionMenuEvent = CustomEvent<SwipeQuickActionMenuEventDetail>
 export type SwipeQuickActionRunEvent = CustomEvent<SwipeQuickActionRunEventDetail>
+export type SwipeQuickActionProgressEvent = CustomEvent<SwipeQuickActionProgressEventDetail>
 
 export const SWIPE_QUICK_ACTION_OPEN_EVENT = 'swipe-quick-actions:open'
 export const SWIPE_QUICK_ACTION_CLOSE_EVENT = 'swipe-quick-actions:close'
 export const SWIPE_QUICK_ACTION_RUN_EVENT = 'swipe-quick-actions:run'
+export const SWIPE_QUICK_ACTION_PROGRESS_EVENT = 'swipe-quick-actions:progress'
 
 export const isSwipeQuickActionMenuEvent = (
   event: Event,
@@ -26,6 +40,13 @@ export const isSwipeQuickActionRunEvent = (
 ): event is SwipeQuickActionRunEvent =>
   isSwipeQuickActionMenuEvent(event) &&
   typeof (event.detail as {actionId?: unknown}).actionId === 'string'
+
+export const isSwipeQuickActionProgressEvent = (
+  event: Event,
+): event is SwipeQuickActionProgressEvent =>
+  isSwipeQuickActionMenuEvent(event) &&
+  typeof (event.detail as {dx?: unknown}).dx === 'number' &&
+  typeof (event.detail as {phase?: unknown}).phase === 'string'
 
 export const dispatchSwipeQuickActionMenuEvent = (
   target: EventTarget,
@@ -47,4 +68,16 @@ export const dispatchSwipeQuickActionRunEvent = (
     bubbles: true,
     cancelable: true,
     detail: {blockId, actionId},
+  }))
+
+export const dispatchSwipeQuickActionProgressEvent = (
+  target: EventTarget,
+  blockId: string,
+  dx: number,
+  phase: 'active' | 'cancel',
+): boolean =>
+  target.dispatchEvent(new CustomEvent<SwipeQuickActionProgressEventDetail>(SWIPE_QUICK_ACTION_PROGRESS_EVENT, {
+    bubbles: true,
+    cancelable: true,
+    detail: {blockId, dx, phase},
   }))

--- a/src/plugins/swipe-quick-actions/swipeGesture.ts
+++ b/src/plugins/swipe-quick-actions/swipeGesture.ts
@@ -7,6 +7,7 @@ import { focusedBlockIdProp, isEditingProp } from '@/data/properties.ts'
 import type { Block } from '@/data/block'
 import {
   dispatchSwipeQuickActionMenuEvent,
+  dispatchSwipeQuickActionProgressEvent,
   dispatchSwipeQuickActionRunEvent,
   SWIPE_QUICK_ACTION_CLOSE_EVENT,
   SWIPE_QUICK_ACTION_OPEN_EVENT,
@@ -156,6 +157,15 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
       // later horizontal pivot mid-scroll doesn't surprise the user.
       if (start.decided === 'vertical') {
         touchStartByBlockId.delete(block.id)
+        return
+      }
+
+      // Stream live progress for the toolbar reveal preview. Only the
+      // leftward (opening) gesture has a preview — right-swipe on the
+      // closed block surface runs a semantic action and doesn't need
+      // intermediate visual feedback.
+      if (start.decided === 'horizontal' && dx < 0 && !isBlockEditing(block.id, uiStateBlock)) {
+        dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'active')
       }
     },
 
@@ -175,8 +185,19 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
       const dx = touch.clientX - start.x
       const dy = touch.clientY - start.y
 
+      // Whether we previewed an open during the drag — set whenever a
+      // progress 'active' event would have been dispatched. We owe the
+      // menu a 'cancel' event in any branch that doesn't end up opening,
+      // so it can animate the toolbar back to hidden.
+      const previewed = dx < 0 && !isBlockEditing(block.id, uiStateBlock)
+
       // Horizontal-only — vertical scrolls and taps are someone else's job.
-      if (Math.abs(dx) <= Math.abs(dy)) return
+      if (Math.abs(dx) <= Math.abs(dy)) {
+        if (previewed) {
+          dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'cancel')
+        }
+        return
+      }
 
       // Swipe-left opens this block's menu in this panel. Swipe-right on
       // the block surface runs the semantic block action; if no mounted
@@ -194,6 +215,9 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
         if (handled) {
           event.preventDefault()
           event.stopPropagation()
+        } else if (previewed) {
+          // Open wasn't accepted by any panel — settle the preview back.
+          dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'cancel')
         }
       } else if (dx >= SWIPE_TRIGGER_PX) {
         const actionHandled = !dispatchSwipeQuickActionRunEvent(
@@ -216,6 +240,10 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
           event.preventDefault()
           event.stopPropagation()
         }
+      } else if (previewed) {
+        // Insufficient leftward swipe; tell the menu to animate the
+        // preview back to hidden.
+        dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'cancel')
       }
     },
 
@@ -228,6 +256,12 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
       // in play.
       if (findTrackedTouch(event.changedTouches, start.identifier)) {
         touchStartByBlockId.delete(block.id)
+        // If we had been previewing, settle back. The dx isn't
+        // recoverable here so we pass 0 — the menu just needs the
+        // 'cancel' signal to start its hide animation.
+        if (start.decided === 'horizontal') {
+          dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, 0, 'cancel')
+        }
       }
     },
   }

--- a/src/plugins/swipe-quick-actions/swipeGesture.ts
+++ b/src/plugins/swipe-quick-actions/swipeGesture.ts
@@ -28,6 +28,13 @@ interface TouchStart {
   /** Once a horizontal-swipe intent is locked in, we set this so further
    *  movement doesn't keep re-evaluating direction. */
   decided: 'horizontal' | 'vertical' | null
+  /** True once we've emitted at least one 'active' progress event for
+   *  this gesture. We owe the menu a matching 'cancel' on any exit
+   *  path that doesn't commit to opening — including the case where
+   *  the finger crossed zero on the way out and the final `dx` is no
+   *  longer negative. Re-deriving from the final dx would miss those
+   *  reversed gestures and leave the toolbar stuck partially revealed. */
+  previewed: boolean
 }
 
 const touchStartByBlockId = new Map<string, TouchStart>()
@@ -132,6 +139,7 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
         time: Date.now(),
         identifier: touch.identifier,
         decided: null,
+        previewed: false,
       })
     },
 
@@ -165,6 +173,7 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
       // closed block surface runs a semantic action and doesn't need
       // intermediate visual feedback.
       if (start.decided === 'horizontal' && dx < 0 && !isBlockEditing(block.id, uiStateBlock)) {
+        start.previewed = true
         dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'active')
       }
     },
@@ -184,65 +193,57 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
 
       const dx = touch.clientX - start.x
       const dy = touch.clientY - start.y
-
-      // Whether we previewed an open during the drag — set whenever a
-      // progress 'active' event would have been dispatched. We owe the
-      // menu a 'cancel' event in any branch that doesn't end up opening,
-      // so it can animate the toolbar back to hidden.
-      const previewed = dx < 0 && !isBlockEditing(block.id, uiStateBlock)
+      const previewed = start.previewed
+      let openCommitted = false
 
       // Horizontal-only — vertical scrolls and taps are someone else's job.
-      if (Math.abs(dx) <= Math.abs(dy)) {
-        if (previewed) {
-          dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'cancel')
-        }
-        return
-      }
-
       // Swipe-left opens this block's menu in this panel. Swipe-right on
       // the block surface runs the semantic block action; if no mounted
       // runtime handles that action, we preserve the old fallback of
       // asking the panel menu to dismiss when anchored here. A rightward
       // swipe directly on the open menu/toolbar is handled inside
       // SwipeActionMenu itself and remains the close gesture.
-      if (dx <= -SWIPE_TRIGGER_PX) {
-        if (isBlockEditing(block.id, uiStateBlock)) return
-        const handled = !dispatchSwipeQuickActionMenuEvent(
-          event.currentTarget,
-          SWIPE_QUICK_ACTION_OPEN_EVENT,
-          block.id,
-        )
-        if (handled) {
-          event.preventDefault()
-          event.stopPropagation()
-        } else if (previewed) {
-          // Open wasn't accepted by any panel — settle the preview back.
-          dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'cancel')
+      if (Math.abs(dx) > Math.abs(dy)) {
+        if (dx <= -SWIPE_TRIGGER_PX && !isBlockEditing(block.id, uiStateBlock)) {
+          const handled = !dispatchSwipeQuickActionMenuEvent(
+            event.currentTarget,
+            SWIPE_QUICK_ACTION_OPEN_EVENT,
+            block.id,
+          )
+          if (handled) {
+            event.preventDefault()
+            event.stopPropagation()
+            openCommitted = true
+          }
+        } else if (dx >= SWIPE_TRIGGER_PX) {
+          const actionHandled = !dispatchSwipeQuickActionRunEvent(
+            event.currentTarget,
+            SWIPE_RIGHT_BLOCK_ACTION_ID,
+            block.id,
+          )
+          if (actionHandled) {
+            event.preventDefault()
+            event.stopPropagation()
+          } else {
+            const handled = !dispatchSwipeQuickActionMenuEvent(
+              event.currentTarget,
+              SWIPE_QUICK_ACTION_CLOSE_EVENT,
+              block.id,
+            )
+            if (handled) {
+              event.preventDefault()
+              event.stopPropagation()
+            }
+          }
         }
-      } else if (dx >= SWIPE_TRIGGER_PX) {
-        const actionHandled = !dispatchSwipeQuickActionRunEvent(
-          event.currentTarget,
-          SWIPE_RIGHT_BLOCK_ACTION_ID,
-          block.id,
-        )
-        if (actionHandled) {
-          event.preventDefault()
-          event.stopPropagation()
-          return
-        }
+      }
 
-        const handled = !dispatchSwipeQuickActionMenuEvent(
-          event.currentTarget,
-          SWIPE_QUICK_ACTION_CLOSE_EVENT,
-          block.id,
-        )
-        if (handled) {
-          event.preventDefault()
-          event.stopPropagation()
-        }
-      } else if (previewed) {
-        // Insufficient leftward swipe; tell the menu to animate the
-        // preview back to hidden.
+      // If we previewed during the drag and didn't commit to opening,
+      // tell the menu to animate the toolbar back. Catches every
+      // non-committing exit, including the reversed-past-zero case
+      // (drag left, then back right) where final dx wouldn't tell us
+      // a preview was in flight.
+      if (previewed && !openCommitted) {
         dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, dx, 'cancel')
       }
     },
@@ -259,7 +260,7 @@ export const swipeQuickActionsContentSurface: BlockContentSurfaceContribution = 
         // If we had been previewing, settle back. The dx isn't
         // recoverable here so we pass 0 — the menu just needs the
         // 'cancel' signal to start its hide animation.
-        if (start.decided === 'horizontal') {
+        if (start.previewed) {
           dispatchSwipeQuickActionProgressEvent(event.currentTarget, block.id, 0, 'cancel')
         }
       }

--- a/src/plugins/swipe-quick-actions/test/swipeGesture.test.ts
+++ b/src/plugins/swipe-quick-actions/test/swipeGesture.test.ts
@@ -12,8 +12,10 @@ import { swipeQuickActionsContentSurface } from '../swipeGesture.ts'
 import {
   SWIPE_QUICK_ACTION_CLOSE_EVENT,
   SWIPE_QUICK_ACTION_OPEN_EVENT,
+  SWIPE_QUICK_ACTION_PROGRESS_EVENT,
   SWIPE_QUICK_ACTION_RUN_EVENT,
   type SwipeQuickActionMenuEvent,
+  type SwipeQuickActionProgressEvent,
   type SwipeQuickActionRunEvent,
 } from '../events.ts'
 import { SWIPE_RIGHT_BLOCK_ACTION_ID } from '../actions.ts'
@@ -97,6 +99,17 @@ const recordCloseEvents = (
     if (menuEvent.detail.blockId === activeBlockId) event.preventDefault()
   })
   return closed
+}
+
+const recordProgressEvents = (
+  target: EventTarget,
+): Array<{blockId: string; dx: number; phase: 'active' | 'cancel'}> => {
+  const progress: Array<{blockId: string; dx: number; phase: 'active' | 'cancel'}> = []
+  target.addEventListener(SWIPE_QUICK_ACTION_PROGRESS_EVENT, event => {
+    const detail = (event as SwipeQuickActionProgressEvent).detail
+    progress.push({blockId: detail.blockId, dx: detail.dx, phase: detail.phase})
+  })
+  return progress
 }
 
 const recordRunEvents = (target: EventTarget): Array<{blockId: string; actionId: string}> => {
@@ -330,6 +343,56 @@ describe('swipe-quick-actions gesture', () => {
     props.onTouchStart?.(touchEvent('changedTouches', second, surface))
     props.onTouchEnd?.(touchEvent('changedTouches', touch(120, 100, 1), surface))
     expect(opened).toEqual(['b-lock'])
+  })
+
+  it('streams progress events during a leftward drag and stops on cancel', () => {
+    const surface = document.createElement('div')
+    const progress = recordProgressEvents(surface)
+    const props = handlers(makeContext('b-preview'))
+
+    props.onTouchStart?.(touchEvent('changedTouches', touch(200, 100), surface))
+    // Two move samples mid-drag — direction lock decides 'horizontal'
+    // immediately because |dx|>|dy| at the first sample past the lock
+    // threshold, so both samples should fire 'active' progress.
+    props.onTouchMove?.(touchEvent('touches', touch(180, 102), surface))
+    props.onTouchMove?.(touchEvent('touches', touch(160, 102), surface))
+    // Release short of the trigger threshold — should emit a 'cancel'
+    // so the menu can animate the toolbar back.
+    props.onTouchEnd?.(touchEvent('changedTouches', touch(170, 102), surface))
+
+    expect(progress.map(p => p.phase)).toEqual(['active', 'active', 'cancel'])
+    expect(progress.every(p => p.blockId === 'b-preview')).toBe(true)
+    expect(progress[0].dx).toBe(-20)
+    expect(progress[1].dx).toBe(-40)
+  })
+
+  it('omits the trailing cancel when the swipe commits to opening', () => {
+    const surface = document.createElement('div')
+    const progress = recordProgressEvents(surface)
+    recordOpenEvents(surface)
+    const props = handlers(makeContext('b-commit'))
+
+    props.onTouchStart?.(touchEvent('changedTouches', touch(200, 100), surface))
+    props.onTouchMove?.(touchEvent('touches', touch(150, 102), surface))
+    props.onTouchEnd?.(touchEvent('changedTouches', touch(120, 102), surface))
+
+    // Active was streamed during the move; the commit path delegates
+    // the "finalize" to the OPEN event, not a cancel, so the menu can
+    // settle into the open state instead of bouncing back.
+    expect(progress.map(p => p.phase)).toEqual(['active'])
+  })
+
+  it('does not preview right-swipe drags', () => {
+    const surface = document.createElement('div')
+    const progress = recordProgressEvents(surface)
+    const props = handlers(makeContext('b-right-only'))
+
+    props.onTouchStart?.(touchEvent('changedTouches', touch(50, 100), surface))
+    props.onTouchMove?.(touchEvent('touches', touch(90, 102), surface))
+    props.onTouchEnd?.(touchEvent('changedTouches', touch(140, 102), surface))
+
+    // Right-swipe runs a semantic action and has no toolbar preview.
+    expect(progress).toEqual([])
   })
 
   it('does not open the menu on non-mobile viewports', () => {

--- a/src/plugins/swipe-quick-actions/test/swipeGesture.test.ts
+++ b/src/plugins/swipe-quick-actions/test/swipeGesture.test.ts
@@ -382,6 +382,26 @@ describe('swipe-quick-actions gesture', () => {
     expect(progress.map(p => p.phase)).toEqual(['active'])
   })
 
+  it('emits cancel when a left-swipe preview reverses past zero before lift', () => {
+    const surface = document.createElement('div')
+    const progress = recordProgressEvents(surface)
+    const props = handlers(makeContext('b-reverse'))
+
+    props.onTouchStart?.(touchEvent('changedTouches', touch(200, 100), surface))
+    // Drag left enough to register as a preview.
+    props.onTouchMove?.(touchEvent('touches', touch(170, 102), surface))
+    // Reverse past the starting point — final dx is now positive but
+    // below the right-swipe trigger.
+    props.onTouchMove?.(touchEvent('touches', touch(210, 102), surface))
+    props.onTouchEnd?.(touchEvent('changedTouches', touch(210, 102), surface))
+
+    const phases = progress.map(p => p.phase)
+    // At minimum: at least one active, and a cancel at the end so the
+    // toolbar doesn't get stranded partially revealed.
+    expect(phases[0]).toBe('active')
+    expect(phases[phases.length - 1]).toBe('cancel')
+  })
+
   it('does not preview right-swipe drags', () => {
     const surface = document.createElement('div')
     const progress = recordProgressEvents(surface)


### PR DESCRIPTION
Adds Workflowy-style proportional reveal to the left-swipe pull-out and
the right-swipe close: instead of the toolbar popping in/out only at the
trigger point, it slides with the finger during the drag and snaps
either to fully open or back to hidden on release.

* New SWIPE_QUICK_ACTION_PROGRESS_EVENT streamed from the gesture handler
  on every touchmove past the direction lock (and a final 'cancel' on
  release without commit).
* SwipeActionMenu renders during the preview, anchored to the dragged
  block, with translateX driven by drag distance. Full reveal at 100px
  > 50px commit threshold, so releasing right at trigger plays the
  "completes appearing" snap.
* Right-swipe-to-close on the open menu mirrors the same logic: the
  toolbar slides out as the finger moves, snaps closed past trigger or
  back open below it. Touchcancel recovers the offset.