### PR TITLE
Make today highlight in reschedule scrub more prominent

### DIFF
--- a/src/plugins/daily-notes/ReschedulePicker.tsx
+++ b/src/plugins/daily-notes/ReschedulePicker.tsx
@@ -326,7 +326,7 @@ export const ReschedulePicker = () => {
                     isSelected
                       ? 'border-primary bg-primary text-primary-foreground'
                       : cell.isToday
-                        ? 'border-primary bg-primary/10 text-primary'
+                        ? 'border-2 border-primary bg-primary/20 font-semibold text-primary shadow-sm ring-1 ring-primary/40'
                         : 'border-border bg-background text-foreground hover:bg-muted',
                   )}
                 >


### PR DESCRIPTION
## Summary
- Bumps the today cell in the reschedule scrub strip to a 2px primary border, 20% primary background, semibold primary text, a soft outer ring, and a small shadow.
- Stays clearly distinct from the solid filled selected style, but is unmistakable against default cells.

Stacked on top of #(label-fix PR for `claude/highlight-today-reschedule-30BOP`) — that PR fixes the mislabeled "today" cell and lays down a baseline today highlight; this one cranks the prominence up.

## Test plan
- [ ] Open the Reschedule Date Picker on a mobile block where the original date ≠ today; confirm the today cell in the Quick scrub strip is clearly highlighted at a glance and visually distinct from both default cells and the selected cell.
- [ ] Tap a different date in the strip; confirm today stays highlighted after the selection moves away from it.
- [ ] Verify the today cell when it's also the original (offset 0) — selected style should still win on open.


---
_Generated by [Claude Code](https://claude.ai/code/session_016gqhKX2XpfyLFVqrQHRUGY)_