### PR TITLE
PWA manifest polish: label fix, stable id, two more shortcuts

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,12 +1,17 @@
 {
   "name": "Knowledge Medium",
-  "short_name": "Knowledge",
+  "short_name": "Knowledge Medium",
+  "id": ".",
   "description": "A malleable, offline-first medium for knowledge work.",
+  "categories": ["productivity", "utilities"],
+  "lang": "en",
+  "dir": "ltr",
   "start_url": ".",
   "scope": ".",
   "launch_handler": {
     "client_mode": ["focus-existing", "auto"]
   },
+  "handle_links": "preferred",
   "display": "standalone",
   "display_override": ["standalone", "minimal-ui"],
   "background_color": "#1e1b4b",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -11,12 +11,31 @@
   "display_override": ["standalone", "minimal-ui"],
   "background_color": "#1e1b4b",
   "theme_color": "#1e1b4b",
+  "prefer_related_applications": false,
   "shortcuts": [
     {
       "name": "New daily block",
       "short_name": "New block",
       "description": "Append a new block to today's daily note",
       "url": "./?intent=new-daily-block",
+      "icons": [
+        { "src": "icon-192.png", "sizes": "192x192", "type": "image/png" }
+      ]
+    },
+    {
+      "name": "Pick a date",
+      "short_name": "Pick date",
+      "description": "Open the calendar to jump to a daily note",
+      "url": "./?intent=open-picker",
+      "icons": [
+        { "src": "icon-192.png", "sizes": "192x192", "type": "image/png" }
+      ]
+    },
+    {
+      "name": "Quick find",
+      "short_name": "Find",
+      "description": "Search for a page or block",
+      "url": "./?intent=quick-find",
       "icons": [
         { "src": "icon-192.png", "sizes": "192x192", "type": "image/png" }
       ]

--- a/src/plugins/app-intents/appIntents.ts
+++ b/src/plugins/app-intents/appIntents.ts
@@ -1,16 +1,20 @@
 /**
  * PWA-shortcut and Web Share Target dispatcher.
  *
- * The manifest exposes three URL surfaces that land back in the SPA:
+ * The manifest exposes URL surfaces that land back in the SPA:
  *   - shortcuts                  → `./?intent=new-daily-block`
+ *                                 `./?intent=open-picker`
+ *                                 `./?intent=quick-find`
  *   - share_target action        → `./?intent=share&title=…&text=…&url=…`
  *   - note_taking.new_note_url   → `./?intent=new-daily-block`
  *
- * Each should drop the user into a freshly-created block on today's
- * daily note (the share-target variant pre-fills it with the shared
- * payload). We delegate to `appendTodayDailyBlockInStack` from the
- * daily-notes plugin so the UX matches Ctrl+Shift+N exactly — same
- * panel placement, same focus, same editing state.
+ * `new-daily-block` and `share` drop the user into a freshly-created
+ * block on today's daily note (the share-target variant pre-fills
+ * it with the shared payload); we delegate to
+ * `appendTodayDailyBlockInStack` so the UX matches Ctrl+Shift+N
+ * exactly. `open-picker` and `quick-find` just fire the same global
+ * events the matching keyboard actions / header buttons do, so the
+ * launcher entry points are 1:1 with the in-app affordances.
  *
  * The dispatcher runs once per page load (module-level `consumed`
  * flag), fired by `appIntentsBootstrapEffect` once the workspace's
@@ -26,7 +30,11 @@
  */
 import type { Block } from '@/data/block'
 import type { Repo } from '@/data/repo'
-import { appendTodayDailyBlockInStack } from '@/plugins/daily-notes'
+import {
+  appendTodayDailyBlockInStack,
+  openDailyNotePicker,
+} from '@/plugins/daily-notes'
+import { toggleQuickFindEvent } from '@/plugins/quick-find'
 
 const INTENT_PARAMS = ['intent', 'title', 'text', 'url'] as const
 
@@ -93,7 +101,9 @@ export const consumeAppIntent = async (
 
   const isShare = intent === 'share' || hasShareFields
   const isNewBlock = intent === 'new-daily-block'
-  if (!isShare && !isNewBlock) return
+  const isOpenPicker = intent === 'open-picker'
+  const isQuickFind = intent === 'quick-find'
+  if (!isShare && !isNewBlock && !isOpenPicker && !isQuickFind) return
 
   // Flip the module-level guard BEFORE awaiting so a re-entrant
   // call (e.g. React strict-mode double-invoke of the bootstrap
@@ -103,6 +113,20 @@ export const consumeAppIntent = async (
   // (read-only mode, missing workspace) or a thrown mutator would
   // silently drop the shared payload with no way to recover.
   consumed = true
+
+  // UI-only intents — fire-and-forget window events that the
+  // matching app mounts listen for. No data to lose, so we strip
+  // the URL params unconditionally.
+  if (isOpenPicker) {
+    openDailyNotePicker()
+    stripIntentParams()
+    return
+  }
+  if (isQuickFind) {
+    window.dispatchEvent(new CustomEvent(toggleQuickFindEvent))
+    stripIntentParams()
+    return
+  }
 
   const dispatched = isShare
     ? await appendTodayDailyBlockInStack(repo, layoutSessionBlock, {

--- a/src/plugins/app-intents/test/appIntents.test.ts
+++ b/src/plugins/app-intents/test/appIntents.test.ts
@@ -19,7 +19,12 @@ import {
   panelRowsInLayoutOrder,
 } from '@/utils/panelLayoutProjection'
 import { __resetAppIntentForTesting, consumeAppIntent, formatSharedContent } from '../appIntents.ts'
-import { dailyNotesDataExtension, getOrCreateDailyNote } from '@/plugins/daily-notes'
+import {
+  dailyNotesDataExtension,
+  getOrCreateDailyNote,
+  openDailyNotePickerEvent,
+} from '@/plugins/daily-notes'
+import { toggleQuickFindEvent } from '@/plugins/quick-find'
 
 const WS = 'ws-1'
 const USER: User = {id: 'user-1', name: 'Alice'}
@@ -172,6 +177,39 @@ describe('consumeAppIntent', () => {
 
     const dailyChildren = await env.repo.block(daily.id).childIds.load()
     expect(dailyChildren).toHaveLength(1)
+  })
+
+  it('on intent=open-picker fires the daily-note picker event and clears params', async () => {
+    const {daily, layoutSession} = await seedLandingLayout()
+    setLocationSearch('?intent=open-picker')
+    const handler = vi.fn()
+    window.addEventListener(openDailyNotePickerEvent, handler)
+
+    await consumeAppIntent(env.repo, layoutSession)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(window.location.search).toBe('')
+    // Picker is a UI-only intent — must not create a block.
+    const dailyChildren = await env.repo.block(daily.id).childIds.load()
+    expect(dailyChildren).toHaveLength(0)
+
+    window.removeEventListener(openDailyNotePickerEvent, handler)
+  })
+
+  it('on intent=quick-find fires the quick-find toggle and clears params', async () => {
+    const {daily, layoutSession} = await seedLandingLayout()
+    setLocationSearch('?intent=quick-find')
+    const handler = vi.fn()
+    window.addEventListener(toggleQuickFindEvent, handler)
+
+    await consumeAppIntent(env.repo, layoutSession)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(window.location.search).toBe('')
+    const dailyChildren = await env.repo.block(daily.id).childIds.load()
+    expect(dailyChildren).toHaveLength(0)
+
+    window.removeEventListener(toggleQuickFindEvent, handler)
   })
 
   it('preserves URL params when the dispatch no-ops in read-only mode', async () => {


### PR DESCRIPTION
## Summary

Round of PWA manifest cleanup driven by watching the installed app
on Android.

### Label / identity / behaviour fields

- **`short_name`** was `"Knowledge"`, so Android's home-screen
  launcher (which prefers `short_name` over `name`) labelled the
  icon `Knowledge`. Set both to `"Knowledge Medium"` so the icon
  reads the intended name. Some launchers will still elide past
  ~14 chars to `"Knowledge Mediu…"`, but that beats the ambiguous
  `"Knowledge"`.
- **`id: "."`** — pins the app's stable identifier to the manifest
  base (matching the implicit default today). Future changes to
  `start_url` won't make browsers treat the install as a different
  app and lose state.
- **`categories`, `lang`, `dir`** — surface us in app stores / OS
  app pickers under the right metadata.
- **`handle_links: "preferred"`** — when the PWA is installed,
  clicks on knowledge-medium URLs from other apps open in the PWA
  instead of the browser.
- **`prefer_related_applications: false`** — mostly a no-op today
  but cheap insurance against future browsers preferring some
  native match over the PWA.

### Two more shortcuts

Now three launcher entries (Android long-press / Windows-Linux jump
list) cover the three highest-frequency entry points into the app:

- **New daily block** (already existed) — append a fresh editable
  block to today's note (`?intent=new-daily-block`).
- **Pick a date** — opens the existing daily-note calendar picker
  so you can jump to any date (`?intent=open-picker`). Reuses
  `openDailyNotePicker()`.
- **Quick find** — fires the same `toggleQuickFindEvent` that
  Ctrl+P uses, opening the search overlay
  (`?intent=quick-find`). Reuses the existing mount.

Both new intents are fire-and-forget UI events with no data to
lose, so they strip the URL params unconditionally — unlike the
existing `new-block` / `share` intents whose strip is gated on the
mutator's return value (so a no-op in read-only mode doesn't
silently drop the shared payload).

## Test plan

- [x] `yarn compile` — passes.
- [x] `yarn vitest run src/plugins/app-intents` — all tests pass,
      including new coverage for the two added intents.
- [ ] Reinstall the PWA via Chrome on Android, confirm:
   - [ ] Home-screen label reads "Knowledge Medium" (or its
         truncation), not "Knowledge".
   - [ ] Long-press app icon shows "New daily block", "Pick a
         date", "Quick find".
   - [ ] Opening a link to the deployed site from another app on
         Android lands in the installed PWA rather than the
         browser.
- [ ] `chrome://web-app-internals/` shows the new fields and three
      shortcut entries in the captured manifest.

## Follow-ups (not in this PR)

Discussed in the conversation: `screenshots` for richer install
dialogs, `file_handlers` for `.md`/`.txt` import, Window Controls
Overlay for desktop. Will open separate PRs if/when we pull the
trigger.

Closes #45 (changes folded in here).

https://claude.ai/code/session_01Aw2DnAfeqZS9oSkG5u9KYJ