### PR TITLE
Surface singleton high-priority groups instead of folding into Other

### DIFF
--- a/src/plugins/grouped-backlinks/grouping.ts
+++ b/src/plugins/grouped-backlinks/grouping.ts
@@ -167,10 +167,13 @@ export const buildGroupedBacklinks = ({
   }
 
   const consumePriority = (priority: GroupPriority) => {
+    // High-priority groups are always surfaced — even a single-item group must
+    // appear at the top rather than getting absorbed into the Other fallback.
+    const minSize = priority === 'high' ? 1 : minGroupSize
     const priorityGroups = Array.from(groups.values())
       .filter(group => group.priority === priority && group.kind !== 'field')
     while (priorityGroups.length > 0) {
-      const picked = pickLargestGroup(priorityGroups, sourceOrder, consumed, minGroupSize)
+      const picked = pickLargestGroup(priorityGroups, sourceOrder, consumed, minSize)
       if (!picked) return
       result.push({
         groupId: picked.group.groupId,

--- a/src/plugins/grouped-backlinks/test/query.test.ts
+++ b/src/plugins/grouped-backlinks/test/query.test.ts
@@ -352,6 +352,40 @@ describe('groupedBacklinksDataExtension query', () => {
     expect(sorted(out.groups[0].sourceIds)).toEqual(['src-1', 'src-2'])
   })
 
+  it('surfaces singleton high-priority groups at the top instead of folding them into Other', async () => {
+    await create({id: 'target', content: 'Target'})
+    await create({id: 'project', content: 'Project'})
+    await create({id: 'topic', content: 'Topic'})
+    await create({
+      id: 'src-solo',
+      references: [{id: 'target', alias: 'T'}, {id: 'project', alias: 'Project'}],
+    })
+    await create({
+      id: 'src-topic-1',
+      references: [{id: 'target', alias: 'T'}, {id: 'topic', alias: 'Topic'}],
+    })
+    await create({
+      id: 'src-topic-2',
+      references: [{id: 'target', alias: 'T'}, {id: 'topic', alias: 'Topic'}],
+    })
+
+    const out = await env.repo.query[GROUPED_BACKLINKS_FOR_BLOCK_QUERY]({
+      workspaceId: WS,
+      id: 'target',
+      groupingConfig: {
+        highPriorityTags: ['Project'],
+        lowPriorityTags: [],
+        excludedTags: [],
+        excludedPatterns: [],
+      },
+    }).load()
+
+    expect(out.total).toBe(3)
+    expect(out.groups.map(group => group.label)).toEqual(['Project', 'Topic'])
+    expect(out.groups[0].sourceIds).toEqual(['src-solo'])
+    expect(sorted(out.groups[1].sourceIds)).toEqual(['src-topic-1', 'src-topic-2'])
+  })
+
   it('does not treat include filters as grouping priority', async () => {
     await create({id: 'target', content: 'Target'})
     await create({id: 'project', content: 'Project'})


### PR DESCRIPTION
## Summary
Modified the grouped backlinks grouping logic to ensure that high-priority groups are always displayed at the top level, even when they contain only a single item. Previously, singleton groups would be absorbed into the "Other" fallback group.

## Changes
- **grouping.ts**: Updated `consumePriority()` to use a minimum group size of 1 for high-priority groups (instead of the standard `minGroupSize`), ensuring they are always surfaced as separate groups rather than being filtered out and merged into the fallback
- **query.test.ts**: Added test case verifying that a singleton high-priority group ("Project") appears at the top of results instead of being folded into other groups

## Implementation Details
The fix introduces priority-aware minimum group sizing: high-priority groups bypass the normal minimum size threshold and are always included in results. This allows important single-item groups to be prominently displayed while still applying size filtering to lower-priority groups.

https://claude.ai/code/session_01JuDXQT1xvSxzr1miG2Wmbq