### PR TITLE
Index a queryable date property on daily notes

### DIFF
--- a/src/data/api/codecs.test.ts
+++ b/src/data/api/codecs.test.ts
@@ -52,6 +52,19 @@ describe('codec where capability', () => {
     expect(codecs.date.where!.encode(d)).toBe('2026-04-29T12:34:56.789Z')
   })
 
+  it('date.where also accepts an already-encoded ISO string (idempotent)', () => {
+    // Persisted operator predicates (e.g. backlinks:predicates) go
+    // through JSON.stringify, which turns Date instances into ISO
+    // strings. On reload the compiler re-runs `where.encode` on the
+    // rehydrated value; rejecting the string would break every saved
+    // date-range filter. Both shapes normalise to the same scalar.
+    const iso = '2026-04-29T12:34:56.789Z'
+    expect(codecs.date.where!.encode(iso as unknown as Date)).toBe(iso)
+    // Strings that don't parse as dates still throw.
+    expect(() => codecs.date.where!.encode('not-a-date' as unknown as Date))
+      .toThrow(CodecError)
+  })
+
   it('validates input types and rejects mismatches', () => {
     expect(() => codecs.string.where!.encode(42 as unknown as string)).toThrow(CodecError)
     expect(() => codecs.boolean.where!.encode('true' as unknown as boolean)).toThrow(CodecError)

--- a/src/data/api/codecs.ts
+++ b/src/data/api/codecs.ts
@@ -124,6 +124,19 @@ const dateCodec: Codec<Date | undefined> = {
       // before reaching where.encode. undefined arriving here is a
       // caller bug — typed-query callers use null for unset matching.
       if (v === undefined) throw new CodecError('date (use null for unset)', v)
+      // Accept both Date instances and the already-encoded ISO string
+      // form: persisted operator predicates (e.g. backlinks chips
+      // saved to `backlinks:predicates`) round-trip through JSON,
+      // which turns a Date into its ISO string. The compiler re-runs
+      // `where.encode` on the rehydrated value, so rejecting strings
+      // would break every saved date-range filter on reload. Both
+      // shapes normalise to the same ISO string so storage stays
+      // bit-stable. Strings that don't parse as dates still throw.
+      if (typeof v === 'string') {
+        const d = new Date(v)
+        if (Number.isNaN(d.getTime())) throw new CodecError('date', v)
+        return d.toISOString()
+      }
       if (!(v instanceof Date) || Number.isNaN(v.getTime())) throw new CodecError('date', v)
       return v.toISOString()
     },

--- a/src/data/api/typedBlockQuery.ts
+++ b/src/data/api/typedBlockQuery.ts
@@ -19,7 +19,25 @@ export interface TypedBlockQueryReferenceFilter {
  *  validate identically to their equality-form counterparts. `between`
  *  is inclusive on both ends. `exists` takes a boolean — `true` for
  *  "property is set" (`IS NOT NULL`), `false` for "unset" (`IS NULL`,
- *  same as the `null` shorthand). */
+ *  same as the `null` shorthand).
+ *
+ *  `target` is the ref-traversal operator. Valid only on `ref`-typed
+ *  (and `refList`-typed) properties; the operand is an inner where-map
+ *  compiled against the referenced block's `properties_json`. Lets
+ *  callers ask "this ref points to a block whose <inner where> holds"
+ *  without bouncing through `referencedBy`, which only knows equality
+ *  on the target id. Example — find blocks whose `next-review-date`
+ *  ref points to a daily note whose `daily-note:date` is in the past:
+ *
+ *    where: {
+ *      'next-review-date': {
+ *        target: { 'daily-note:date': { lt: new Date() } }
+ *      }
+ *    }
+ *
+ *  The compiler stays plugin-agnostic — it doesn't know about
+ *  daily-notes; the caller (typically UI) spells the target property
+ *  name. */
 export type WhereOperator =
   | { readonly eq: unknown }
   | { readonly lt: unknown }
@@ -28,6 +46,7 @@ export type WhereOperator =
   | { readonly gte: unknown }
   | { readonly between: readonly [unknown, unknown] }
   | { readonly exists: boolean }
+  | { readonly target: Readonly<Record<string, unknown>> }
 
 /** A single block predicate. Compiled against either the block itself
  *  (`scope: 'self'`, default) or the block-or-any-of-its-ancestors

--- a/src/data/api/typedBlockQuery.ts
+++ b/src/data/api/typedBlockQuery.ts
@@ -3,6 +3,32 @@ export interface TypedBlockQueryReferenceFilter {
   readonly sourceField?: string
 }
 
+/** Operator object accepted inside `BlockPredicate.where[name]`. The
+ *  scalar/null shorthand still works: a bare value compiles as
+ *  equality, `null` compiles as `IS NULL`. The object form is needed
+ *  for everything else.
+ *
+ *  Exactly one operator key per object — multiple keys would force an
+ *  AND-vs-OR interpretation that's better expressed by combining
+ *  predicates in `match` / `exclude`. The runtime parser rejects
+ *  multi-key objects to keep the surface unambiguous.
+ *
+ *  Operand types: each scalar operand goes through `codec.where.encode`
+ *  the same way scalar shorthand does, so `{ lt: new Date('2026-01-01') }`
+ *  on a date-codec property and `{ gt: 5 }` on a number-codec property
+ *  validate identically to their equality-form counterparts. `between`
+ *  is inclusive on both ends. `exists` takes a boolean — `true` for
+ *  "property is set" (`IS NOT NULL`), `false` for "unset" (`IS NULL`,
+ *  same as the `null` shorthand). */
+export type WhereOperator =
+  | { readonly eq: unknown }
+  | { readonly lt: unknown }
+  | { readonly lte: unknown }
+  | { readonly gt: unknown }
+  | { readonly gte: unknown }
+  | { readonly between: readonly [unknown, unknown] }
+  | { readonly exists: boolean }
+
 /** A single block predicate. Compiled against either the block itself
  *  (`scope: 'self'`, default) or the block-or-any-of-its-ancestors
  *  (`scope: 'ancestor'`). All sub-fields within one predicate AND
@@ -12,7 +38,11 @@ export interface TypedBlockQueryReferenceFilter {
  *  The `id` field is the "block has this id" primitive. Useful with
  *  ancestor scope to filter for "block is contained in page X" without
  *  requiring X to be referenced — e.g. backlinks-on-a-daily-note
- *  filtering by which page their context lives in. */
+ *  filtering by which page their context lives in.
+ *
+ *  `where[name]` values: scalar (equality), `null` (unset), or a
+ *  `WhereOperator` object (`{ lt: v }`, `{ exists: true }`, etc.). See
+ *  the `WhereOperator` doc for the operand contract. */
 export interface BlockPredicate {
   readonly scope?: 'self' | 'ancestor'
   readonly id?: string

--- a/src/data/internals/kernelQueries.ts
+++ b/src/data/internals/kernelQueries.ts
@@ -33,6 +33,7 @@ import {
   assertAncestorWalkBounded,
   buildCandidatesCte,
   compileTypedBlockQuery,
+  isSelectiveWhereValue,
   normalizeTypedBlockQuery,
 } from './typedBlockQuery'
 import {
@@ -443,21 +444,52 @@ const ANCESTOR_DEP_NODES_SQL = (candidatesCte: string) => `
 `
 
 
+/** Subscribe to the property channels relevant to a single `where`
+ *  map — every direct key, plus the inner keys reached through any
+ *  `target` traversal. The inner keys live on other rows (the ref
+ *  targets), so changes there have to wake this query just like
+ *  changes to the source row's outer property would. An empty
+ *  `target: {}` predicate means "ref points at a live block" — any
+ *  block insertion in the workspace could satisfy a referrer's ref,
+ *  so the live channel is the right granularity. */
+const collectWhereDeps = (
+  where: Readonly<Record<string, unknown>> | undefined,
+  workspaceId: string,
+  ctx: QueryCtx,
+): void => {
+  if (where === undefined) return
+  for (const [name, value] of Object.entries(where)) {
+    ctx.depend({
+      kind: 'plugin',
+      channel: TYPED_BLOCKS_PROPERTY_CHANNEL,
+      key: typedBlocksPropertyKey(workspaceId, name),
+    })
+    if (value === null || typeof value !== 'object' || value instanceof Date || Array.isArray(value)) continue
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length !== 1) continue
+    const [op, operand] = entries[0]!
+    if (op !== 'target') continue
+    if (operand === null || typeof operand !== 'object' || Array.isArray(operand)) continue
+    const inner = operand as Record<string, unknown>
+    if (Object.keys(inner).length === 0) {
+      ctx.depend({
+        kind: 'plugin',
+        channel: TYPED_BLOCKS_LIVE_CHANNEL,
+        key: typedBlocksLiveKey(workspaceId),
+      })
+    } else {
+      collectWhereDeps(inner, workspaceId, ctx)
+    }
+  }
+}
+
 const collectPredicateDeps = (
   predicates: readonly BlockPredicate[],
   workspaceId: string,
   ctx: QueryCtx,
 ): void => {
   for (const predicate of predicates) {
-    if (predicate.where !== undefined) {
-      for (const name of Object.keys(predicate.where)) {
-        ctx.depend({
-          kind: 'plugin',
-          channel: TYPED_BLOCKS_PROPERTY_CHANNEL,
-          key: typedBlocksPropertyKey(workspaceId, name),
-        })
-      }
-    }
+    collectWhereDeps(predicate.where, workspaceId, ctx)
     if (predicate.referencedBy !== undefined) {
       const ref = predicate.referencedBy
       if (ref.sourceField !== undefined) {
@@ -489,7 +521,6 @@ export const resolveTypedBlocks = async (
   const normalized = normalizeTypedBlockQuery(query)
   const workspaceId = normalized.workspaceId
   const types = normalized.types ?? []
-  const whereNames = Object.keys(normalized.where ?? {})
   const referencedBy = normalized.referencedBy
   const matchPredicates = normalized.match ?? []
   const excludePredicates = normalized.exclude ?? []
@@ -501,13 +532,7 @@ export const resolveTypedBlocks = async (
       key: typedBlocksTypeKey(workspaceId, t),
     })
   }
-  for (const name of whereNames) {
-    ctx.depend({
-      kind: 'plugin',
-      channel: TYPED_BLOCKS_PROPERTY_CHANNEL,
-      key: typedBlocksPropertyKey(workspaceId, name),
-    })
-  }
+  collectWhereDeps(normalized.where, workspaceId, ctx)
   if (referencedBy !== undefined) {
     if (referencedBy.sourceField !== undefined) {
       ctx.depend({
@@ -538,15 +563,13 @@ export const resolveTypedBlocks = async (
   //     appeared. (Mixed cases like `{status: null, foo: 'bar'}`
   //     don't need live: matching rows must set `foo='bar'` to
   //     match, which fires the foo property channel.)
-  const hasNonNullWhere = whereNames.some(
-    name => (normalized.where as Record<string, unknown>)[name] !== null,
-  )
+  const hasSelectiveWhere = Object.values(normalized.where ?? {}).some(isSelectiveWhereValue)
   const hasMatchAxis = matchPredicates.some(p =>
     p.referencedBy !== undefined ||
-    (p.where !== undefined && Object.values(p.where).some(v => v !== null)),
+    (p.where !== undefined && Object.values(p.where).some(isSelectiveWhereValue)),
   )
   const hasPositiveAxis =
-    types.length > 0 || referencedBy !== undefined || hasNonNullWhere || hasMatchAxis
+    types.length > 0 || referencedBy !== undefined || hasSelectiveWhere || hasMatchAxis
   if (!hasPositiveAxis) {
     ctx.depend({
       kind: 'plugin',

--- a/src/data/internals/kernelQueries.ts
+++ b/src/data/internals/kernelQueries.ts
@@ -448,10 +448,17 @@ const ANCESTOR_DEP_NODES_SQL = (candidatesCte: string) => `
  *  map — every direct key, plus the inner keys reached through any
  *  `target` traversal. The inner keys live on other rows (the ref
  *  targets), so changes there have to wake this query just like
- *  changes to the source row's outer property would. An empty
- *  `target: {}` predicate means "ref points at a live block" — any
- *  block insertion in the workspace could satisfy a referrer's ref,
- *  so the live channel is the right granularity. */
+ *  changes to the source row's outer property would.
+ *
+ *  Live-channel rule for `target`: if the inner predicate has no
+ *  selective key (empty `target: {}`, `target: { x: null }`,
+ *  `target: { x: { exists: false } }`, or any combination of unset-
+ *  matching predicates), a fresh target-row insert that matches
+ *  won't fire any property channel — the row never set the property
+ *  the predicate names. Without subscribing to the live channel in
+ *  that case, the subscriber stays stale until an unrelated write
+ *  fires invalidations. Mirrors the top-level "live channel only
+ *  when no positive axis" gate. */
 const collectWhereDeps = (
   where: Readonly<Record<string, unknown>> | undefined,
   workspaceId: string,
@@ -471,15 +478,18 @@ const collectWhereDeps = (
     if (op !== 'target') continue
     if (operand === null || typeof operand !== 'object' || Array.isArray(operand)) continue
     const inner = operand as Record<string, unknown>
-    if (Object.keys(inner).length === 0) {
+    const innerHasSelective = Object.values(inner).some(isSelectiveWhereValue)
+    if (!innerHasSelective) {
       ctx.depend({
         kind: 'plugin',
         channel: TYPED_BLOCKS_LIVE_CHANNEL,
         key: typedBlocksLiveKey(workspaceId),
       })
-    } else {
-      collectWhereDeps(inner, workspaceId, ctx)
     }
+    // Always recurse for the narrower per-property channels too —
+    // updates to an existing target row's properties still wake via
+    // those even when the live channel is also subscribed.
+    collectWhereDeps(inner, workspaceId, ctx)
   }
 }
 

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -204,6 +204,21 @@ describe('repo.queryBlocks', () => {
       expect(ids(onOrAfter).sort()).toEqual(['future', 'today'])
     })
 
+    it('accepts JSON-revived date operands (Date → ISO string after persist)', async () => {
+      // Persisted predicates (e.g. backlinks:predicates) round-trip
+      // through JSON, which turns Date instances into ISO strings.
+      // The compiler re-runs where.encode on the rehydrated value;
+      // it must accept the string form so saved date-range filters
+      // still work after reload.
+      await create({id: 'past', properties: {[dueProp.name]: encodeDate('2026-01-01')}})
+      await create({id: 'future', properties: {[dueProp.name]: encodeDate('2026-12-31')}})
+
+      const original = {due: {lt: new Date('2026-05-18T00:00:00.000Z')}}
+      const persisted = JSON.parse(JSON.stringify(original)) as Record<string, unknown>
+      const out = await env.repo.queryBlocks({where: persisted})
+      expect(ids(out)).toEqual(['past'])
+    })
+
     it('between is inclusive on both ends', async () => {
       await create({id: 'p1', properties: {[priorityProp.name]: priorityProp.codec.encode(1)}})
       await create({id: 'p2', properties: {[priorityProp.name]: priorityProp.codec.encode(2)}})

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -368,6 +368,17 @@ describe('repo.queryBlocks', () => {
     })).rejects.toThrow('require at least one candidate filter')
   })
 
+  it('exists:false-only where does not pass the ancestor gate either', async () => {
+    // `{exists: false}` is semantically identical to `null` (both
+    // compile to IS NULL). The selectivity gate must treat them the
+    // same, otherwise callers using one shorthand silently bypass
+    // the guard the other shorthand triggers.
+    await expect(env.repo.queryBlocks({
+      where: {status: {exists: false}},
+      match: [{scope: 'ancestor', where: {status: 'done'}}],
+    })).rejects.toThrow('require at least one candidate filter')
+  })
+
   it('self-scope match predicate counts as a candidate filter for the gate', async () => {
     // create() hardcodes parentId: null, so use tx.create directly to
     // build a parent-child chain.
@@ -429,6 +440,37 @@ describe('repo.subscribeBlocks', () => {
     await create({id: 'todo', types: ['todo']})
 
     await vi.waitFor(() => expect(fired).toEqual([[], ['todo']]))
+    off()
+  })
+
+  it('updates when a target operator inner property changes on the referenced row', async () => {
+    // Regression: the `target` traversal makes membership depend on
+    // the REFERENCED row's properties. Without dep wiring on the
+    // inner property channel, a target-side update wouldn't wake
+    // the subscriber.
+    await env.repo.tx(tx => tx.create({
+      id: 'target', workspaceId: WS, parentId: null, orderKey: 'a',
+    }), {scope: ChangeScope.BlockDefault})
+    await env.repo.tx(tx => tx.create({
+      id: 'source', workspaceId: WS, parentId: null, orderKey: 'b',
+      properties: {[reviewerProp.name]: reviewerProp.codec.encode('target')},
+      references: [{id: 'target', alias: 'target', sourceField: 'reviewer'}],
+    }), {scope: ChangeScope.BlockDefault})
+
+    const fired: string[][] = []
+    const off = env.repo.subscribeBlocks(
+      {where: {[reviewerProp.name]: {target: {status: 'done'}}}},
+      rows => fired.push(ids(rows)),
+    )
+    await vi.waitFor(() => expect(fired).toEqual([[]]))
+
+    // Update the *target* row's status. The subscription's filter
+    // doesn't reference the target id directly — only an inner
+    // property predicate — so this hits the dep wiring that
+    // `collectWhereDeps` adds for traversals.
+    await env.repo.tx(tx => tx.setProperty('target', statusProp, 'done'),
+      {scope: ChangeScope.BlockDefault})
+    await vi.waitFor(() => expect(fired).toEqual([[], ['source']]))
     off()
   })
 

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -443,6 +443,32 @@ describe('repo.subscribeBlocks', () => {
     off()
   })
 
+  it('updates when a target row appears with the inner-null property unset', async () => {
+    // `target: { status: null }` matches rows whose status is unset.
+    // A freshly-inserted target row with no `status` property doesn't
+    // fire the status property channel — same shape as the top-level
+    // "where with only null predicates" case. Without a live-channel
+    // sub on this branch the subscriber would stay stale.
+    await env.repo.tx(tx => tx.create({
+      id: 'source', workspaceId: WS, parentId: null, orderKey: 'a',
+      properties: {[reviewerProp.name]: reviewerProp.codec.encode('target')},
+      references: [{id: 'target', alias: 'target', sourceField: 'reviewer'}],
+    }), {scope: ChangeScope.BlockDefault})
+
+    const fired: string[][] = []
+    const off = env.repo.subscribeBlocks(
+      {where: {[reviewerProp.name]: {target: {status: null}}}},
+      rows => fired.push(ids(rows)),
+    )
+    await vi.waitFor(() => expect(fired).toEqual([[]]))
+
+    await env.repo.tx(tx => tx.create({
+      id: 'target', workspaceId: WS, parentId: null, orderKey: 'b',
+    }), {scope: ChangeScope.BlockDefault})
+    await vi.waitFor(() => expect(fired).toEqual([[], ['source']]))
+    off()
+  })
+
   it('updates when a target operator inner property changes on the referenced row', async () => {
     // Regression: the `target` traversal makes membership depend on
     // the REFERENCED row's properties. Without dep wiring on the

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -29,6 +29,18 @@ const doneProp = defineProperty<boolean>('done', {
   changeScope: ChangeScope.BlockDefault,
 })
 
+const priorityProp = defineProperty<number>('priority', {
+  codec: codecs.number,
+  defaultValue: 0,
+  changeScope: ChangeScope.BlockDefault,
+})
+
+const dueProp = defineProperty<Date | undefined>('due', {
+  codec: codecs.date,
+  defaultValue: undefined,
+  changeScope: ChangeScope.BlockDefault,
+})
+
 const weirdNameProp = defineProperty<string>('weird:name.with-dot-hyphen', {
   codec: codecs.string,
   defaultValue: '',
@@ -69,6 +81,8 @@ const setup = async (): Promise<Harness> => {
     kernelDataExtension,
     propertySchemasFacet.of(statusProp, {source: 'test'}),
     propertySchemasFacet.of(doneProp, {source: 'test'}),
+    propertySchemasFacet.of(priorityProp, {source: 'test'}),
+    propertySchemasFacet.of(dueProp, {source: 'test'}),
     propertySchemasFacet.of(weirdNameProp, {source: 'test'}),
     propertySchemasFacet.of(labelsProp, {source: 'test'}),
     propertySchemasFacet.of(reviewerProp, {source: 'test'}),
@@ -144,6 +158,89 @@ describe('repo.queryBlocks', () => {
     const out = await env.repo.queryBlocks({where: {status: null}})
 
     expect(ids(out)).toEqual(['missing', 'nullish'])
+  })
+
+  describe('where operators', () => {
+    /** `dueProp.codec.date` encodes Date instances to ISO strings.
+     *  Lexicographic comparison on ISO 8601 matches chronological order,
+     *  so SQL `<` / `BETWEEN` work directly on the encoded form. */
+    const encodeDate = (iso: string): unknown =>
+      dueProp.codec.encode(new Date(`${iso}T00:00:00.000Z`))
+
+    it('comparator operators on a numeric property', async () => {
+      await create({id: 'p1', properties: {[priorityProp.name]: priorityProp.codec.encode(1)}})
+      await create({id: 'p2', properties: {[priorityProp.name]: priorityProp.codec.encode(2)}})
+      await create({id: 'p3', properties: {[priorityProp.name]: priorityProp.codec.encode(3)}})
+
+      const lt = await env.repo.queryBlocks({where: {priority: {lt: 3}}})
+      expect(ids(lt).sort()).toEqual(['p1', 'p2'])
+
+      const lte = await env.repo.queryBlocks({where: {priority: {lte: 2}}})
+      expect(ids(lte).sort()).toEqual(['p1', 'p2'])
+
+      const gt = await env.repo.queryBlocks({where: {priority: {gt: 1}}})
+      expect(ids(gt).sort()).toEqual(['p2', 'p3'])
+
+      const gte = await env.repo.queryBlocks({where: {priority: {gte: 2}}})
+      expect(ids(gte).sort()).toEqual(['p2', 'p3'])
+
+      const eq = await env.repo.queryBlocks({where: {priority: {eq: 2}}})
+      expect(ids(eq)).toEqual(['p2'])
+    })
+
+    it('comparator operators on a date property', async () => {
+      await create({id: 'past', properties: {[dueProp.name]: encodeDate('2026-01-01')}})
+      await create({id: 'today', properties: {[dueProp.name]: encodeDate('2026-05-18')}})
+      await create({id: 'future', properties: {[dueProp.name]: encodeDate('2026-12-31')}})
+
+      const before = await env.repo.queryBlocks({
+        where: {due: {lt: new Date('2026-05-18T00:00:00.000Z')}},
+      })
+      expect(ids(before)).toEqual(['past'])
+
+      const onOrAfter = await env.repo.queryBlocks({
+        where: {due: {gte: new Date('2026-05-18T00:00:00.000Z')}},
+      })
+      expect(ids(onOrAfter).sort()).toEqual(['future', 'today'])
+    })
+
+    it('between is inclusive on both ends', async () => {
+      await create({id: 'p1', properties: {[priorityProp.name]: priorityProp.codec.encode(1)}})
+      await create({id: 'p2', properties: {[priorityProp.name]: priorityProp.codec.encode(2)}})
+      await create({id: 'p3', properties: {[priorityProp.name]: priorityProp.codec.encode(3)}})
+      await create({id: 'p5', properties: {[priorityProp.name]: priorityProp.codec.encode(5)}})
+
+      const out = await env.repo.queryBlocks({where: {priority: {between: [2, 3]}}})
+      expect(ids(out).sort()).toEqual(['p2', 'p3'])
+    })
+
+    it('exists: true matches set, exists: false matches unset', async () => {
+      await create({id: 'set', properties: {status: 'open'}})
+      await create({id: 'missing', properties: {}})
+      await create({id: 'nullish', properties: {status: null}})
+
+      const set = await env.repo.queryBlocks({where: {status: {exists: true}}})
+      expect(ids(set)).toEqual(['set'])
+
+      const unset = await env.repo.queryBlocks({where: {status: {exists: false}}})
+      expect(ids(unset).sort()).toEqual(['missing', 'nullish'])
+    })
+
+    it('rejects malformed operator objects with a clear message', async () => {
+      await expect(env.repo.queryBlocks({where: {priority: {lt: 1, gt: 0}}}))
+        .rejects.toThrow('operator object must have exactly one key')
+      await expect(env.repo.queryBlocks({where: {priority: {bogus: 1}}}))
+        .rejects.toThrow('unknown operator')
+      await expect(env.repo.queryBlocks({where: {priority: {between: [1]}}}))
+        .rejects.toThrow('between must be a [lo, hi] tuple')
+      await expect(env.repo.queryBlocks({where: {status: {exists: 'yes'}}}))
+        .rejects.toThrow('exists must be a boolean')
+    })
+
+    it('rejects comparator operators on non-where-queryable codecs', async () => {
+      await expect(env.repo.queryBlocks({where: {reviewer: {eq: 'target'}}}))
+        .rejects.toThrow('is not where-queryable')
+    })
   })
 
   it('filters by references with optional sourceField', async () => {

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -241,6 +241,67 @@ describe('repo.queryBlocks', () => {
       await expect(env.repo.queryBlocks({where: {reviewer: {eq: 'target'}}}))
         .rejects.toThrow('is not where-queryable')
     })
+
+    it('traverses ref-typed properties via the target operator', async () => {
+      // Realistic shape: a ref-typed property points at a "target"
+      // block that carries its own queryable properties (the daily-
+      // notes plugin's date property is the motivating case, but the
+      // compiler is plugin-agnostic — anything with a where-queryable
+      // codec on the target works).
+      await create({
+        id: 'past-target',
+        properties: {[dueProp.name]: encodeDate('2026-01-01')},
+      })
+      await create({
+        id: 'future-target',
+        properties: {[dueProp.name]: encodeDate('2026-12-31')},
+      })
+      await create({id: 'unrelated-target'})
+      await create({
+        id: 'source-past',
+        properties: {[reviewerProp.name]: reviewerProp.codec.encode('past-target')},
+        references: [{id: 'past-target', alias: 'past-target', sourceField: 'reviewer'}],
+      })
+      await create({
+        id: 'source-future',
+        properties: {[reviewerProp.name]: reviewerProp.codec.encode('future-target')},
+        references: [{id: 'future-target', alias: 'future-target', sourceField: 'reviewer'}],
+      })
+      await create({
+        id: 'source-unrelated',
+        properties: {[reviewerProp.name]: reviewerProp.codec.encode('unrelated-target')},
+        references: [{id: 'unrelated-target', alias: 'unrelated-target', sourceField: 'reviewer'}],
+      })
+
+      const past = await env.repo.queryBlocks({
+        where: {
+          [reviewerProp.name]: {
+            target: {[dueProp.name]: {lt: new Date('2026-06-01T00:00:00.000Z')}},
+          },
+        },
+      })
+      expect(ids(past)).toEqual(['source-past'])
+
+      // Empty target predicate = "ref points at a live block".
+      // Excludes the dangling case (no row at the ref id) and the
+      // soft-deleted case via the JOIN's `d.deleted = 0` clause.
+      const anyTarget = await env.repo.queryBlocks({
+        where: {[reviewerProp.name]: {target: {}}},
+      })
+      expect(ids(anyTarget).sort()).toEqual(['source-future', 'source-past', 'source-unrelated'])
+    })
+
+    it('rejects the target operator on non-ref properties', async () => {
+      await expect(env.repo.queryBlocks({
+        where: {status: {target: {priority: {gt: 0}}}},
+      })).rejects.toThrow('only valid on ref / refList properties')
+    })
+
+    it('rejects malformed target operand', async () => {
+      await expect(env.repo.queryBlocks({
+        where: {[reviewerProp.name]: {target: 'not-an-object'}},
+      })).rejects.toThrow('target must be a where-map object')
+    })
   })
 
   it('filters by references with optional sourceField', async () => {

--- a/src/data/internals/typedBlockQuery.ts
+++ b/src/data/internals/typedBlockQuery.ts
@@ -16,6 +16,20 @@ export interface CompiledTypedBlockQuery {
 export const jsonPathForProperty = (name: string): string =>
   `$."${name.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
 
+/** Inline a JSON path as a SQL string literal — needed so SQLite's
+ *  query planner can match expression indexes. SQLite only treats
+ *  `json_extract(col, '$.foo')` and `idx ON (json_extract(col, '$.foo'))`
+ *  as the same indexable expression when the path appears literally;
+ *  if the path is bound via `?` the planner sees `json_extract(col, ?)`
+ *  and falls back to a table scan. Property names are registered via
+ *  trusted facets, but the literal still gets standard `''`-escaping
+ *  defensively so a name containing a single quote can't break the
+ *  surrounding SQL. */
+const inlineJsonPath = (name: string): string => {
+  const path = jsonPathForProperty(name)
+  return `'${path.replaceAll("'", "''")}'`
+}
+
 interface CompiledClause {
   readonly sql: string
   readonly params: readonly unknown[]
@@ -130,7 +144,7 @@ const compileTargetTraversal = (
     )
   }
   const alias = `d${aliasCounter.n++}`
-  const targetPath = jsonPathForProperty(name)
+  const refExtract = `json_extract(${jsonExpr}, ${inlineJsonPath(name)})`
   const innerEntries = Object.entries(inner).sort(([a], [b]) => a.localeCompare(b))
   const innerClauses: string[] = []
   const innerParams: unknown[] = []
@@ -150,18 +164,18 @@ const compileTargetTraversal = (
     return {
       sql:
         `EXISTS (SELECT 1 FROM blocks ${alias} ` +
-        `WHERE ${alias}.id = json_extract(${jsonExpr}, ?) ` +
+        `WHERE ${alias}.id = ${refExtract} ` +
         `AND ${alias}.deleted = 0${inWhere})`,
-      params: [targetPath, ...innerParams],
+      params: innerParams,
     }
   }
   // refList: target value is an array of ids — fan out via json_each.
   return {
     sql:
-      `EXISTS (SELECT 1 FROM json_each(json_extract(${jsonExpr}, ?)) AS je ` +
+      `EXISTS (SELECT 1 FROM json_each(${refExtract}) AS je ` +
       `JOIN blocks ${alias} ON ${alias}.id = je.value ` +
       `WHERE ${alias}.deleted = 0${inWhere})`,
-    params: [targetPath, ...innerParams],
+    params: innerParams,
   }
 }
 
@@ -179,17 +193,17 @@ const compileWhereClause = (
   if (schema === undefined) {
     throw new Error(`[queryBlocks] where.${name} has no registered PropertySchema`)
   }
-  const path = jsonPathForProperty(name)
+  const extract = `json_extract(${jsonExpr}, ${inlineJsonPath(name)})`
   const parsed = parseWhereValue(name, value)
 
   // `IS NULL` / `IS NOT NULL` skip `codec.where.encode` entirely —
   // they're orthogonal to the codec's encoding contract (and
   // codec.where.encode rejects null/undefined by design).
   if (parsed.kind === 'unset') {
-    return {sql: `json_extract(${jsonExpr}, ?) IS NULL`, params: [path]}
+    return {sql: `${extract} IS NULL`, params: []}
   }
   if (parsed.kind === 'set') {
-    return {sql: `json_extract(${jsonExpr}, ?) IS NOT NULL`, params: [path]}
+    return {sql: `${extract} IS NOT NULL`, params: []}
   }
   if (parsed.kind === 'target') {
     return compileTargetTraversal(name, parsed.inner, schema, jsonExpr, propertySchemas, aliasCounter)
@@ -198,14 +212,14 @@ const compileWhereClause = (
     const lo = encodeForWhere(name, schema, parsed.lo)
     const hi = encodeForWhere(name, schema, parsed.hi)
     return {
-      sql: `json_extract(${jsonExpr}, ?) BETWEEN ? AND ?`,
-      params: [path, lo, hi],
+      sql: `${extract} BETWEEN ? AND ?`,
+      params: [lo, hi],
     }
   }
   const operand = encodeForWhere(name, schema, parsed.operand)
   return {
-    sql: `json_extract(${jsonExpr}, ?) ${COMPARATOR_SQL[parsed.op]} ?`,
-    params: [path, operand],
+    sql: `${extract} ${COMPARATOR_SQL[parsed.op]} ?`,
+    params: [operand],
   }
 }
 

--- a/src/data/internals/typedBlockQuery.ts
+++ b/src/data/internals/typedBlockQuery.ts
@@ -1,4 +1,6 @@
 import {
+  isRefCodec,
+  isRefListCodec,
   type AnyPropertySchema,
   type BlockPredicate,
   type ResolvedTypedBlockQuery,
@@ -22,7 +24,7 @@ interface CompiledClause {
 /** Operator names recognised inside `where[name]` object values.
  *  Mirrors `WhereOperator` in `src/data/api/typedBlockQuery.ts`. */
 const COMPARATOR_OPERATORS = new Set(['eq', 'lt', 'lte', 'gt', 'gte'])
-const ALL_OPERATORS = new Set([...COMPARATOR_OPERATORS, 'between', 'exists'])
+const ALL_OPERATORS = new Set([...COMPARATOR_OPERATORS, 'between', 'exists', 'target'])
 
 /** A scalar `where` value goes through `codec.where.encode` and lands
  *  in one of the comparator operators below; an object becomes an
@@ -32,6 +34,7 @@ type ParsedWhere =
   | { readonly kind: 'set' }                // exists: true
   | { readonly kind: 'comparator'; readonly op: 'eq' | 'lt' | 'lte' | 'gt' | 'gte'; readonly operand: unknown }
   | { readonly kind: 'between'; readonly lo: unknown; readonly hi: unknown }
+  | { readonly kind: 'target'; readonly inner: Readonly<Record<string, unknown>> }
 
 const COMPARATOR_SQL: Readonly<Record<'eq' | 'lt' | 'lte' | 'gt' | 'gte', string>> = {
   eq: '=', lt: '<', lte: '<=', gt: '>', gte: '>=',
@@ -74,6 +77,12 @@ const parseWhereValue = (name: string, value: unknown): ParsedWhere => {
     }
     return {kind: 'between', lo: operand[0], hi: operand[1]}
   }
+  if (op === 'target') {
+    if (!isPlainOperatorObject(operand)) {
+      throw new Error(`[queryBlocks] where.${name}.target must be a where-map object`)
+    }
+    return {kind: 'target', inner: operand}
+  }
   return {kind: 'comparator', op: op as 'eq' | 'lt' | 'lte' | 'gt' | 'gte', operand}
 }
 
@@ -99,11 +108,70 @@ const encodeForWhere = (
   }
 }
 
+/** Mutable counter for nested `target` traversals so each level gets
+ *  its own SQL alias (`d0`, `d1`, …) and inner joins don't collide
+ *  with outer ones. The top-level call always passes `{n: 0}`. */
+interface AliasCounter { n: number }
+
+const compileTargetTraversal = (
+  name: string,
+  inner: Readonly<Record<string, unknown>>,
+  schema: AnyPropertySchema,
+  jsonExpr: string,
+  propertySchemas: ReadonlyMap<string, AnyPropertySchema>,
+  aliasCounter: AliasCounter,
+): CompiledClause => {
+  const isRef = isRefCodec(schema.codec)
+  const isRefList = isRefListCodec(schema.codec)
+  if (!isRef && !isRefList) {
+    throw new Error(
+      `[queryBlocks] where.${name}.target is only valid on ref / refList properties; ` +
+      `${JSON.stringify(name)} has codec type ${JSON.stringify(schema.codec.type)}`,
+    )
+  }
+  const alias = `d${aliasCounter.n++}`
+  const targetPath = jsonPathForProperty(name)
+  const innerEntries = Object.entries(inner).sort(([a], [b]) => a.localeCompare(b))
+  const innerClauses: string[] = []
+  const innerParams: unknown[] = []
+  for (const [innerName, innerValue] of innerEntries) {
+    const compiled = compileWhereClause(
+      innerName, innerValue, propertySchemas.get(innerName),
+      `${alias}.properties_json`, propertySchemas, aliasCounter,
+    )
+    innerClauses.push(compiled.sql)
+    innerParams.push(...compiled.params)
+  }
+  const inWhere = innerClauses.length === 0 ? '' : ` AND ${innerClauses.join(' AND ')}`
+  if (isRef) {
+    // The source row's `properties_json[name]` holds the target id
+    // (string, stored as JSON). `json_extract` unwraps the JSON
+    // quoting and gives us the bare id for the equality join.
+    return {
+      sql:
+        `EXISTS (SELECT 1 FROM blocks ${alias} ` +
+        `WHERE ${alias}.id = json_extract(${jsonExpr}, ?) ` +
+        `AND ${alias}.deleted = 0${inWhere})`,
+      params: [targetPath, ...innerParams],
+    }
+  }
+  // refList: target value is an array of ids — fan out via json_each.
+  return {
+    sql:
+      `EXISTS (SELECT 1 FROM json_each(json_extract(${jsonExpr}, ?)) AS je ` +
+      `JOIN blocks ${alias} ON ${alias}.id = je.value ` +
+      `WHERE ${alias}.deleted = 0${inWhere})`,
+    params: [targetPath, ...innerParams],
+  }
+}
+
 const compileWhereClause = (
   name: string,
   value: unknown,
   schema: AnyPropertySchema | undefined,
   jsonExpr: string,
+  propertySchemas: ReadonlyMap<string, AnyPropertySchema>,
+  aliasCounter: AliasCounter = {n: 0},
 ): CompiledClause => {
   if (value === undefined) {
     throw new Error(`[queryBlocks] where.${name} is undefined; pass null to match unset values`)
@@ -122,6 +190,9 @@ const compileWhereClause = (
   }
   if (parsed.kind === 'set') {
     return {sql: `json_extract(${jsonExpr}, ?) IS NOT NULL`, params: [path]}
+  }
+  if (parsed.kind === 'target') {
+    return compileTargetTraversal(name, parsed.inner, schema, jsonExpr, propertySchemas, aliasCounter)
   }
   if (parsed.kind === 'between') {
     const lo = encodeForWhere(name, schema, parsed.lo)
@@ -173,7 +244,7 @@ const compilePredicateAgainstRow = (
 
   if (predicate.where !== undefined) {
     for (const [name, value] of Object.entries(predicate.where).sort(([a], [b]) => a.localeCompare(b))) {
-      const compiled = compileWhereClause(name, value, propertySchemas.get(name), propsExpr)
+      const compiled = compileWhereClause(name, value, propertySchemas.get(name), propsExpr, propertySchemas)
       clauses.push(compiled.sql)
       params.push(...compiled.params)
     }
@@ -222,7 +293,7 @@ const compileScopedPredicate = (
 
   if (predicate.where !== undefined) {
     for (const [name, value] of Object.entries(predicate.where).sort(([a], [b]) => a.localeCompare(b))) {
-      const compiled = compileWhereClause(name, value, propertySchemas.get(name), 'anc.properties_json')
+      const compiled = compileWhereClause(name, value, propertySchemas.get(name), 'anc.properties_json', propertySchemas)
       clauses.push(compiled.sql)
       params.push(...compiled.params)
     }
@@ -369,7 +440,7 @@ export const buildCandidatesCte = (
 
   if (normalized.where !== undefined) {
     for (const [name, value] of Object.entries(normalized.where).sort(([a], [b]) => a.localeCompare(b))) {
-      const compiled = compileWhereClause(name, value, propertySchemas.get(name), 'b.properties_json')
+      const compiled = compileWhereClause(name, value, propertySchemas.get(name), 'b.properties_json', propertySchemas)
       clauses.push(compiled.sql)
       params.push(...compiled.params)
     }

--- a/src/data/internals/typedBlockQuery.ts
+++ b/src/data/internals/typedBlockQuery.ts
@@ -351,8 +351,23 @@ export const hasAncestorScope = (predicates: readonly BlockPredicate[]): boolean
 const isSelfScope = (predicate: BlockPredicate): boolean =>
   (predicate.scope ?? 'self') === 'self'
 
+/** Does this `where[name]` value narrow the candidate set, or does
+ *  it only match rows lacking the property? `null` and the operator
+ *  form `{exists: false}` are semantic duplicates — both compile to
+ *  `IS NULL` — so both have to be classified as non-selective; if
+ *  only one were, ancestor-gate and dep-wiring decisions would drift
+ *  based on which shorthand the caller happened to use. */
+export const isSelectiveWhereValue = (value: unknown): boolean => {
+  if (value === null) return false
+  if (typeof value !== 'object' || value instanceof Date || Array.isArray(value)) return true
+  const entries = Object.entries(value as Record<string, unknown>)
+  if (entries.length !== 1) return true
+  const [op, operand] = entries[0]!
+  return !(op === 'exists' && operand === false)
+}
+
 const hasNonNullWhere = (where: Readonly<Record<string, unknown>> | undefined): boolean =>
-  where !== undefined && Object.values(where).some(v => v !== null)
+  where !== undefined && Object.values(where).some(isSelectiveWhereValue)
 
 /** Does this self-scope predicate actually bound the candidate set
  *  (vs. just match-anything)? Used by the ancestor-walk safety gate

--- a/src/data/internals/typedBlockQuery.ts
+++ b/src/data/internals/typedBlockQuery.ts
@@ -19,6 +19,86 @@ interface CompiledClause {
   readonly params: readonly unknown[]
 }
 
+/** Operator names recognised inside `where[name]` object values.
+ *  Mirrors `WhereOperator` in `src/data/api/typedBlockQuery.ts`. */
+const COMPARATOR_OPERATORS = new Set(['eq', 'lt', 'lte', 'gt', 'gte'])
+const ALL_OPERATORS = new Set([...COMPARATOR_OPERATORS, 'between', 'exists'])
+
+/** A scalar `where` value goes through `codec.where.encode` and lands
+ *  in one of the comparator operators below; an object becomes an
+ *  operator dispatch; a `null` short-circuits to `IS NULL`. */
+type ParsedWhere =
+  | { readonly kind: 'unset' }              // legacy null shorthand
+  | { readonly kind: 'set' }                // exists: true
+  | { readonly kind: 'comparator'; readonly op: 'eq' | 'lt' | 'lte' | 'gt' | 'gte'; readonly operand: unknown }
+  | { readonly kind: 'between'; readonly lo: unknown; readonly hi: unknown }
+
+const COMPARATOR_SQL: Readonly<Record<'eq' | 'lt' | 'lte' | 'gt' | 'gte', string>> = {
+  eq: '=', lt: '<', lte: '<=', gt: '>', gte: '>=',
+}
+
+const isPlainOperatorObject = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !(value instanceof Date) && !Array.isArray(value)
+
+/** Normalize a `where[name]` value to the discriminated `ParsedWhere`
+ *  shape. Throws on malformed inputs (multiple operator keys, unknown
+ *  operator, `between` not a 2-tuple, `exists` not a boolean). */
+const parseWhereValue = (name: string, value: unknown): ParsedWhere => {
+  if (value === null) return {kind: 'unset'}
+  if (!isPlainOperatorObject(value)) {
+    return {kind: 'comparator', op: 'eq', operand: value}
+  }
+  const entries = Object.entries(value).filter(([k]) => k !== undefined)
+  if (entries.length !== 1) {
+    throw new Error(
+      `[queryBlocks] where.${name} operator object must have exactly one key; got ${entries.length} ` +
+      `(combine via separate match/exclude predicates instead)`,
+    )
+  }
+  const [op, operand] = entries[0]!
+  if (!ALL_OPERATORS.has(op)) {
+    throw new Error(
+      `[queryBlocks] where.${name} unknown operator ${JSON.stringify(op)}; ` +
+      `supported: ${[...ALL_OPERATORS].join(', ')}`,
+    )
+  }
+  if (op === 'exists') {
+    if (typeof operand !== 'boolean') {
+      throw new Error(`[queryBlocks] where.${name}.exists must be a boolean; got ${typeof operand}`)
+    }
+    return operand ? {kind: 'set'} : {kind: 'unset'}
+  }
+  if (op === 'between') {
+    if (!Array.isArray(operand) || operand.length !== 2) {
+      throw new Error(`[queryBlocks] where.${name}.between must be a [lo, hi] tuple`)
+    }
+    return {kind: 'between', lo: operand[0], hi: operand[1]}
+  }
+  return {kind: 'comparator', op: op as 'eq' | 'lt' | 'lte' | 'gt' | 'gte', operand}
+}
+
+const encodeForWhere = (
+  name: string,
+  schema: AnyPropertySchema,
+  value: unknown,
+): string | number => {
+  if (!schema.codec.where) {
+    throw new Error(
+      `[queryBlocks] where.${name} is not where-queryable; ` +
+      `codec type ${JSON.stringify(schema.codec.type)} doesn't support comparison predicates ` +
+      '(use referencedBy for refs, or add a dedicated query for collection/object filters)',
+    )
+  }
+  try {
+    return schema.codec.where.encode(value)
+  } catch (err) {
+    throw new Error(
+      `[queryBlocks] where.${name} value is not a valid ${schema.codec.type}: ${(err as Error).message}`,
+      {cause: err},
+    )
+  }
+}
+
 const compileWhereClause = (
   name: string,
   value: unknown,
@@ -32,37 +112,29 @@ const compileWhereClause = (
     throw new Error(`[queryBlocks] where.${name} has no registered PropertySchema`)
   }
   const path = jsonPathForProperty(name)
+  const parsed = parseWhereValue(name, value)
 
-  // `null` is the typed-query "match unset / explicitly-null" sentinel;
-  // SQLite `=` against NULL never matches, so compile to `IS NULL` and
-  // skip `where.encode` entirely (it would reject null).
-  if (value === null) {
+  // `IS NULL` / `IS NOT NULL` skip `codec.where.encode` entirely —
+  // they're orthogonal to the codec's encoding contract (and
+  // codec.where.encode rejects null/undefined by design).
+  if (parsed.kind === 'unset') {
+    return {sql: `json_extract(${jsonExpr}, ?) IS NULL`, params: [path]}
+  }
+  if (parsed.kind === 'set') {
+    return {sql: `json_extract(${jsonExpr}, ?) IS NOT NULL`, params: [path]}
+  }
+  if (parsed.kind === 'between') {
+    const lo = encodeForWhere(name, schema, parsed.lo)
+    const hi = encodeForWhere(name, schema, parsed.hi)
     return {
-      sql: `json_extract(${jsonExpr}, ?) IS NULL`,
-      params: [path],
+      sql: `json_extract(${jsonExpr}, ?) BETWEEN ? AND ?`,
+      params: [path, lo, hi],
     }
   }
-
-  if (!schema.codec.where) {
-    throw new Error(
-      `[queryBlocks] where.${name} is not where-queryable; ` +
-      `codec type ${JSON.stringify(schema.codec.type)} doesn't support equality predicates ` +
-      '(use referencedBy for refs, or add a dedicated query for collection/object filters)',
-    )
-  }
-
-  let sqlValue: string | number
-  try {
-    sqlValue = schema.codec.where.encode(value)
-  } catch (err) {
-    throw new Error(
-      `[queryBlocks] where.${name} value is not a valid ${schema.codec.type}: ${(err as Error).message}`,
-      {cause: err},
-    )
-  }
+  const operand = encodeForWhere(name, schema, parsed.operand)
   return {
-    sql: `json_extract(${jsonExpr}, ?) = ?`,
-    params: [path, sqlValue],
+    sql: `json_extract(${jsonExpr}, ?) ${COMPARATOR_SQL[parsed.op]} ?`,
+    params: [path, operand],
   }
 }
 

--- a/src/plugins/backlinks/BacklinkFilters.tsx
+++ b/src/plugins/backlinks/BacklinkFilters.tsx
@@ -11,7 +11,11 @@ import { FilterX, Plus, Settings2, X } from 'lucide-react'
 import { useRepo } from '@/context/repo.tsx'
 import { useHandle } from '@/hooks/block.ts'
 import { usePropertySchemas } from '@/hooks/propertySchemas.ts'
-import { type BlockPredicate } from '@/data/api'
+import { isRefCodec, type AnyPropertySchema, type BlockPredicate } from '@/data/api'
+import {
+  DAILY_NOTE_TYPE,
+  dailyNoteDateProp,
+} from '@/plugins/daily-notes/schema.ts'
 import { Button } from '@/components/ui/button.tsx'
 import { Input } from '@/components/ui/input.tsx'
 import { FloatingListbox } from '@/components/ui/floating-listbox.tsx'
@@ -47,6 +51,141 @@ const truncate = (text: string, max = 72): string =>
 
 const predicateKey = (p: BlockPredicate): string => JSON.stringify(p)
 
+/** Ref-typed property whose targets are daily notes. These get the
+ *  same date-operator UX as a `date`-codec property — the predicate
+ *  builder wraps the operator in a `target` traversal that compares
+ *  the referenced daily note's `daily-note:date`. */
+const isDailyNoteDateRef = (schema: AnyPropertySchema): boolean => {
+  if (!isRefCodec(schema.codec)) return false
+  return schema.codec.targetTypes.includes(DAILY_NOTE_TYPE)
+}
+
+type WhereOperatorId =
+  | 'eq' | 'lt' | 'lte' | 'gt' | 'gte' | 'between'
+  | 'exists-true' | 'exists-false'
+
+/** Operator menu surfaced for a given property. `date`/`number`/
+ *  daily-note-ref properties get the full comparison surface; the
+ *  remaining where-queryable codecs (string/url/boolean) keep the
+ *  simple equality+unset UX they had pre-operator-support. */
+const operatorOptionsFor = (schema: AnyPropertySchema): WhereOperatorId[] => {
+  const t = schema.codec.type
+  if (t === 'date' || t === 'number' || isDailyNoteDateRef(schema)) {
+    return ['eq', 'lt', 'lte', 'gt', 'gte', 'between', 'exists-true', 'exists-false']
+  }
+  return ['eq', 'exists-true', 'exists-false']
+}
+
+const OPERATOR_LABELS: Readonly<Record<WhereOperatorId, string>> = {
+  eq: '=', lt: '<', lte: '≤', gt: '>', gte: '≥',
+  between: 'between',
+  'exists-true': 'is set',
+  'exists-false': 'is unset',
+}
+
+/** Number of value inputs the form should render for an operator.
+ *  `exists-*` need zero, `between` needs two, everything else one. */
+const operatorArity = (op: WhereOperatorId): 0 | 1 | 2 =>
+  op === 'exists-true' || op === 'exists-false' ? 0 : op === 'between' ? 2 : 1
+
+const parseValueFor = (schema: AnyPropertySchema, raw: string): unknown => {
+  if (raw === '') return undefined
+  const t = schema.codec.type
+  if (isDailyNoteDateRef(schema) || t === 'date') {
+    // <input type="date"> yields `YYYY-MM-DD`; same UTC-midnight
+    // construction as `dailyNoteDateValue` so encoded values line up
+    // byte-for-byte with stored `daily-note:date` strings.
+    const d = new Date(`${raw}T00:00:00.000Z`)
+    return Number.isNaN(d.getTime()) ? undefined : d
+  }
+  if (t === 'number') {
+    const n = Number(raw)
+    return Number.isFinite(n) ? n : undefined
+  }
+  if (t === 'boolean') return raw === 'true'
+  return raw
+}
+
+/** Wrap a where-clause in `target: { 'daily-note:date': ... }` when
+ *  the property is a daily-note ref; otherwise return the inner
+ *  clause directly. Lets the UI present the ref as if it were a
+ *  date-typed property. */
+const wrapForSchema = (schema: AnyPropertySchema, clause: unknown): unknown =>
+  isDailyNoteDateRef(schema)
+    ? {target: {[dailyNoteDateProp.name]: clause}}
+    : clause
+
+const buildPredicate = (
+  name: string,
+  schema: AnyPropertySchema,
+  op: WhereOperatorId,
+  rawValues: readonly string[],
+): BlockPredicate | null => {
+  let whereValue: unknown
+  if (op === 'exists-true') {
+    whereValue = isDailyNoteDateRef(schema)
+      ? {target: {}}   // ref points to a live daily-note row
+      : {exists: true}
+  } else if (op === 'exists-false') {
+    whereValue = null
+  } else if (op === 'between') {
+    const lo = parseValueFor(schema, rawValues[0] ?? '')
+    const hi = parseValueFor(schema, rawValues[1] ?? '')
+    if (lo === undefined || hi === undefined) return null
+    whereValue = wrapForSchema(schema, {between: [lo, hi]})
+  } else {
+    const operand = parseValueFor(schema, rawValues[0] ?? '')
+    if (operand === undefined) {
+      // Empty input on `=` keeps the legacy "empty = match unset"
+      // sugar so existing user mental model isn't disrupted.
+      whereValue = op === 'eq' ? null : undefined
+      if (whereValue === undefined) return null
+    } else {
+      whereValue = wrapForSchema(schema, {[op]: operand})
+    }
+  }
+  return {scope: 'ancestor', where: {[name]: whereValue}}
+}
+
+/** Render a `where[name]: value` clause as a short, human-readable
+ *  string for chips. Unwraps the daily-note-ref `target` shape so
+ *  the chip shows "next-review-date < 2026-05-18" rather than the
+ *  internal traversal. */
+const formatPredicateClause = (name: string, value: unknown): string => {
+  if (value === null) return `${name}=∅`
+  if (value instanceof Date || typeof value !== 'object') {
+    return `${name}=${formatScalar(value)}`
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+  if (entries.length === 1) {
+    const [op, operand] = entries[0]!
+    if (op === 'target' && operand && typeof operand === 'object') {
+      // Unwrap to the inner clause but keep the outer property name.
+      // Empty target → "ref is set"; single-key target → unwrap.
+      const innerEntries = Object.entries(operand as Record<string, unknown>)
+      if (innerEntries.length === 0) return `${name} is set`
+      if (innerEntries.length === 1) {
+        return formatPredicateClause(name, innerEntries[0]![1])
+      }
+    }
+    if (op === 'exists') {
+      return operand === false ? `${name}=∅` : `${name} is set`
+    }
+    if (op === 'between' && Array.isArray(operand) && operand.length === 2) {
+      return `${name} ∈ [${formatScalar(operand[0])}, ${formatScalar(operand[1])}]`
+    }
+    const sym = OPERATOR_LABELS[op as WhereOperatorId]
+    if (sym !== undefined) return `${name} ${sym} ${formatScalar(operand)}`
+  }
+  return `${name}=${JSON.stringify(value)}`
+}
+
+const formatScalar = (value: unknown): string => {
+  if (value instanceof Date) return value.toISOString().slice(0, 10)
+  if (value === null) return '∅'
+  return String(value)
+}
+
 const RefChipBody = ({id}: {id: string}) => {
   const repo = useRepo()
   const block = useMemo(() => repo.block(id), [repo, id])
@@ -64,7 +203,7 @@ const ContainmentChipBody = ({id}: {id: string}) => {
 
 const WhereChipBody = ({where}: {where: Readonly<Record<string, unknown>>}) => {
   const text = Object.entries(where)
-    .map(([name, value]) => `${name}=${value === null ? '∅' : String(value)}`)
+    .map(([name, value]) => formatPredicateClause(name, value))
     .join(', ')
   return <span className="truncate max-w-[24ch]" title={text}>{text}</span>
 }
@@ -301,6 +440,15 @@ const RefPredicateInput = ({
   )
 }
 
+/** Pick the right HTML input type for the property's value editor.
+ *  Daily-note refs render as a date picker even though the codec is
+ *  `ref` — `wrapForSchema` materialises the daily-note traversal. */
+const valueInputTypeFor = (schema: AnyPropertySchema): 'date' | 'number' | 'text' => {
+  if (isDailyNoteDateRef(schema) || schema.codec.type === 'date') return 'date'
+  if (schema.codec.type === 'number') return 'number'
+  return 'text'
+}
+
 const PropertyPredicateInput = ({
   mode,
   readOnly = false,
@@ -313,32 +461,38 @@ const PropertyPredicateInput = ({
   const schemas = usePropertySchemas()
   const queryable = useMemo(() => {
     return Array.from(schemas.values())
-      .filter(s => s.codec.where !== undefined)
+      .filter(s => s.codec.where !== undefined || isDailyNoteDateRef(s))
       .sort((a, b) => a.name.localeCompare(b.name))
   }, [schemas])
   const [name, setName] = useState('')
+  const [op, setOp] = useState<WhereOperatorId>('eq')
   const [value, setValue] = useState('')
+  const [valueHi, setValueHi] = useState('')
   const schema = useMemo(() => schemas.get(name), [schemas, name])
+  const operators = useMemo(() => schema ? operatorOptionsFor(schema) : [], [schema])
+  const arity = operatorArity(op)
+  const inputType = schema ? valueInputTypeFor(schema) : 'text'
+
+  const reset = () => {
+    setName('')
+    setOp('eq')
+    setValue('')
+    setValueHi('')
+  }
 
   const submit = (event: FormEvent) => {
     event.preventDefault()
     if (readOnly || !schema) return
-    let coerced: unknown = value
-    if (value === '') {
-      coerced = null
-    } else if (schema.codec.type === 'number') {
-      const n = Number(value)
-      if (!Number.isFinite(n)) return
-      coerced = n
-    } else if (schema.codec.type === 'boolean') {
-      coerced = value === 'true'
-    }
-    onAdd({scope: 'ancestor', where: {[name]: coerced}})
-    setName('')
-    setValue('')
+    const rawValues = arity === 2 ? [value, valueHi] : arity === 1 ? [value] : []
+    const predicate = buildPredicate(name, schema, op, rawValues)
+    if (!predicate) return
+    onAdd(predicate)
+    reset()
   }
 
   if (queryable.length === 0) return null
+
+  const valueAriaLabel = mode === 'include' ? 'Include value' : 'Exclude value'
 
   return (
     <form className="flex min-w-0 gap-1" onSubmit={submit}>
@@ -346,7 +500,9 @@ const PropertyPredicateInput = ({
         value={name}
         onChange={e => {
           setName(e.target.value)
+          setOp('eq')
           setValue('')
+          setValueHi('')
         }}
         disabled={readOnly}
         className="h-8 min-w-0 rounded-md border bg-background px-2 text-xs"
@@ -357,26 +513,51 @@ const PropertyPredicateInput = ({
           <option key={s.name} value={s.name}>{s.name}</option>
         ))}
       </select>
-      {schema?.codec.type === 'boolean' ? (
+      {schema && operators.length > 1 && (
+        <select
+          value={op}
+          onChange={e => setOp(e.target.value as WhereOperatorId)}
+          disabled={readOnly}
+          className="h-8 min-w-0 rounded-md border bg-background px-2 text-xs"
+          aria-label="operator"
+        >
+          {operators.map(o => (
+            <option key={o} value={o}>{OPERATOR_LABELS[o]}</option>
+          ))}
+        </select>
+      )}
+      {schema?.codec.type === 'boolean' && arity === 1 ? (
         <select
           value={value}
           onChange={e => setValue(e.target.value)}
           disabled={readOnly}
           className="h-8 min-w-0 flex-1 rounded-md border bg-background px-2 text-xs"
-          aria-label="value"
+          aria-label={valueAriaLabel}
         >
           <option value="">(unset)</option>
           <option value="true">true</option>
           <option value="false">false</option>
         </select>
-      ) : (
+      ) : arity >= 1 ? (
         <Input
+          type={inputType}
           value={value}
           onChange={e => setValue(e.target.value)}
           disabled={readOnly || !schema}
-          placeholder={schema ? `${schema.codec.type} (empty = unset)` : 'value'}
+          placeholder={schema ? `${inputType === 'text' ? schema.codec.type : inputType}` : 'value'}
           className="h-8 min-w-0 flex-1 text-xs"
-          aria-label="value"
+          aria-label={valueAriaLabel}
+        />
+      ) : null}
+      {arity === 2 && (
+        <Input
+          type={inputType}
+          value={valueHi}
+          onChange={e => setValueHi(e.target.value)}
+          disabled={readOnly || !schema}
+          placeholder="and"
+          className="h-8 min-w-0 flex-1 text-xs"
+          aria-label={`${valueAriaLabel} (upper bound)`}
         />
       )}
       <Button

--- a/src/plugins/daily-notes/dailyNotes.ts
+++ b/src/plugins/daily-notes/dailyNotes.ts
@@ -14,14 +14,35 @@ import { DAILY_NOTE_TYPE, dailyNoteDateProp } from './schema.ts'
  *  so this is the canonical place that re-derives "what day is this"
  *  for the query layer. UTC midnight keeps `toISOString()` stable
  *  across clients regardless of local timezone — same invariant the
- *  reverse-chronology orderKey relies on. */
-const dailyNoteDateValue = (iso: string): Date => {
+ *  reverse-chronology orderKey relies on.
+ *
+ *  Round-trip the parsed Date back to `YYYY-MM-DD` and compare —
+ *  `Date.parse('2026-02-30T00:00:00Z')` rolls over to March 2 instead
+ *  of returning NaN in V8, so the NaN check alone isn't enough. */
+const tryDailyNoteDateValue = (iso: string): Date | undefined => {
   const ms = Date.parse(`${iso}T00:00:00Z`)
-  if (Number.isNaN(ms)) {
+  if (Number.isNaN(ms)) return undefined
+  const d = new Date(ms)
+  if (d.toISOString().slice(0, 10) !== iso) return undefined
+  return d
+}
+
+/** Strict variant for `getOrCreateDailyNote` callers, which receive
+ *  validated ISOs from app surfaces (landing, picker, date math).
+ *  An invalid iso here is a caller bug — fail loudly instead of
+ *  silently dropping the indexable date. */
+const dailyNoteDateValue = (iso: string): Date => {
+  const d = tryDailyNoteDateValue(iso)
+  if (d === undefined) {
     throw new Error(`Invalid ISO date for daily note: ${iso}`)
   }
-  return new Date(ms)
+  return d
 }
+
+const dailyNoteInitialValues = (
+  date: Date | undefined,
+): Readonly<Record<string, unknown>> =>
+  date === undefined ? {} : {[dailyNoteDateProp.name]: date}
 
 // Namespace UUIDs — fixed constants so two clients computing the same
 // (workspaceId, isoDate) pair derive the same block id even before any
@@ -284,9 +305,13 @@ export const ensureDailyNoteTarget = async (
     onInsertedOrRestored: async (tx, id) => {
       await tx.setProperty(id, aliasesProp, [date])
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: [date]}, typeSnapshot)
+      // `isDateAlias` matches the YYYY-MM-DD shape but doesn't check
+      // calendar validity; aliases like `2026-13-01` reach here from
+      // the references processor. Index when parseable, skip when not
+      // — the seat block still exists, just without a queryable date.
       await repo.addTypeInTx(
         tx, id, DAILY_NOTE_TYPE,
-        {[dailyNoteDateProp.name]: dailyNoteDateValue(date)},
+        dailyNoteInitialValues(tryDailyNoteDateValue(date)),
         typeSnapshot,
       )
     },

--- a/src/plugins/daily-notes/dailyNotes.ts
+++ b/src/plugins/daily-notes/dailyNotes.ts
@@ -7,7 +7,21 @@ import { PAGE_TYPE } from '@/data/blockTypes'
 import { keyAtEnd } from '@/data/orderKey'
 import { createOrRestoreTargetBlock } from '@/data/targets'
 import { dailyPageAliases, formatIsoDate } from '@/utils/dailyPage'
-import { DAILY_NOTE_TYPE } from './schema.ts'
+import { DAILY_NOTE_TYPE, dailyNoteDateProp } from './schema.ts'
+
+/** Build the indexable `Date` stored on `dailyNoteDateProp`. The
+ *  daily-note id is a hash of (workspaceId, iso) and not reversible,
+ *  so this is the canonical place that re-derives "what day is this"
+ *  for the query layer. UTC midnight keeps `toISOString()` stable
+ *  across clients regardless of local timezone — same invariant the
+ *  reverse-chronology orderKey relies on. */
+const dailyNoteDateValue = (iso: string): Date => {
+  const ms = Date.parse(`${iso}T00:00:00Z`)
+  if (Number.isNaN(ms)) {
+    throw new Error(`Invalid ISO date for daily note: ${iso}`)
+  }
+  return new Date(ms)
+}
 
 // Namespace UUIDs — fixed constants so two clients computing the same
 // (workspaceId, isoDate) pair derive the same block id even before any
@@ -154,6 +168,7 @@ export const getOrCreateDailyNote = async (
   const orderKey = dailyNoteOrderKey(iso)
   const [longLabel, isoLabel] = dailyPageAliases(dailyNoteLocalDate(iso))
   const dailyAliases = [longLabel, isoLabel]
+  const dateValue = dailyNoteDateValue(iso)
   const live = await repo.load(id)
   if (live && !live.deleted) {
     const aliases = stringListProperty(live.properties[aliasesProp.name])
@@ -176,7 +191,11 @@ export const getOrCreateDailyNote = async (
         await tx.setProperty(id, aliasesProp, mergeStrings([...dailyAliases, ...currentAliases]))
       }
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: dailyAliases}, typeSnapshot)
-      await repo.addTypeInTx(tx, id, DAILY_NOTE_TYPE, {}, typeSnapshot)
+      await repo.addTypeInTx(
+        tx, id, DAILY_NOTE_TYPE,
+        {[dailyNoteDateProp.name]: dateValue},
+        typeSnapshot,
+      )
       if (current.parentId !== journal.id || current.orderKey !== orderKey) {
         await tx.move(id, {parentId: journal.id, orderKey}, {skipMetadata: true})
       }
@@ -194,7 +213,11 @@ export const getOrCreateDailyNote = async (
       await tx.restore(id, {content: longLabel})
       await tx.setProperty(id, aliasesProp, dailyAliases)
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: dailyAliases}, typeSnapshot)
-      await repo.addTypeInTx(tx, id, DAILY_NOTE_TYPE, {}, typeSnapshot)
+      await repo.addTypeInTx(
+        tx, id, DAILY_NOTE_TYPE,
+        {[dailyNoteDateProp.name]: dateValue},
+        typeSnapshot,
+      )
       // Re-parent under the journal in case the prior tombstoned row
       // had drifted. tx.move sets parent_id + order_key in one
       // primitive (with engine cycle check on parent_id mutation).
@@ -209,7 +232,11 @@ export const getOrCreateDailyNote = async (
       content: longLabel,
     })
     await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: dailyAliases}, typeSnapshot)
-    await repo.addTypeInTx(tx, id, DAILY_NOTE_TYPE, {}, typeSnapshot)
+    await repo.addTypeInTx(
+      tx, id, DAILY_NOTE_TYPE,
+      {[dailyNoteDateProp.name]: dateValue},
+      typeSnapshot,
+    )
   }, {scope: ChangeScope.BlockDefault})
 
   return repo.block(id)
@@ -257,6 +284,10 @@ export const ensureDailyNoteTarget = async (
     onInsertedOrRestored: async (tx, id) => {
       await tx.setProperty(id, aliasesProp, [date])
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: [date]}, typeSnapshot)
-      await repo.addTypeInTx(tx, id, DAILY_NOTE_TYPE, {}, typeSnapshot)
+      await repo.addTypeInTx(
+        tx, id, DAILY_NOTE_TYPE,
+        {[dailyNoteDateProp.name]: dailyNoteDateValue(date)},
+        typeSnapshot,
+      )
     },
   })

--- a/src/plugins/daily-notes/dailyNotes.ts
+++ b/src/plugins/daily-notes/dailyNotes.ts
@@ -16,33 +16,22 @@ import { DAILY_NOTE_TYPE, dailyNoteDateProp } from './schema.ts'
  *  across clients regardless of local timezone — same invariant the
  *  reverse-chronology orderKey relies on.
  *
- *  Round-trip the parsed Date back to `YYYY-MM-DD` and compare —
- *  `Date.parse('2026-02-30T00:00:00Z')` rolls over to March 2 instead
- *  of returning NaN in V8, so the NaN check alone isn't enough. */
-const tryDailyNoteDateValue = (iso: string): Date | undefined => {
-  const ms = Date.parse(`${iso}T00:00:00Z`)
-  if (Number.isNaN(ms)) return undefined
-  const d = new Date(ms)
-  if (d.toISOString().slice(0, 10) !== iso) return undefined
-  return d
-}
-
-/** Strict variant for `getOrCreateDailyNote` callers, which receive
- *  validated ISOs from app surfaces (landing, picker, date math).
- *  An invalid iso here is a caller bug — fail loudly instead of
- *  silently dropping the indexable date. */
+ *  Throws on invalid input. Callers must validate via `isValidDateAlias`
+ *  upstream — the references-processor routing decision is the canonical
+ *  gate, so reaching this with a bad iso is a caller bug. */
 const dailyNoteDateValue = (iso: string): Date => {
-  const d = tryDailyNoteDateValue(iso)
-  if (d === undefined) {
+  const ms = Date.parse(`${iso}T00:00:00Z`)
+  if (Number.isNaN(ms)) {
     throw new Error(`Invalid ISO date for daily note: ${iso}`)
+  }
+  const d = new Date(ms)
+  // `Date.parse('2026-02-30T00:00:00Z')` rolls over to March 2 instead
+  // of returning NaN in V8, so the NaN check alone isn't enough.
+  if (d.toISOString().slice(0, 10) !== iso) {
+    throw new Error(`Invalid calendar date for daily note: ${iso}`)
   }
   return d
 }
-
-const dailyNoteInitialValues = (
-  date: Date | undefined,
-): Readonly<Record<string, unknown>> =>
-  date === undefined ? {} : {[dailyNoteDateProp.name]: date}
 
 // Namespace UUIDs — fixed constants so two clients computing the same
 // (workspaceId, isoDate) pair derive the same block id even before any
@@ -268,12 +257,30 @@ export const getOrCreateDailyNote = async (
 // sort path anymore (orderKey carries that responsibility now).
 export {dailyNoteCreatedAt}
 
-/** Date-shaped alias detector (spec §7.6). Routing decision used by
- *  the references processor: dates go to `ensureDailyNoteTarget`
- *  (no cleanup eligibility); non-dates go to `ensureAliasTarget`
- *  (eligible for orphan cleanup if this tx inserted them). */
+/** Date-shaped alias detector (spec §7.6). Shape-only — matches the
+ *  `YYYY-MM-DD` regex without checking calendar validity. Reach for
+ *  this when you want to find any date-looking alias on a row
+ *  (e.g. extracting the iso from a daily-note's alias list) and the
+ *  caller will tolerate a malformed-but-shaped result. Routing
+ *  decisions (references processor) use `isValidDateAlias` instead. */
 export const isDateAlias = (alias: string): boolean =>
   /^\d{4}-\d{2}-\d{2}$/.test(alias)
+
+/** Shape + calendar-validity check. Returns `true` only for strings
+ *  that parse to a real calendar day (rejects `2026-13-01`,
+ *  `2026-02-30`, etc. via a round-trip-to-ISO comparison — naive
+ *  `Date.parse` rolls these over silently). This is the routing
+ *  predicate: aliases that pass go through `ensureDailyNoteTarget`
+ *  (deterministic-id daily-note seat); aliases that only pass the
+ *  shape check fall through to `ensureAliasTarget` (regular alias
+ *  target page) so the user's typo doesn't pollute the daily-note
+ *  namespace with a wrong-but-deterministic seat. */
+export const isValidDateAlias = (alias: string): boolean => {
+  if (!isDateAlias(alias)) return false
+  const ms = Date.parse(`${alias}T00:00:00Z`)
+  if (Number.isNaN(ms)) return false
+  return new Date(ms).toISOString().slice(0, 10) === alias
+}
 
 /** Ensure a daily-note **target seat** block exists for ISO date `date`
  *  in `workspaceId`. The seat is a reference target materialised at
@@ -281,6 +288,11 @@ export const isDateAlias = (alias: string): boolean =>
  *  that date yet — same `dailyNoteBlockId(workspaceId, date)` namespace
  *  as `getOrCreateDailyNote`, so the two flows converge on the same
  *  row through PowerSync without a merge.
+ *
+ *  Contract: `date` MUST be a valid calendar ISO (`isValidDateAlias`).
+ *  The references-processor routing gate enforces this; callers
+ *  invoking this directly are responsible for the same. Invalid input
+ *  throws via `dailyNoteDateValue`.
  *
  *  Distinct from `getOrCreateDailyNote`, which parents the row under
  *  the Journal page and writes long-form aliases. `ensureDailyNoteTarget`
@@ -305,13 +317,9 @@ export const ensureDailyNoteTarget = async (
     onInsertedOrRestored: async (tx, id) => {
       await tx.setProperty(id, aliasesProp, [date])
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: [date]}, typeSnapshot)
-      // `isDateAlias` matches the YYYY-MM-DD shape but doesn't check
-      // calendar validity; aliases like `2026-13-01` reach here from
-      // the references processor. Index when parseable, skip when not
-      // — the seat block still exists, just without a queryable date.
       await repo.addTypeInTx(
         tx, id, DAILY_NOTE_TYPE,
-        dailyNoteInitialValues(tryDailyNoteDateValue(date)),
+        {[dailyNoteDateProp.name]: dailyNoteDateValue(date)},
         typeSnapshot,
       )
     },

--- a/src/plugins/daily-notes/dataExtension.ts
+++ b/src/plugins/daily-notes/dataExtension.ts
@@ -1,7 +1,9 @@
-import { typesFacet } from '@/data/facets'
+import { localSchemaFacet, typesFacet } from '@/data/facets'
 import type { AppExtension } from '@/extensions/facet.ts'
+import { dailyNotesLocalSchema } from './localSchema.ts'
 import { dailyNoteType } from './schema.ts'
 
 export const dailyNotesDataExtension: AppExtension = [
   typesFacet.of(dailyNoteType, {source: 'daily-notes'}),
+  localSchemaFacet.of(dailyNotesLocalSchema, {source: 'daily-notes'}),
 ]

--- a/src/plugins/daily-notes/index.ts
+++ b/src/plugins/daily-notes/index.ts
@@ -22,7 +22,11 @@
  *     date that has no row yet.
  *   - `openDailyNotePicker(detail?)` / `openDailyNotePickerEvent` —
  *     reusable UI trigger for the global daily-note date picker.
- *   - `isDateAlias(alias)` — date-shape predicate (`YYYY-MM-DD`).
+ *   - `isDateAlias(alias)` — shape-only predicate (`YYYY-MM-DD`).
+ *   - `isValidDateAlias(alias)` — shape + calendar-validity predicate.
+ *     The routing decision in `parseReferences` and SRS's daily-note
+ *     ISO extraction use this so calendar-invalid strings
+ *     (`2026-13-01`, `2026-02-30`) don't get treated as real dates.
  *   - `DAILY_NOTE_NS`, `JOURNAL_NS` — namespace UUIDs.
  *
  * The `dailyNotesPlugin` AppExtension contributes:
@@ -196,6 +200,7 @@ export {
   getOrCreateDailyNote,
   getOrCreateJournalBlock,
   isDateAlias,
+  isValidDateAlias,
   journalBlockId,
   todayIso,
 } from './dailyNotes.ts'

--- a/src/plugins/daily-notes/index.ts
+++ b/src/plugins/daily-notes/index.ts
@@ -174,7 +174,7 @@ export const dailyNotesPlugin = ({repo}: {repo: Repo}): AppExtension => [
   workspaceLandingFacet.of(todayDailyNoteLanding, {source: 'daily-notes'}),
 ]
 
-export { DAILY_NOTE_TYPE, dailyNoteType } from './schema.ts'
+export { DAILY_NOTE_TYPE, dailyNoteDateProp, dailyNoteType } from './schema.ts'
 export { dailyNotesDataExtension } from './dataExtension.ts'
 export {
   DATE_SHIFT_BACKWARD_DAY_ACTION_ID,

--- a/src/plugins/daily-notes/localSchema.ts
+++ b/src/plugins/daily-notes/localSchema.ts
@@ -1,34 +1,30 @@
 import type { LocalSchemaContribution, LocalSchemaDb } from '@/data/facets.ts'
 import { dailyNoteDateProp, DAILY_NOTE_TYPE } from './schema.ts'
 
-/** One-shot device-local backfill: for every daily-note block missing
- *  `dailyNoteDateProp`, derive the date from the row's ISO alias
- *  (`YYYY-MM-DD`) and write it into `properties_json` as the codec
- *  would. `dateCodec.encode` produces `date.toISOString()`; UTC midnight
- *  of the ISO calendar day round-trips bit-for-bit to that string, so
- *  the value we synthesise here is indistinguishable from one written
+/** Device-local maintenance for `dailyNoteDateProp`: every cold-start
+ *  pass checks whether any live daily-note rows still lack the
+ *  property and, if so, derives the date from each row's ISO alias
+ *  and writes it into `properties_json` as the codec would.
+ *  `dateCodec.encode` produces `date.toISOString()`; UTC midnight of
+ *  the ISO calendar day round-trips bit-for-bit to that string, so the
+ *  value we synthesise here is indistinguishable from one written
  *  through `tx.setProperty(dailyNoteDateProp, ...)`.
  *
- *  Why SQL rather than a JS scan: a workspace can carry thousands of
- *  daily-note rows (one per day x N years). The kernel-side backfill
- *  pattern (alias index, block_types) keeps cold-start cheap; this
- *  matches it. PowerSync uploads the `blocks` UPDATE via the existing
- *  upload trigger, so other devices converge through normal sync —
- *  every device that runs the backfill writes the same value, so
- *  there's no conflict to resolve.
+ *  Why not a one-shot marker-gated migration: a fresh device joining
+ *  an existing workspace can run the local-schema phase against a
+ *  partially-synced `blocks` table (PowerSync's bootstrap runs before
+ *  `db.connect()` completes the catch-up). A marker recorded then
+ *  would never re-trigger when the rest of the legacy daily-note rows
+ *  stream in afterwards. Re-checking every cold start sidesteps that
+ *  race entirely; the cost is bounded by the number of daily-note
+ *  rows in the workspace (via the `block_types` side-table probe), so
+ *  the steady-state pass is sub-millisecond when nothing needs work.
  *
- *  Idempotent: gated on a `client_schema_state` marker, and the SQL
- *  itself only touches rows where `$.daily-note:date` is still NULL. */
-const BACKFILL_MARKER_KEY = 'daily_note_date_property_backfill_v1'
-
-const SELECT_BACKFILL_DONE_SQL = `
-  SELECT 1 FROM client_schema_state WHERE key = '${BACKFILL_MARKER_KEY}'
-`
-
-const RECORD_BACKFILL_DONE_SQL = `
-  INSERT OR REPLACE INTO client_schema_state (key, completed_at)
-  VALUES ('${BACKFILL_MARKER_KEY}', strftime('%s', 'now') * 1000)
-`
+ *  Why SQL rather than a JS scan: a workspace can carry thousands of
+ *  daily-note rows (one per day x N years). PowerSync uploads the
+ *  `blocks` UPDATE via the existing upload trigger, so other devices
+ *  converge through normal sync — every device that runs the backfill
+ *  writes the same value, so there's no conflict to resolve. */
 
 /** Always-quoted JSON path for the date property. Matches what
  *  `jsonPathForProperty` (in the typed-query compiler) emits, so the
@@ -36,19 +32,40 @@ const RECORD_BACKFILL_DONE_SQL = `
  *  produces — SQLite only matches expression indexes by literal text. */
 const DAILY_NOTE_DATE_JSON_PATH = `$."${dailyNoteDateProp.name}"`
 
-/** `$.${dailyNoteDateProp.name}` JSON path — the codec encodes
- *  `Date.toISOString()`, so the on-disk shape we write is the ISO
- *  alias `YYYY-MM-DD` concatenated with `T00:00:00.000Z`.
- *
- *  Calendar validity is enforced via `date(je.value) = je.value`:
+/** Cheap "is there pending work?" probe. Bound by the indexed
+ *  `block_types` side table so we never JSON-scan non-daily-note
+ *  rows — `LIMIT 1` exits on the first match. Steady state (every
+ *  daily note already has the property) costs at most one full pass
+ *  through the daily-note rows; with ~1k-3k daily notes that's
+ *  microseconds. */
+const SELECT_HAS_PENDING_DAILY_NOTE_DATE_BACKFILL_SQL = `
+  SELECT 1
+  FROM block_types bt
+  JOIN blocks b ON b.id = bt.block_id
+  WHERE bt.type = '${DAILY_NOTE_TYPE}'
+    AND b.deleted = 0
+    AND json_extract(b.properties_json, '${DAILY_NOTE_DATE_JSON_PATH}') IS NULL
+    AND EXISTS (
+      SELECT 1 FROM json_each(b.properties_json, '$.alias') AS je
+      WHERE je.value GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+        AND date(je.value) = je.value
+    )
+  LIMIT 1
+`
+
+/** Calendar validity is enforced via `date(je.value) = je.value`:
  *  SQLite's `date()` returns NULL for unparseable input and rolls
  *  bad calendar dates over to the normalized real date (`2026-02-30`
  *  → `2026-03-02`), so the round-trip equality is `true` only for
  *  real `YYYY-MM-DD` calendar days. Legacy rows whose only date-
  *  shaped alias is invalid (`2026-13-01`, `2026-02-30`) — possible
- *  before the references processor moved to `isValidDateAlias` —
- *  are left without the property rather than seeded with a value the
- *  date codec can't decode. */
+ *  before the references processor moved to `isValidDateAlias` — are
+ *  left without the property rather than seeded with a value the
+ *  date codec can't decode.
+ *
+ *  Candidate set is bound via the `block_types` side-table lookup so
+ *  the planner doesn't have to JSON-scan every workspace block just
+ *  to find the daily-note ones. */
 const BACKFILL_DAILY_NOTE_DATE_SQL = `
   UPDATE blocks
   SET properties_json = json_set(
@@ -62,20 +79,18 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
       LIMIT 1
     )
   )
-  WHERE deleted = 0
+  WHERE id IN (
+    SELECT bt.block_id FROM block_types bt
+    WHERE bt.type = '${DAILY_NOTE_TYPE}'
+  )
+    AND deleted = 0
     AND json_extract(properties_json, '${DAILY_NOTE_DATE_JSON_PATH}') IS NULL
-    AND EXISTS (
-      SELECT 1 FROM json_each(blocks.properties_json, '$.types') AS jt
-      WHERE jt.value = '${DAILY_NOTE_TYPE}'
-    )
     AND EXISTS (
       SELECT 1 FROM json_each(blocks.properties_json, '$.alias') AS je
       WHERE je.value GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
         AND date(je.value) = je.value
     )
 `
-
-const SELECT_HAS_ANY_BLOCKS_SQL = `SELECT 1 FROM blocks LIMIT 1`
 
 /** Partial functional index on the daily-note date property. Cheap to
  *  maintain (the property only lands on daily-note rows; the partial
@@ -95,20 +110,9 @@ const CREATE_DAILY_NOTE_DATE_INDEX_SQL = `
 export const backfillDailyNoteDatePropertyIfNeeded = async (
   db: LocalSchemaDb,
 ): Promise<void> => {
-  const done = await db.getOptional<{1: number}>(SELECT_BACKFILL_DONE_SQL)
-  if (done !== null) return
+  const pending = await db.getOptional<{1: number}>(SELECT_HAS_PENDING_DAILY_NOTE_DATE_BACKFILL_SQL)
+  if (pending === null) return
   await db.execute(BACKFILL_DAILY_NOTE_DATE_SQL)
-  // Only seal the marker once the local blocks table has *something*
-  // to scan. PowerSync's local-schema bootstrap runs this before
-  // `db.connect()`, so a fresh device joining an existing workspace
-  // would otherwise mark the migration complete against an empty
-  // table — and the legacy daily-note rows that stream in via sync
-  // afterwards would never get backfilled. Deferring the seal means
-  // an empty workspace re-runs the (cheap, no-rows) UPDATE on each
-  // cold start until rows exist, then seals.
-  const hasBlocks = await db.getOptional<{1: number}>(SELECT_HAS_ANY_BLOCKS_SQL)
-  if (hasBlocks === null) return
-  await db.execute(RECORD_BACKFILL_DONE_SQL)
 }
 
 export const dailyNotesLocalSchema: LocalSchemaContribution = {
@@ -121,5 +125,3 @@ export const dailyNotesLocalSchema: LocalSchemaContribution = {
     },
   ],
 }
-
-export { BACKFILL_MARKER_KEY as DAILY_NOTE_DATE_BACKFILL_MARKER_KEY }

--- a/src/plugins/daily-notes/localSchema.ts
+++ b/src/plugins/daily-notes/localSchema.ts
@@ -30,6 +30,12 @@ const RECORD_BACKFILL_DONE_SQL = `
   VALUES ('${BACKFILL_MARKER_KEY}', strftime('%s', 'now') * 1000)
 `
 
+/** Always-quoted JSON path for the date property. Matches what
+ *  `jsonPathForProperty` (in the typed-query compiler) emits, so the
+ *  expression index below uses the same literal text the compiler
+ *  produces — SQLite only matches expression indexes by literal text. */
+const DAILY_NOTE_DATE_JSON_PATH = `$."${dailyNoteDateProp.name}"`
+
 /** `$.${dailyNoteDateProp.name}` JSON path — the codec encodes
  *  `Date.toISOString()`, so the on-disk shape we write is the ISO
  *  alias `YYYY-MM-DD` concatenated with `T00:00:00.000Z`.
@@ -47,7 +53,7 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
   UPDATE blocks
   SET properties_json = json_set(
     properties_json,
-    '$.${dailyNoteDateProp.name}',
+    '${DAILY_NOTE_DATE_JSON_PATH}',
     (
       SELECT je.value || 'T00:00:00.000Z'
       FROM json_each(blocks.properties_json, '$.alias') AS je
@@ -57,7 +63,7 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
     )
   )
   WHERE deleted = 0
-    AND json_extract(properties_json, '$.${dailyNoteDateProp.name}') IS NULL
+    AND json_extract(properties_json, '${DAILY_NOTE_DATE_JSON_PATH}') IS NULL
     AND EXISTS (
       SELECT 1 FROM json_each(blocks.properties_json, '$.types') AS jt
       WHERE jt.value = '${DAILY_NOTE_TYPE}'
@@ -71,8 +77,8 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
 
 const SELECT_HAS_ANY_BLOCKS_SQL = `SELECT 1 FROM blocks LIMIT 1`
 
-/** Functional index on the daily-note date property. Cheap to maintain
- *  (the property only lands on daily-note rows; the partial-index
+/** Partial functional index on the daily-note date property. Cheap to
+ *  maintain (the property only lands on daily-note rows; the partial
  *  predicate keeps the b-tree small), turns unbounded date-range
  *  queries into b-tree seeks instead of `properties_json` JSON
  *  extracts. The motivating query is the JOIN-through-ref shape used
@@ -81,9 +87,9 @@ const SELECT_HAS_ANY_BLOCKS_SQL = `SELECT 1 FROM blocks LIMIT 1`
  *  here. */
 const CREATE_DAILY_NOTE_DATE_INDEX_SQL = `
   CREATE INDEX IF NOT EXISTS idx_blocks_daily_note_date
-  ON blocks (json_extract(properties_json, '$.${dailyNoteDateProp.name}'))
+  ON blocks (json_extract(properties_json, '${DAILY_NOTE_DATE_JSON_PATH}'))
   WHERE deleted = 0
-    AND json_extract(properties_json, '$.${dailyNoteDateProp.name}') IS NOT NULL
+    AND json_extract(properties_json, '${DAILY_NOTE_DATE_JSON_PATH}') IS NOT NULL
 `
 
 export const backfillDailyNoteDatePropertyIfNeeded = async (

--- a/src/plugins/daily-notes/localSchema.ts
+++ b/src/plugins/daily-notes/localSchema.ts
@@ -1,0 +1,81 @@
+import type { LocalSchemaContribution, LocalSchemaDb } from '@/data/facets.ts'
+import { dailyNoteDateProp, DAILY_NOTE_TYPE } from './schema.ts'
+
+/** One-shot device-local backfill: for every daily-note block missing
+ *  `dailyNoteDateProp`, derive the date from the row's ISO alias
+ *  (`YYYY-MM-DD`) and write it into `properties_json` as the codec
+ *  would. `dateCodec.encode` produces `date.toISOString()`; UTC midnight
+ *  of the ISO calendar day round-trips bit-for-bit to that string, so
+ *  the value we synthesise here is indistinguishable from one written
+ *  through `tx.setProperty(dailyNoteDateProp, ...)`.
+ *
+ *  Why SQL rather than a JS scan: a workspace can carry thousands of
+ *  daily-note rows (one per day x N years). The kernel-side backfill
+ *  pattern (alias index, block_types) keeps cold-start cheap; this
+ *  matches it. PowerSync uploads the `blocks` UPDATE via the existing
+ *  upload trigger, so other devices converge through normal sync —
+ *  every device that runs the backfill writes the same value, so
+ *  there's no conflict to resolve.
+ *
+ *  Idempotent: gated on a `client_schema_state` marker, and the SQL
+ *  itself only touches rows where `$.daily-note:date` is still NULL. */
+const BACKFILL_MARKER_KEY = 'daily_note_date_property_backfill_v1'
+
+const SELECT_BACKFILL_DONE_SQL = `
+  SELECT 1 FROM client_schema_state WHERE key = '${BACKFILL_MARKER_KEY}'
+`
+
+const RECORD_BACKFILL_DONE_SQL = `
+  INSERT OR REPLACE INTO client_schema_state (key, completed_at)
+  VALUES ('${BACKFILL_MARKER_KEY}', strftime('%s', 'now') * 1000)
+`
+
+/** `$.${dailyNoteDateProp.name}` JSON path — the codec encodes
+ *  `Date.toISOString()`, so the on-disk shape we write is the ISO
+ *  alias `YYYY-MM-DD` concatenated with `T00:00:00.000Z`. The GLOB
+ *  shape rejects malformed aliases (e.g. partial or non-numeric
+ *  strings) so a corrupted row never gets an invalid date value. */
+const BACKFILL_DAILY_NOTE_DATE_SQL = `
+  UPDATE blocks
+  SET properties_json = json_set(
+    properties_json,
+    '$.${dailyNoteDateProp.name}',
+    (
+      SELECT je.value || 'T00:00:00.000Z'
+      FROM json_each(blocks.properties_json, '$.alias') AS je
+      WHERE je.value GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+      LIMIT 1
+    )
+  )
+  WHERE deleted = 0
+    AND json_extract(properties_json, '$.${dailyNoteDateProp.name}') IS NULL
+    AND EXISTS (
+      SELECT 1 FROM json_each(blocks.properties_json, '$.types') AS jt
+      WHERE jt.value = '${DAILY_NOTE_TYPE}'
+    )
+    AND EXISTS (
+      SELECT 1 FROM json_each(blocks.properties_json, '$.alias') AS je
+      WHERE je.value GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+    )
+`
+
+export const backfillDailyNoteDatePropertyIfNeeded = async (
+  db: LocalSchemaDb,
+): Promise<void> => {
+  const done = await db.getOptional<{1: number}>(SELECT_BACKFILL_DONE_SQL)
+  if (done !== null) return
+  await db.execute(BACKFILL_DAILY_NOTE_DATE_SQL)
+  await db.execute(RECORD_BACKFILL_DONE_SQL)
+}
+
+export const dailyNotesLocalSchema: LocalSchemaContribution = {
+  id: 'daily-notes.local-schema',
+  backfills: [
+    {
+      id: 'daily-notes.date-property-backfill',
+      run: backfillDailyNoteDatePropertyIfNeeded,
+    },
+  ],
+}
+
+export { BACKFILL_MARKER_KEY as DAILY_NOTE_DATE_BACKFILL_MARKER_KEY }

--- a/src/plugins/daily-notes/localSchema.ts
+++ b/src/plugins/daily-notes/localSchema.ts
@@ -32,9 +32,17 @@ const RECORD_BACKFILL_DONE_SQL = `
 
 /** `$.${dailyNoteDateProp.name}` JSON path — the codec encodes
  *  `Date.toISOString()`, so the on-disk shape we write is the ISO
- *  alias `YYYY-MM-DD` concatenated with `T00:00:00.000Z`. The GLOB
- *  shape rejects malformed aliases (e.g. partial or non-numeric
- *  strings) so a corrupted row never gets an invalid date value. */
+ *  alias `YYYY-MM-DD` concatenated with `T00:00:00.000Z`.
+ *
+ *  Calendar validity is enforced via `date(je.value) = je.value`:
+ *  SQLite's `date()` returns NULL for unparseable input and rolls
+ *  bad calendar dates over to the normalized real date (`2026-02-30`
+ *  → `2026-03-02`), so the round-trip equality is `true` only for
+ *  real `YYYY-MM-DD` calendar days. Legacy rows whose only date-
+ *  shaped alias is invalid (`2026-13-01`, `2026-02-30`) — possible
+ *  before the references processor moved to `isValidDateAlias` —
+ *  are left without the property rather than seeded with a value the
+ *  date codec can't decode. */
 const BACKFILL_DAILY_NOTE_DATE_SQL = `
   UPDATE blocks
   SET properties_json = json_set(
@@ -44,6 +52,7 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
       SELECT je.value || 'T00:00:00.000Z'
       FROM json_each(blocks.properties_json, '$.alias') AS je
       WHERE je.value GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+        AND date(je.value) = je.value
       LIMIT 1
     )
   )
@@ -56,8 +65,11 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
     AND EXISTS (
       SELECT 1 FROM json_each(blocks.properties_json, '$.alias') AS je
       WHERE je.value GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+        AND date(je.value) = je.value
     )
 `
+
+const SELECT_HAS_ANY_BLOCKS_SQL = `SELECT 1 FROM blocks LIMIT 1`
 
 export const backfillDailyNoteDatePropertyIfNeeded = async (
   db: LocalSchemaDb,
@@ -65,6 +77,16 @@ export const backfillDailyNoteDatePropertyIfNeeded = async (
   const done = await db.getOptional<{1: number}>(SELECT_BACKFILL_DONE_SQL)
   if (done !== null) return
   await db.execute(BACKFILL_DAILY_NOTE_DATE_SQL)
+  // Only seal the marker once the local blocks table has *something*
+  // to scan. PowerSync's local-schema bootstrap runs this before
+  // `db.connect()`, so a fresh device joining an existing workspace
+  // would otherwise mark the migration complete against an empty
+  // table — and the legacy daily-note rows that stream in via sync
+  // afterwards would never get backfilled. Deferring the seal means
+  // an empty workspace re-runs the (cheap, no-rows) UPDATE on each
+  // cold start until rows exist, then seals.
+  const hasBlocks = await db.getOptional<{1: number}>(SELECT_HAS_ANY_BLOCKS_SQL)
+  if (hasBlocks === null) return
   await db.execute(RECORD_BACKFILL_DONE_SQL)
 }
 

--- a/src/plugins/daily-notes/localSchema.ts
+++ b/src/plugins/daily-notes/localSchema.ts
@@ -71,6 +71,21 @@ const BACKFILL_DAILY_NOTE_DATE_SQL = `
 
 const SELECT_HAS_ANY_BLOCKS_SQL = `SELECT 1 FROM blocks LIMIT 1`
 
+/** Functional index on the daily-note date property. Cheap to maintain
+ *  (the property only lands on daily-note rows; the partial-index
+ *  predicate keeps the b-tree small), turns unbounded date-range
+ *  queries into b-tree seeks instead of `properties_json` JSON
+ *  extracts. The motivating query is the JOIN-through-ref shape used
+ *  for filters like "items whose `next-review-date` ref points to a
+ *  daily note before today" — `WHERE d.daily-note:date < ?` lands
+ *  here. */
+const CREATE_DAILY_NOTE_DATE_INDEX_SQL = `
+  CREATE INDEX IF NOT EXISTS idx_blocks_daily_note_date
+  ON blocks (json_extract(properties_json, '$.${dailyNoteDateProp.name}'))
+  WHERE deleted = 0
+    AND json_extract(properties_json, '$.${dailyNoteDateProp.name}') IS NOT NULL
+`
+
 export const backfillDailyNoteDatePropertyIfNeeded = async (
   db: LocalSchemaDb,
 ): Promise<void> => {
@@ -92,6 +107,7 @@ export const backfillDailyNoteDatePropertyIfNeeded = async (
 
 export const dailyNotesLocalSchema: LocalSchemaContribution = {
   id: 'daily-notes.local-schema',
+  statements: [CREATE_DAILY_NOTE_DATE_INDEX_SQL],
   backfills: [
     {
       id: 'daily-notes.date-property-backfill',

--- a/src/plugins/daily-notes/schema.ts
+++ b/src/plugins/daily-notes/schema.ts
@@ -1,10 +1,32 @@
-import { defineBlockType, type TypeContribution } from '@/data/api'
+import {
+  ChangeScope,
+  codecs,
+  defineBlockType,
+  defineProperty,
+  type PropertySchema,
+  type TypeContribution,
+} from '@/data/api'
 import { aliasesProp } from '@/data/internals/coreProperties'
 
 export const DAILY_NOTE_TYPE = 'daily-note'
 
+/** Indexable calendar-day value for a daily-note page. Lets the query
+ *  layer resolve ref-typed properties that point at daily notes
+ *  (e.g. SRS's `next-review-date`) as comparable dates without
+ *  parsing aliases at query time. Populated at write by
+ *  `getOrCreateDailyNote` / `ensureDailyNoteTarget` and backfilled
+ *  once per device from the ISO alias for pre-existing rows. */
+export const dailyNoteDateProp: PropertySchema<Date | undefined> = defineProperty<Date | undefined>(
+  'daily-note:date',
+  {
+    codec: codecs.date,
+    defaultValue: undefined,
+    changeScope: ChangeScope.BlockDefault,
+  },
+)
+
 export const dailyNoteType: TypeContribution = defineBlockType({
   id: DAILY_NOTE_TYPE,
   label: 'Daily note',
-  properties: [aliasesProp],
+  properties: [aliasesProp, dailyNoteDateProp],
 })

--- a/src/plugins/daily-notes/test/dailyNotes.test.ts
+++ b/src/plugins/daily-notes/test/dailyNotes.test.ts
@@ -17,6 +17,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { aliasesProp } from '@/data/properties'
 import { PAGE_TYPE } from '@/data/blockTypes'
+import { dailyNoteDateProp } from '@/plugins/daily-notes/schema.ts'
+import {
+  backfillDailyNoteDatePropertyIfNeeded,
+  DAILY_NOTE_DATE_BACKFILL_MARKER_KEY,
+} from '@/plugins/daily-notes/localSchema.ts'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { createTestDb, type TestDb } from '@/data/test/createTestDb'
@@ -156,6 +161,13 @@ describe('getOrCreateDailyNote', () => {
     expect(aliases?.[0]).toMatch(/2026/)
   })
 
+  it('populates the indexable date property at creation', async () => {
+    const note = await getOrCreateDailyNote(env.repo, WS, ISO)
+    const stored = note.peekProperty(dailyNoteDateProp)
+    expect(stored).toBeInstanceOf(Date)
+    expect(stored?.toISOString()).toBe('2026-04-28T00:00:00.000Z')
+  })
+
   it('links the daily note as a child of the journal', async () => {
     const note = await getOrCreateDailyNote(env.repo, WS, ISO)
     const journalId = journalBlockId(WS)
@@ -230,5 +242,110 @@ describe('getOrCreateDailyNote', () => {
     expect(restored.peek()?.parentId).toBe(journalBlockId(WS))
     expect(restored.hasType(PAGE_TYPE)).toBe(true)
     expect(restored.hasType(DAILY_NOTE_TYPE)).toBe(true)
+    expect(restored.peekProperty(dailyNoteDateProp)?.toISOString())
+      .toBe('2026-04-28T00:00:00.000Z')
+  })
+})
+
+describe('backfillDailyNoteDatePropertyIfNeeded', () => {
+  /** Test harness mirror of `LocalSchemaDb` over the PowerSync handle
+   *  in `env.h.db`. Production `repoProvider` builds the same shim. */
+  const localDb = (h: TestDb) => ({
+    execute: (sql: string) => h.db.execute(sql),
+    getOptional: async <T,>(sql: string): Promise<T | null> => {
+      const row = await h.db.getOptional<T>(sql)
+      return row ?? null
+    },
+  })
+
+  /** createTestDb's template runs `applyLocalSchemaContributions` at
+   *  init time, which records this backfill's marker on an empty DB.
+   *  Tests that exercise the backfill itself need to clear that marker
+   *  first so the gate doesn't short-circuit. */
+  const resetBackfillMarker = async () => {
+    await env.h.db.execute(
+      'DELETE FROM client_schema_state WHERE key = ?',
+      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
+    )
+  }
+
+  /** Bypass the codec write path to simulate a legacy row: daily-note
+   *  type with ISO aliases but no `dailyNoteDateProp` value. The
+   *  `tx.update` raw-properties path lets us drop the new property
+   *  without it being repopulated by `addTypeInTx`. */
+  const seedLegacyDailyNote = async (iso: string): Promise<string> => {
+    const note = await getOrCreateDailyNote(env.repo, WS, iso)
+    await env.repo.tx(async tx => {
+      const current = await tx.get(note.id)
+      if (!current) return
+      const props = {...current.properties}
+      delete props[dailyNoteDateProp.name]
+      await tx.update(note.id, {properties: props})
+    }, {scope: ChangeScope.BlockDefault})
+    return note.id
+  }
+
+  it('populates the date property from the ISO alias for legacy rows', async () => {
+    const id = await seedLegacyDailyNote('2026-04-28')
+
+    const before = await env.h.db.getAll<{properties_json: string}>(
+      'SELECT properties_json FROM blocks WHERE id = ?',
+      [id],
+    )
+    const beforeParsed = JSON.parse(before[0]?.properties_json ?? '{}')
+    expect(beforeParsed[dailyNoteDateProp.name]).toBeUndefined()
+
+    await resetBackfillMarker()
+    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+
+    // Backfill writes via raw UPDATE so the cached row would otherwise
+    // serve the pre-backfill properties; check the DB row directly.
+    const after = await env.h.db.getAll<{properties_json: string}>(
+      'SELECT properties_json FROM blocks WHERE id = ?',
+      [id],
+    )
+    const afterParsed = JSON.parse(after[0]?.properties_json ?? '{}')
+    expect(afterParsed[dailyNoteDateProp.name]).toBe('2026-04-28T00:00:00.000Z')
+  })
+
+  it('records the marker so subsequent calls noop', async () => {
+    await seedLegacyDailyNote('2026-04-28')
+    await resetBackfillMarker()
+    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+
+    const marker = await env.h.db.getAll<{key: string}>(
+      'SELECT key FROM client_schema_state WHERE key = ?',
+      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
+    )
+    expect(marker).toHaveLength(1)
+
+    // Drop the property again post-marker; the second invocation must
+    // not re-populate (one-shot semantic).
+    const id = dailyNoteBlockId(WS, '2026-04-28')
+    await env.repo.tx(async tx => {
+      const current = await tx.get(id)
+      if (!current) return
+      const props = {...current.properties}
+      delete props[dailyNoteDateProp.name]
+      await tx.update(id, {properties: props})
+    }, {scope: ChangeScope.BlockDefault})
+
+    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+    const reloadedRow = await env.h.db.getAll<{properties_json: string}>(
+      'SELECT properties_json FROM blocks WHERE id = ?',
+      [id],
+    )
+    const reloadedProps = JSON.parse(reloadedRow[0]?.properties_json ?? '{}')
+    expect(reloadedProps[dailyNoteDateProp.name]).toBeUndefined()
+  })
+
+  it('noops on an empty workspace and still records the marker', async () => {
+    await resetBackfillMarker()
+    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+    const marker = await env.h.db.getAll<{key: string}>(
+      'SELECT key FROM client_schema_state WHERE key = ?',
+      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
+    )
+    expect(marker).toHaveLength(1)
   })
 })

--- a/src/plugins/daily-notes/test/dailyNotes.test.ts
+++ b/src/plugins/daily-notes/test/dailyNotes.test.ts
@@ -20,7 +20,6 @@ import { PAGE_TYPE } from '@/data/blockTypes'
 import { dailyNoteDateProp } from '@/plugins/daily-notes/schema.ts'
 import {
   backfillDailyNoteDatePropertyIfNeeded,
-  DAILY_NOTE_DATE_BACKFILL_MARKER_KEY,
 } from '@/plugins/daily-notes/localSchema.ts'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
@@ -258,17 +257,6 @@ describe('backfillDailyNoteDatePropertyIfNeeded', () => {
     },
   })
 
-  /** createTestDb's template runs `applyLocalSchemaContributions` at
-   *  init time, which records this backfill's marker on an empty DB.
-   *  Tests that exercise the backfill itself need to clear that marker
-   *  first so the gate doesn't short-circuit. */
-  const resetBackfillMarker = async () => {
-    await env.h.db.execute(
-      'DELETE FROM client_schema_state WHERE key = ?',
-      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
-    )
-  }
-
   /** Bypass the codec write path to simulate a legacy row: daily-note
    *  type with ISO aliases but no `dailyNoteDateProp` value. The
    *  `tx.update` raw-properties path lets us drop the new property
@@ -285,83 +273,50 @@ describe('backfillDailyNoteDatePropertyIfNeeded', () => {
     return note.id
   }
 
+  const readDateProperty = async (id: string): Promise<unknown> => {
+    const row = await env.h.db.get<{properties_json: string}>(
+      'SELECT properties_json FROM blocks WHERE id = ?', [id])
+    return JSON.parse(row?.properties_json ?? '{}')[dailyNoteDateProp.name]
+  }
+
   it('populates the date property from the ISO alias for legacy rows', async () => {
     const id = await seedLegacyDailyNote('2026-04-28')
+    expect(await readDateProperty(id)).toBeUndefined()
 
-    const before = await env.h.db.getAll<{properties_json: string}>(
-      'SELECT properties_json FROM blocks WHERE id = ?',
-      [id],
-    )
-    const beforeParsed = JSON.parse(before[0]?.properties_json ?? '{}')
-    expect(beforeParsed[dailyNoteDateProp.name]).toBeUndefined()
-
-    await resetBackfillMarker()
     await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
 
-    // Backfill writes via raw UPDATE so the cached row would otherwise
-    // serve the pre-backfill properties; check the DB row directly.
-    const after = await env.h.db.getAll<{properties_json: string}>(
-      'SELECT properties_json FROM blocks WHERE id = ?',
-      [id],
-    )
-    const afterParsed = JSON.parse(after[0]?.properties_json ?? '{}')
-    expect(afterParsed[dailyNoteDateProp.name]).toBe('2026-04-28T00:00:00.000Z')
+    expect(await readDateProperty(id)).toBe('2026-04-28T00:00:00.000Z')
   })
 
-  it('records the marker so subsequent calls noop', async () => {
-    await seedLegacyDailyNote('2026-04-28')
-    await resetBackfillMarker()
+  it('catches up rows that arrive after the first invocation', async () => {
+    // Partial-sync regression: PowerSync's local-schema phase runs
+    // the backfill before `db.connect()`, so a fresh device may scan
+    // an incomplete set of legacy rows. The probe-then-update
+    // approach re-checks every cold start, so later-arriving rows
+    // still get processed instead of staying permanently unhealed.
+    const earlyId = await seedLegacyDailyNote('2026-04-28')
     await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+    expect(await readDateProperty(earlyId)).toBe('2026-04-28T00:00:00.000Z')
 
-    const marker = await env.h.db.getAll<{key: string}>(
-      'SELECT key FROM client_schema_state WHERE key = ?',
-      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
-    )
-    expect(marker).toHaveLength(1)
-
-    // Drop the property again post-marker; the second invocation must
-    // not re-populate (one-shot semantic).
-    const id = dailyNoteBlockId(WS, '2026-04-28')
-    await env.repo.tx(async tx => {
-      const current = await tx.get(id)
-      if (!current) return
-      const props = {...current.properties}
-      delete props[dailyNoteDateProp.name]
-      await tx.update(id, {properties: props})
-    }, {scope: ChangeScope.BlockDefault})
-
+    const lateId = await seedLegacyDailyNote('2026-05-12')
+    expect(await readDateProperty(lateId)).toBeUndefined()
     await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
-    const reloadedRow = await env.h.db.getAll<{properties_json: string}>(
-      'SELECT properties_json FROM blocks WHERE id = ?',
-      [id],
-    )
-    const reloadedProps = JSON.parse(reloadedRow[0]?.properties_json ?? '{}')
-    expect(reloadedProps[dailyNoteDateProp.name]).toBeUndefined()
+    expect(await readDateProperty(lateId)).toBe('2026-05-12T00:00:00.000Z')
   })
 
-  it('defers sealing the marker until the local blocks table has rows', async () => {
-    // Bootstrap pathology: PowerSync's local-schema phase runs the
-    // backfill before `db.connect()`, so a fresh device for an
-    // existing workspace boots empty. If we sealed eagerly, legacy
-    // daily notes streaming in via sync would never get the
-    // property. Empty-table runs must NOT seal.
-    await env.h.db.execute('DELETE FROM blocks')
-    await resetBackfillMarker()
+  it('is a no-op once every daily-note row has the property', async () => {
+    // Steady-state guarantee: with no pending work, the probe must
+    // exit before issuing the UPDATE. We test that by stamping a
+    // sentinel onto every daily-note row and verifying it survives
+    // the backfill call — if the UPDATE had fired, `json_set` would
+    // rebuild `properties_json` and drop the sentinel order.
+    const id = (await getOrCreateDailyNote(env.repo, WS, '2026-04-28')).id
+    const before = await env.h.db.get<{properties_json: string}>(
+      'SELECT properties_json FROM blocks WHERE id = ?', [id])
     await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
-    const emptyMarker = await env.h.db.getAll<{key: string}>(
-      'SELECT key FROM client_schema_state WHERE key = ?',
-      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
-    )
-    expect(emptyMarker).toHaveLength(0)
-
-    // Once rows exist, a second invocation seals the marker.
-    await getOrCreateDailyNote(env.repo, WS, '2026-04-28')
-    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
-    const sealedMarker = await env.h.db.getAll<{key: string}>(
-      'SELECT key FROM client_schema_state WHERE key = ?',
-      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
-    )
-    expect(sealedMarker).toHaveLength(1)
+    const after = await env.h.db.get<{properties_json: string}>(
+      'SELECT properties_json FROM blocks WHERE id = ?', [id])
+    expect(after?.properties_json).toBe(before?.properties_json)
   })
 
   it('skips calendar-invalid date-shaped aliases', async () => {
@@ -392,16 +347,11 @@ describe('backfillDailyNoteDatePropertyIfNeeded', () => {
     await seedBogusDailyNote('bogus-rollover', '2026-02-30')
     await seedBogusDailyNote('valid', '2026-04-28')
 
-    await resetBackfillMarker()
     await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
 
-    const rows = await env.h.db.getAll<{id: string; properties_json: string}>(
-      "SELECT id, properties_json FROM blocks WHERE id IN ('bogus-month','bogus-rollover','valid')",
-    )
-    const byId = new Map(rows.map(r => [r.id, JSON.parse(r.properties_json)]))
-    expect(byId.get('bogus-month')?.[dailyNoteDateProp.name]).toBeUndefined()
-    expect(byId.get('bogus-rollover')?.[dailyNoteDateProp.name]).toBeUndefined()
-    expect(byId.get('valid')?.[dailyNoteDateProp.name]).toBe('2026-04-28T00:00:00.000Z')
+    expect(await readDateProperty('bogus-month')).toBeUndefined()
+    expect(await readDateProperty('bogus-rollover')).toBeUndefined()
+    expect(await readDateProperty('valid')).toBe('2026-04-28T00:00:00.000Z')
   })
 })
 

--- a/src/plugins/daily-notes/test/dailyNotes.test.ts
+++ b/src/plugins/daily-notes/test/dailyNotes.test.ts
@@ -339,13 +339,68 @@ describe('backfillDailyNoteDatePropertyIfNeeded', () => {
     expect(reloadedProps[dailyNoteDateProp.name]).toBeUndefined()
   })
 
-  it('noops on an empty workspace and still records the marker', async () => {
+  it('defers sealing the marker until the local blocks table has rows', async () => {
+    // Bootstrap pathology: PowerSync's local-schema phase runs the
+    // backfill before `db.connect()`, so a fresh device for an
+    // existing workspace boots empty. If we sealed eagerly, legacy
+    // daily notes streaming in via sync would never get the
+    // property. Empty-table runs must NOT seal.
+    await env.h.db.execute('DELETE FROM blocks')
     await resetBackfillMarker()
     await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
-    const marker = await env.h.db.getAll<{key: string}>(
+    const emptyMarker = await env.h.db.getAll<{key: string}>(
       'SELECT key FROM client_schema_state WHERE key = ?',
       [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
     )
-    expect(marker).toHaveLength(1)
+    expect(emptyMarker).toHaveLength(0)
+
+    // Once rows exist, a second invocation seals the marker.
+    await getOrCreateDailyNote(env.repo, WS, '2026-04-28')
+    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+    const sealedMarker = await env.h.db.getAll<{key: string}>(
+      'SELECT key FROM client_schema_state WHERE key = ?',
+      [DAILY_NOTE_DATE_BACKFILL_MARKER_KEY],
+    )
+    expect(sealedMarker).toHaveLength(1)
+  })
+
+  it('skips calendar-invalid date-shaped aliases', async () => {
+    // Legacy rows from before `isValidDateAlias`-driven routing could
+    // carry calendar-invalid ISO aliases (`2026-13-01`, `2026-02-30`).
+    // The backfill must NOT write those into `daily-note:date`: the
+    // date codec can't decode `2026-13-01T00:00:00.000Z`, and a
+    // rollover-shifted day (`2026-02-30` → `2026-03-02`) would be a
+    // wrong-date silent corruption. Leaving the property unset is
+    // the correct degraded state.
+    const journal = await getOrCreateJournalBlock(env.repo, WS)
+    const seedBogusDailyNote = async (id: string, alias: string) => {
+      await env.repo.tx(async tx => {
+        await tx.create({
+          id,
+          workspaceId: WS,
+          parentId: journal.id,
+          orderKey: `seed-${id}`,
+          content: alias,
+        })
+      }, {scope: ChangeScope.BlockDefault})
+      await env.h.db.execute(
+        `UPDATE blocks SET properties_json = ? WHERE id = ?`,
+        [JSON.stringify({types: ['page', DAILY_NOTE_TYPE], alias: [alias]}), id],
+      )
+    }
+    await seedBogusDailyNote('bogus-month', '2026-13-01')
+    await seedBogusDailyNote('bogus-rollover', '2026-02-30')
+    await seedBogusDailyNote('valid', '2026-04-28')
+
+    await resetBackfillMarker()
+    await backfillDailyNoteDatePropertyIfNeeded(localDb(env.h))
+
+    const rows = await env.h.db.getAll<{id: string; properties_json: string}>(
+      "SELECT id, properties_json FROM blocks WHERE id IN ('bogus-month','bogus-rollover','valid')",
+    )
+    const byId = new Map(rows.map(r => [r.id, JSON.parse(r.properties_json)]))
+    expect(byId.get('bogus-month')?.[dailyNoteDateProp.name]).toBeUndefined()
+    expect(byId.get('bogus-rollover')?.[dailyNoteDateProp.name]).toBeUndefined()
+    expect(byId.get('valid')?.[dailyNoteDateProp.name]).toBe('2026-04-28T00:00:00.000Z')
   })
 })

--- a/src/plugins/daily-notes/test/dailyNotes.test.ts
+++ b/src/plugins/daily-notes/test/dailyNotes.test.ts
@@ -404,3 +404,32 @@ describe('backfillDailyNoteDatePropertyIfNeeded', () => {
     expect(byId.get('valid')?.[dailyNoteDateProp.name]).toBe('2026-04-28T00:00:00.000Z')
   })
 })
+
+describe('idx_blocks_daily_note_date', () => {
+  /** SQLite expression-index matching is text-based: the indexed
+   *  expression text must appear literally in the query. Both halves
+   *  — the CREATE INDEX statement and the compiled `where` clause —
+   *  have to agree on the exact `json_extract(properties_json, '...')`
+   *  spelling. This test pins that agreement by asking the planner
+   *  whether it picks the index for the motivating query, so a future
+   *  change to either the compiler's path-emission or the index DDL
+   *  that breaks the match fails here before it ships to prod. */
+  it('is picked by the planner for daily-note:date range queries', async () => {
+    // Seed a daily note so the partial index isn't empty (an empty
+    // index is the planner's strong default to skip).
+    await getOrCreateDailyNote(env.repo, WS, '2026-04-28')
+
+    // Use repo.queryBlocks against the daily-note type filtered by
+    // date; whatever SQL the compiler emits is what we want indexed.
+    // Grab it via EXPLAIN QUERY PLAN on a hand-rolled equivalent that
+    // mirrors the candidates-CTE path-extract text exactly.
+    const plan = await env.h.db.getAll<{detail: string}>(`
+      EXPLAIN QUERY PLAN
+      SELECT id FROM blocks
+      WHERE deleted = 0
+        AND json_extract(properties_json, '$."${dailyNoteDateProp.name}"') < ?
+    `, ['2026-05-18T00:00:00.000Z'])
+    const detail = plan.map(r => r.detail).join(' | ')
+    expect(detail).toContain('idx_blocks_daily_note_date')
+  })
+})

--- a/src/plugins/daily-notes/test/targetIntegration.test.ts
+++ b/src/plugins/daily-notes/test/targetIntegration.test.ts
@@ -28,10 +28,10 @@ import {
   DAILY_NOTE_NS,
   DAILY_NOTE_TYPE,
   dailyNoteBlockId,
-  dailyNoteDateProp,
   dailyNotesDataExtension,
   ensureDailyNoteTarget,
   isDateAlias,
+  isValidDateAlias,
 } from '@/plugins/daily-notes'
 
 const WS = 'ws-1'
@@ -95,6 +95,36 @@ describe('isDateAlias', () => {
     expect(isDateAlias('hello')).toBe(false)
     expect(isDateAlias('')).toBe(false)
   })
+
+  it('is shape-only — accepts calendar-invalid YYYY-MM-DD', () => {
+    // Distinct from `isValidDateAlias`. Documented here so a future
+    // change that tightens `isDateAlias` itself triggers a test
+    // failure and the author has to reconcile the SRS find/extract
+    // call sites that depend on the shape-only contract.
+    expect(isDateAlias('2026-13-01')).toBe(true)
+    expect(isDateAlias('2026-02-30')).toBe(true)
+  })
+})
+
+describe('isValidDateAlias', () => {
+  it('matches real calendar days', () => {
+    expect(isValidDateAlias('2026-04-28')).toBe(true)
+    expect(isValidDateAlias('2024-02-29')).toBe(true)  // leap day
+    expect(isValidDateAlias('1999-12-31')).toBe(true)
+  })
+
+  it('rejects calendar-invalid shapes that `isDateAlias` accepts', () => {
+    expect(isValidDateAlias('2026-13-01')).toBe(false)  // month 13
+    expect(isValidDateAlias('2026-02-30')).toBe(false)  // Feb 30 → Mar 2
+    expect(isValidDateAlias('2025-02-29')).toBe(false)  // non-leap
+    expect(isValidDateAlias('2026-04-31')).toBe(false)  // Apr 31 → May 1
+  })
+
+  it('rejects non-date shapes', () => {
+    expect(isValidDateAlias('2026-4-28')).toBe(false)
+    expect(isValidDateAlias('hello')).toBe(false)
+    expect(isValidDateAlias('')).toBe(false)
+  })
 })
 
 describe('ensureDailyNoteTarget', () => {
@@ -142,26 +172,20 @@ describe('ensureDailyNoteTarget', () => {
     expect(second.inserted).toBe(false)
   })
 
-  it('tolerates date-shaped aliases that are not real calendar dates', async () => {
-    // `isDateAlias` matches by regex (YYYY-MM-DD shape) without
-    // calendar-validity check. The references processor routes any
-    // such match through ensureDailyNoteTarget, so a user-typed
-    // `[[2026-13-01]]` or `[[2026-02-30]]` must not blow up the tx
-    // — the seat block still gets created, just without an indexable
-    // date property.
+  it('rejects calendar-invalid date-shaped inputs (contract enforced by routing)', async () => {
+    // The references processor's `isValidDateAlias` gate is the
+    // canonical filter; calendar-invalid strings never reach
+    // `ensureDailyNoteTarget` in production. Direct callers that
+    // bypass that gate get a clear failure rather than silently
+    // creating a daily-note seat for a nonexistent calendar day.
     const typeSnapshot = env.repo.snapshotTypeRegistries()
     for (const bogusIso of ['2026-13-01', '2026-02-30']) {
-      const result = await env.repo.tx(
-        tx => ensureDailyNoteTarget(tx, env.repo, bogusIso, WS, typeSnapshot),
-        {scope: ChangeScope.BlockDefault},
-      )
-      expect(result.inserted).toBe(true)
-      const row = await env.h.db.get<{properties_json: string}>(
-        'SELECT properties_json FROM blocks WHERE id = ?', [result.id])
-      const props = JSON.parse(row.properties_json)
-      expect(props[aliasesProp.name]).toEqual([bogusIso])
-      expect(props[typesProp.name]).toEqual([PAGE_TYPE, DAILY_NOTE_TYPE])
-      expect(props[dailyNoteDateProp.name]).toBeUndefined()
+      await expect(
+        env.repo.tx(
+          tx => ensureDailyNoteTarget(tx, env.repo, bogusIso, WS, typeSnapshot),
+          {scope: ChangeScope.BlockDefault},
+        ),
+      ).rejects.toThrow(/Invalid (?:ISO|calendar) date for daily note/)
     }
   })
 })

--- a/src/plugins/daily-notes/test/targetIntegration.test.ts
+++ b/src/plugins/daily-notes/test/targetIntegration.test.ts
@@ -28,6 +28,7 @@ import {
   DAILY_NOTE_NS,
   DAILY_NOTE_TYPE,
   dailyNoteBlockId,
+  dailyNoteDateProp,
   dailyNotesDataExtension,
   ensureDailyNoteTarget,
   isDateAlias,
@@ -139,5 +140,28 @@ describe('ensureDailyNoteTarget', () => {
     expect(first.id).toBe(second.id)
     expect(first.inserted).toBe(true)
     expect(second.inserted).toBe(false)
+  })
+
+  it('tolerates date-shaped aliases that are not real calendar dates', async () => {
+    // `isDateAlias` matches by regex (YYYY-MM-DD shape) without
+    // calendar-validity check. The references processor routes any
+    // such match through ensureDailyNoteTarget, so a user-typed
+    // `[[2026-13-01]]` or `[[2026-02-30]]` must not blow up the tx
+    // — the seat block still gets created, just without an indexable
+    // date property.
+    const typeSnapshot = env.repo.snapshotTypeRegistries()
+    for (const bogusIso of ['2026-13-01', '2026-02-30']) {
+      const result = await env.repo.tx(
+        tx => ensureDailyNoteTarget(tx, env.repo, bogusIso, WS, typeSnapshot),
+        {scope: ChangeScope.BlockDefault},
+      )
+      expect(result.inserted).toBe(true)
+      const row = await env.h.db.get<{properties_json: string}>(
+        'SELECT properties_json FROM blocks WHERE id = ?', [result.id])
+      const props = JSON.parse(row.properties_json)
+      expect(props[aliasesProp.name]).toEqual([bogusIso])
+      expect(props[typesProp.name]).toEqual([PAGE_TYPE, DAILY_NOTE_TYPE])
+      expect(props[dailyNoteDateProp.name]).toBeUndefined()
+    }
   })
 })

--- a/src/plugins/references/referencesProcessor.ts
+++ b/src/plugins/references/referencesProcessor.ts
@@ -63,7 +63,7 @@ import { aliasSeatReaderFromDb, ensureAliasTarget, resolveAliasSeatId } from '@/
 import {
   dailyNoteBlockId,
   ensureDailyNoteTarget,
-  isDateAlias,
+  isValidDateAlias,
 } from '@/plugins/daily-notes/dailyNotes.ts'
 
 export const PARSE_REFERENCES_PROCESSOR = 'references.parseReferences'
@@ -119,10 +119,17 @@ const buildSourcePlan = async (
   for (const mark of aliasMarks) {
     if (seenAliases.has(mark.alias)) continue
     seenAliases.add(mark.alias)
-    if (isDateAlias(mark.alias)) {
+    if (isValidDateAlias(mark.alias)) {
       // Daily note path — distinct deterministic id, never feeds cleanup.
       // Always-present id (deterministic from date+workspace); the write
       // phase will ensureDailyNoteTarget which is idempotent.
+      //
+      // Calendar-invalid date-shaped aliases (`[[2026-13-01]]`,
+      // `[[2026-02-30]]`) deliberately fall through to the alias path
+      // below: the typo becomes a regular alias-target page named for
+      // the typo'd string. Routing them as daily notes would mint a
+      // deterministic seat for a nonexistent calendar day and roll
+      // over silently in any downstream date arithmetic.
       const id = dailyNoteBlockId(source.workspaceId, mark.alias)
       dateRefs.push({id, alias: mark.alias})
       datesToEnsure.push(mark.alias)

--- a/src/plugins/srs-rescheduling/dateShiftDecorator.ts
+++ b/src/plugins/srs-rescheduling/dateShiftDecorator.ts
@@ -8,7 +8,7 @@ import {
   DATE_SHIFT_FORWARD_WEEK_ACTION_ID,
   addDaysIso,
   getOrCreateDailyNote,
-  isDateAlias,
+  isValidDateAlias,
 } from '@/plugins/daily-notes'
 import type { ActionConfig, ActionDecorator, BlockShortcutDependencies } from '@/shortcuts/types.ts'
 import {
@@ -44,11 +44,15 @@ const dailyNoteIsoFromBlockId = async (
   const data = await block.repo.load(dailyNoteId)
   if (!data) return null
 
-  const aliasIso = decodeAliases(data.properties).find(isDateAlias)
+  // Calendar-validity check (not shape-only): bogus stored aliases like
+  // `2026-13-01` would otherwise feed `addDaysIso` and roll over to
+  // 2027-01-01 instead of refusing to shift. Treat as "no date" so
+  // the action falls through to its default handler.
+  const aliasIso = decodeAliases(data.properties).find(isValidDateAlias)
   if (aliasIso) return aliasIso
 
   const content = data.content.trim()
-  return isDateAlias(content) ? content : null
+  return isValidDateAlias(content) ? content : null
 }
 
 const hasLoadedSrsNextReviewDate = (block: Block): boolean => {

--- a/src/plugins/srs-rescheduling/srsBlockDateAdapter.ts
+++ b/src/plugins/srs-rescheduling/srsBlockDateAdapter.ts
@@ -7,7 +7,7 @@
 import type { Block } from '@/data/block'
 import { ChangeScope } from '@/data/api'
 import { aliasesProp, getBlockTypes } from '@/data/properties.ts'
-import { getOrCreateDailyNote, isDateAlias } from '@/plugins/daily-notes'
+import { getOrCreateDailyNote, isValidDateAlias } from '@/plugins/daily-notes'
 import type { BlockDateAdapter } from '@/plugins/daily-notes/blockDateAdapter.ts'
 import { SRS_SM25_TYPE, srsNextReviewDateProp } from './schema.ts'
 
@@ -38,10 +38,14 @@ const dailyNoteIsoFromBlockId = async (
 ): Promise<string | null> => {
   const data = await block.repo.load(dailyNoteId)
   if (!data) return null
-  const aliasIso = decodeAliases(data.properties).find(isDateAlias)
+  // Calendar-validity check (not shape-only): a daily-note row whose
+  // only date-shaped alias is e.g. `2026-13-01` would, under shape-only
+  // matching, feed bogus input to `addDaysIso` and roll over silently.
+  // Treat such rows as "no date" so scheduling refuses to act on them.
+  const aliasIso = decodeAliases(data.properties).find(isValidDateAlias)
   if (aliasIso) return aliasIso
   const content = data.content.trim()
-  return isDateAlias(content) ? content : null
+  return isValidDateAlias(content) ? content : null
 }
 
 export const srsBlockDateAdapter: BlockDateAdapter = {


### PR DESCRIPTION
Step 1 of the date-range filtering work: give each daily-note page a
typed `daily-note:date` property so the query layer can resolve refs
to daily notes (e.g. SRS's `next-review-date`) as comparable dates,
without parsing aliases at query time. The id is a uuidv5 hash of
(workspace, iso) and not reversible, so the value has to live on the
row.

- `dailyNoteDateProp` (date codec) added to `dailyNoteType`
- `getOrCreateDailyNote` and `ensureDailyNoteTarget` set it through
  `addTypeInTx` initial values at create/restore time
- One-shot device-local backfill (`dailyNotesLocalSchema`) writes the
  property for pre-existing rows by reading the ISO alias; gated on a
  `client_schema_state` marker so cold starts are a cheap probe