### PR TITLE
Surround selected text with the [[ and (( toolbar quick actions

### DIFF
--- a/src/plugins/mobile-keyboard-toolbar/actions.test.ts
+++ b/src/plugins/mobile-keyboard-toolbar/actions.test.ts
@@ -1,0 +1,83 @@
+import { EditorSelection, EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { describe, expect, it } from 'vitest'
+import type { ActionConfig, ActionContextTypes as ContextTypes, CodeMirrorEditModeDependencies } from '@/shortcuts/types.ts'
+import {
+  INSERT_BLOCK_REF_TRIGGER_ACTION_ID,
+  INSERT_PAGE_REF_TRIGGER_ACTION_ID,
+  mobileKeyboardToolbarActions,
+} from './actions.ts'
+
+type EditModeAction = ActionConfig<typeof ContextTypes.EDIT_MODE_CM>
+
+const findAction = (id: string): EditModeAction => {
+  const action = mobileKeyboardToolbarActions.find(candidate => candidate.id === id)
+  if (!action) throw new Error(`Action not found: ${id}`)
+  return action
+}
+
+const makeView = (doc: string, anchor: number, head = anchor): EditorView => {
+  const parent = document.createElement('div')
+  document.body.appendChild(parent)
+  return new EditorView({
+    state: EditorState.create({
+      doc,
+      selection: EditorSelection.create([EditorSelection.range(anchor, head)]),
+    }),
+    parent,
+  })
+}
+
+const runAction = async (action: EditModeAction, view: EditorView) => {
+  const deps = {editorView: view} as CodeMirrorEditModeDependencies
+  const trigger = new CustomEvent('test')
+  await action.handler(deps, trigger)
+  const selection = view.state.selection.main
+  return {
+    doc: view.state.doc.toString(),
+    from: selection.from,
+    to: selection.to,
+  }
+}
+
+describe('mobile keyboard toolbar completion-trigger actions', () => {
+  it('inserts an empty page-ref pair at the cursor and places the caret between brackets', async () => {
+    const view = makeView('hello ', 6)
+    expect(await runAction(findAction(INSERT_PAGE_REF_TRIGGER_ACTION_ID), view)).toEqual({
+      doc: 'hello [[]]',
+      from: 8,
+      to: 8,
+    })
+    view.destroy()
+  })
+
+  it('surrounds the selected text with double brackets instead of replacing it', async () => {
+    const view = makeView('hello world', 6, 11)
+    expect(await runAction(findAction(INSERT_PAGE_REF_TRIGGER_ACTION_ID), view)).toEqual({
+      doc: 'hello [[world]]',
+      from: 8,
+      to: 13,
+    })
+    view.destroy()
+  })
+
+  it('inserts an empty block-ref pair at the cursor and places the caret between parens', async () => {
+    const view = makeView('hello ', 6)
+    expect(await runAction(findAction(INSERT_BLOCK_REF_TRIGGER_ACTION_ID), view)).toEqual({
+      doc: 'hello (())',
+      from: 8,
+      to: 8,
+    })
+    view.destroy()
+  })
+
+  it('surrounds the selected text with double parens for block refs', async () => {
+    const view = makeView('hello world', 6, 11)
+    expect(await runAction(findAction(INSERT_BLOCK_REF_TRIGGER_ACTION_ID), view)).toEqual({
+      doc: 'hello ((world))',
+      from: 8,
+      to: 13,
+    })
+    view.destroy()
+  })
+})

--- a/src/plugins/mobile-keyboard-toolbar/actions.ts
+++ b/src/plugins/mobile-keyboard-toolbar/actions.ts
@@ -11,13 +11,24 @@ export const INSERT_BLOCK_REF_TRIGGER_ACTION_ID = 'edit.cm.insert_block_ref_trig
 
 const insertCompletionTrigger = (
   editorView: CodeMirrorEditModeDependencies['editorView'],
-  text: string,
-  cursorOffset = text.length,
+  open: string,
+  close: string,
 ) => {
-  editorView.dispatch(editorView.state.changeByRange(range => ({
-    changes: {from: range.from, to: range.to, insert: text},
-    range: EditorSelection.cursor(range.from + cursorOffset),
-  })))
+  const {state} = editorView
+  editorView.dispatch(state.changeByRange(range => {
+    if (range.empty) {
+      return {
+        changes: {from: range.from, insert: `${open}${close}`},
+        range: EditorSelection.cursor(range.from + open.length),
+      }
+    }
+
+    const selectedText = state.sliceDoc(range.from, range.to)
+    return {
+      changes: {from: range.from, to: range.to, insert: `${open}${selectedText}${close}`},
+      range: EditorSelection.range(range.from + open.length, range.to + open.length),
+    }
+  }))
   editorView.focus()
   startCompletion(editorView)
 }
@@ -25,14 +36,14 @@ const insertCompletionTrigger = (
 const completionTriggerAction = (
   id: string,
   description: string,
-  text: string,
-  cursorOffset?: number,
+  open: string,
+  close: string,
 ): ActionConfig<typeof ActionContextTypes.EDIT_MODE_CM> => ({
   id,
   description,
   context: ActionContextTypes.EDIT_MODE_CM,
   handler: async (deps) => {
-    insertCompletionTrigger(deps.editorView, text, cursorOffset)
+    insertCompletionTrigger(deps.editorView, open, close)
   },
 })
 
@@ -40,13 +51,13 @@ export const mobileKeyboardToolbarActions: readonly ActionConfig<typeof ActionCo
   completionTriggerAction(
     INSERT_PAGE_REF_TRIGGER_ACTION_ID,
     'Insert page reference trigger',
-    '[[]]',
-    2,
+    '[[',
+    ']]',
   ),
   completionTriggerAction(
     INSERT_BLOCK_REF_TRIGGER_ACTION_ID,
     'Insert block reference trigger',
-    '(())',
-    2,
+    '((',
+    '))',
   ),
 ]

--- a/src/plugins/mobile-keyboard-toolbar/actions.ts
+++ b/src/plugins/mobile-keyboard-toolbar/actions.ts
@@ -1,10 +1,10 @@
 import { startCompletion } from '@codemirror/autocomplete'
-import { EditorSelection } from '@codemirror/state'
 import {
   ActionContextTypes,
   type ActionConfig,
   type CodeMirrorEditModeDependencies,
 } from '@/shortcuts/types.ts'
+import { wrapRangeWithPair } from '@/utils/codemirror.ts'
 
 export const INSERT_PAGE_REF_TRIGGER_ACTION_ID = 'edit.cm.insert_page_ref_trigger'
 export const INSERT_BLOCK_REF_TRIGGER_ACTION_ID = 'edit.cm.insert_block_ref_trigger'
@@ -15,20 +15,7 @@ const insertCompletionTrigger = (
   close: string,
 ) => {
   const {state} = editorView
-  editorView.dispatch(state.changeByRange(range => {
-    if (range.empty) {
-      return {
-        changes: {from: range.from, insert: `${open}${close}`},
-        range: EditorSelection.cursor(range.from + open.length),
-      }
-    }
-
-    const selectedText = state.sliceDoc(range.from, range.to)
-    return {
-      changes: {from: range.from, to: range.to, insert: `${open}${selectedText}${close}`},
-      range: EditorSelection.range(range.from + open.length, range.to + open.length),
-    }
-  }))
+  editorView.dispatch(state.changeByRange(range => wrapRangeWithPair(state, range, open, close)))
   editorView.focus()
   startCompletion(editorView)
 }

--- a/src/utils/codemirror.ts
+++ b/src/utils/codemirror.ts
@@ -1,13 +1,36 @@
-import { EditorSelection, type Extension, type StateCommand } from '@codemirror/state'
+import { EditorSelection, type EditorState, type Extension, type SelectionRange, type StateCommand } from '@codemirror/state'
 import { EditorView, keymap, type KeyBinding } from '@codemirror/view'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { javascript } from '@codemirror/lang-javascript'
 
+/** Produce the change/range spec for one selection range that either
+ *  inserts an empty `open`/`close` pair at the cursor or wraps the
+ *  selection with them, keeping the selection inside the wrappers.
+ *  Shared by the markdown formatting commands (bold/italic/etc.) and
+ *  the mobile toolbar's page-ref / block-ref completion triggers. */
+export const wrapRangeWithPair = (
+  state: EditorState,
+  range: SelectionRange,
+  open: string,
+  close: string = open,
+) => {
+  if (range.empty) {
+    return {
+      changes: {from: range.from, insert: `${open}${close}`},
+      range: EditorSelection.cursor(range.from + open.length),
+    }
+  }
+
+  const selectedText = state.sliceDoc(range.from, range.to)
+  return {
+    changes: {from: range.from, to: range.to, insert: `${open}${selectedText}${close}`},
+    range: EditorSelection.range(range.from + open.length, range.to + open.length),
+  }
+}
+
 const markdownInlineFormatCommand = (open: string, close = open): StateCommand =>
   ({state, dispatch}) => {
     const transaction = state.changeByRange(range => {
-      const selectedText = state.sliceDoc(range.from, range.to)
-
       if (range.empty) {
         const isBetweenMarkers =
           range.from >= open.length &&
@@ -25,12 +48,10 @@ const markdownInlineFormatCommand = (open: string, close = open): StateCommand =
           }
         }
 
-        return {
-          changes: {from: range.from, insert: `${open}${close}`},
-          range: EditorSelection.cursor(range.from + open.length),
-        }
+        return wrapRangeWithPair(state, range, open, close)
       }
 
+      const selectedText = state.sliceDoc(range.from, range.to)
       const isWrappedSelection =
         selectedText.startsWith(open) &&
         selectedText.endsWith(close) &&
@@ -62,10 +83,7 @@ const markdownInlineFormatCommand = (open: string, close = open): StateCommand =
         }
       }
 
-      return {
-        changes: {from: range.from, to: range.to, insert: `${open}${selectedText}${close}`},
-        range: EditorSelection.range(range.from + open.length, range.to + open.length),
-      }
+      return wrapRangeWithPair(state, range, open, close)
     })
 
     dispatch(state.update(transaction))


### PR DESCRIPTION
Previously these toolbar buttons unconditionally replaced the active
range with [[]] or (()), discarding the selected text. They now mirror
the decoration commands (bold/italic/etc.): wrap the selection with the
opener and closer, keeping the selection intact for the autocomplete
popover to filter against.