### PR TITLE
Design: user-defined types

### DIFF
--- a/docs/user-defined-types.html
+++ b/docs/user-defined-types.html
@@ -324,6 +324,17 @@ export class UserTypesService {
   <span class="comment">// The block-write that backs `contribution` is the caller's</span>
   <span class="comment">// responsibility &mdash; this only updates the runtime bucket so the</span>
   <span class="comment">// id resolves in addTypeInTx's registry check.</span>
+  <span class="comment">// Look up the current user-data contribution for an id (if any).</span>
+  <span class="comment">// Callers using the synchronous-append pattern peek before</span>
+  <span class="comment">// appending so they can restore the prior value on tx failure</span>
+  <span class="comment">// rather than blindly removing it (which would wipe a legitimate</span>
+  <span class="comment">// pre-existing registration on a retry).</span>
+  peekContribution(typeId: string): {contribution: TypeContribution; blockId: string} | undefined {
+    const contribution = this.contributions.find(t =&gt; t.id === typeId)
+    const blockId = this.nameToBlockId.get(typeId)
+    return contribution && blockId !== undefined ? {contribution, blockId} : undefined
+  }
+
   appendUserType(contribution: TypeContribution, blockId: string): void {
     this.contributions = [
       ...this.contributions.filter(t =&gt; t.id !== contribution.id),
@@ -826,10 +837,25 @@ const candidates = await repo.queryBlocks({
   referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP},
 })
 
+<span class="comment">// Capture the prior user-data contribution for this id (if any).</span>
+<span class="comment">// Restored on tx failure rather than blindly removed &mdash; see</span>
+<span class="comment">// "Rollback must preserve prior registration" callout.</span>
+const prior = userTypesService.peekContribution(targetBlockId)
 userTypesService.appendUserType(contribution, targetBlockId)
 try {
   await repo.tx(async tx =&gt; {
+    <span class="comment">// In-tx guard: the target may have been deleted concurrently</span>
+    <span class="comment">// between our pre-tx load() and the tx opening. addTypeInTx is a</span>
+    <span class="comment">// no-op when tx.get(blockId) returns null (src/data/repo.ts) so</span>
+    <span class="comment">// without this guard the loop below would happily tag N instances</span>
+    <span class="comment">// with a type id whose backing block doesn't exist. Throwing here</span>
+    <span class="comment">// aborts the tx and triggers the rollback path below.</span>
+    const targetInTx = await tx.get(targetBlockId)
+    if (!targetInTx || targetInTx.deleted) {
+      throw new Error(`promoteToType: target ${targetBlockId} no longer exists`)
+    }
     await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})
+
     for (const candidate of candidates) {
       const row = await tx.get(candidate.id)
       if (!row) continue                          <span class="comment">// deleted between prefilter and tx</span>
@@ -840,9 +866,37 @@ try {
     if (rewriteIsaReferences) <span class="comment">/* ... */</span>
   })
 } catch (err) {
-  userTypesService.removeUserType(targetBlockId)
+  if (prior) {
+    userTypesService.appendUserType(prior.contribution, prior.blockId)   <span class="comment">// restore</span>
+  } else {
+    userTypesService.removeUserType(targetBlockId)                       <span class="comment">// drop provisional</span>
+  }
   throw err
 }</code></pre>
+
+<div class="callout warn">
+  <h4>In-tx existence guard for the target</h4>
+  <p style="margin:0">
+    <code>repo.addTypeInTx(tx, blockId, ...)</code> silently no-ops when <code>tx.get(blockId)</code> returns null
+    or a tombstone &mdash; reasonable behavior on sync-applied deletes where another device removed the row, but
+    a footgun for orchestration code that's about to fan out work tied to the target. Without the explicit
+    <code>tx.get</code> + <code>deleted</code> check, a concurrent delete between the pre-tx <code>load()</code> and
+    the tx opening would let the loop persist <code>targetBlockId</code> on every candidate's <code>block:types</code>
+    while the target itself stays a non-<code>block-type</code> tombstone. The next runtime rebuild then drops the
+    provisional registration, leaving orphan ids on N rows.
+  </p>
+</div>
+
+<div class="callout warn">
+  <h4>Rollback must preserve prior registration</h4>
+  <p style="margin:0">
+    A retry on an already-promoted target (e.g. user re-runs promotion with a different property set) has
+    <code>peekContribution(targetBlockId)</code> returning the existing user-data contribution. An unconditional
+    <code>removeUserType</code> on tx failure would wipe that legitimate registration, breaking every block
+    currently tagged with this id until the next subscription tick reconciles. Capture-and-restore is the right
+    primitive: <code>peek &rarr; append &rarr; on-failure-restore-or-drop</code>.
+  </p>
+</div>
 
 <div class="callout warn">
   <h4>Why the query lives outside the tx</h4>

--- a/docs/user-defined-types.html
+++ b/docs/user-defined-types.html
@@ -1,0 +1,763 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>User-defined types</title>
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #555;
+    --line: #ddd;
+    --code: #f5f5f5;
+    --code-inline: #f0f0f0;
+    --accent: #2a7;
+    --warn: #a44;
+    --kernel: #4f74c0;
+    --user: #c08040;
+    --merged: #2a7;
+  }
+  body {
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    max-width: 820px;
+    margin: 2rem auto;
+    padding: 0 1.2rem;
+    color: var(--fg);
+  }
+  h1 { font-size: 1.7rem; margin: 0 0 .3rem; }
+  h2 { font-size: 1.2rem; margin: 2.2rem 0 .5rem; border-bottom: 1px solid var(--line); padding-bottom: .25rem; }
+  h3 { font-size: 1.02rem; margin: 1.4rem 0 .4rem; }
+  h4 { font-size: .92rem; margin: 1rem 0 .3rem; color: var(--muted); }
+  code, pre { font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+  pre { background: var(--code); padding: .75rem 1rem; border-radius: 4px; overflow-x: auto; }
+  code { background: var(--code-inline); padding: 1px 4px; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  .lede { color: var(--muted); margin-top: .3rem; }
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: #f4faf6;
+    padding: .6rem .9rem;
+    margin: 1rem 0;
+    border-radius: 0 4px 4px 0;
+  }
+  .callout.warn {
+    border-left-color: var(--warn);
+    background: #fcf4f4;
+  }
+  .callout.muted {
+    border-left-color: #bbb;
+    background: #fafafa;
+  }
+  .callout h4 { margin-top: 0; color: var(--fg); }
+  .tag {
+    display: inline-block;
+    font-size: 11px;
+    padding: 1px 7px;
+    border-radius: 10px;
+    color: white;
+    margin-left: .4rem;
+    vertical-align: middle;
+    font-weight: 500;
+  }
+  .tag.rec { background: var(--accent); }
+  .tag.bad { background: var(--warn); }
+  .tag.muted { background: #888; }
+  .comment { color: #888; }
+  ul.tight li { margin: .25rem 0; }
+  figure {
+    margin: 1.2rem 0;
+    text-align: center;
+  }
+  figure svg { max-width: 100%; height: auto; }
+  figcaption { color: var(--muted); font-size: 13px; margin-top: .4rem; }
+  table {
+    border-collapse: collapse;
+    margin: .8rem 0;
+    font-size: 13px;
+  }
+  th, td {
+    border: 1px solid var(--line);
+    padding: .35rem .6rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { background: var(--code); font-weight: 600; }
+  .file { color: #06a; font-style: italic; }
+  .diag-box { fill: white; stroke: #555; stroke-width: 1.2; }
+  .diag-box-kernel { fill: #e8edf6; stroke: var(--kernel); }
+  .diag-box-user   { fill: #f8ede0; stroke: var(--user); }
+  .diag-box-merged { fill: #e8f6ec; stroke: var(--merged); }
+  .diag-text { font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #1a1a1a; }
+  .diag-label { font: 11px -apple-system, BlinkMacSystemFont, sans-serif; fill: #555; }
+  .diag-arrow { stroke: #555; stroke-width: 1.4; fill: none; marker-end: url(#arrow); }
+</style>
+</head>
+<body>
+
+<h1>User-defined types</h1>
+<p class="lede">
+Users author types as blocks &mdash; same shape as user-defined property schemas. Code-defined types stop being special.
+Kernel types get a clean override path. Per-type behavior moves from a <code>setup</code> callback to same-tx processors.
+</p>
+
+<h2>The premise has shifted</h2>
+
+<p>
+When <span class="file">docs/type-system.md</span> was written, user-authored types were &sect;9-deferred to a
+<code>dynamicExtensions</code>-style resolver pattern. The reasoning was strong: <code>FacetRuntime</code> is
+immutable after construction for real reasons (atomic switchover, upfront validation, deterministic
+<code>combine</code>, order-independent visibility), and a mutable-contribution sink would compromise those.
+The follow-up at <span class="file">docs/follow-ups.md:147</span> still reflects that position.
+</p>
+
+<p>
+The user-defined&nbsp;<i>properties</i> work invalidated that argument. It shipped exactly the mutable contribution
+path the type-system v1 ruled out &mdash;
+<code>repo.setRuntimeContributions(facet, sourceId, contributions)</code> with per-facet rebuild steps
+(<span class="file">src/data/repo.ts:1340</span>) and an end-to-end service
+(<span class="file">src/data/userSchemasService.ts</span>) that subscribes to <code>property-schema</code> blocks,
+builds <code>AnyPropertySchema</code> entries, and publishes them into the <code>'user-data'</code> source bucket on
+<code>propertySchemasFacet</code>. Atomic switchover is preserved because <i>each rebuild step</i> is atomic and only
+the dependent steps re-run.
+</p>
+
+<p>
+With that primitive paid for, the question for user-defined types isn't "resolver vs sink" anymore. It's:
+do user-defined types mirror <code>UserSchemasService</code>, or stay deferred until something forces the issue?
+This doc takes the mirror path.
+</p>
+
+<h2>Storage model: types are blocks</h2>
+
+<p>
+Symmetric to property-schema blocks. A new kernel type <code>block-type</code> holds three fields:
+</p>
+
+<pre><code><span class="comment">// src/data/properties.ts (additions)</span>
+export const blockTypeLabelProp       = defineProperty&lt;string&gt;('block-type:label',       {...})
+export const blockTypeDescriptionProp = defineProperty&lt;string&gt;('block-type:description', {...})
+export const blockTypePropertiesProp  = defineProperty&lt;readonly string[]&gt;('block-type:properties', {
+  codec: codecs.refList({targetTypes: ['property-schema']}),
+  defaultValue: [],
+  changeScope: ChangeScope.BlockDefault,
+})
+<span class="comment">// Optional &mdash; if present, this is an override of an existing type, not a new one.</span>
+export const blockTypeExtendsProp     = defineProperty&lt;string&gt;('block-type:extends', {...})</code></pre>
+
+<p>
+And the type contribution itself, registered in <span class="file">src/data/blockTypes.ts</span>:
+</p>
+
+<pre><code>export const BLOCK_TYPE_TYPE = 'block-type'
+
+defineBlockType({
+  id: BLOCK_TYPE_TYPE,
+  label: 'Type',
+  properties: [
+    blockTypeLabelProp,
+    blockTypeDescriptionProp,
+    blockTypePropertiesProp,
+    blockTypeExtendsProp,
+  ],
+})</code></pre>
+
+<p>
+Per-workspace <code>Types</code> page (deterministic uuid&nbsp;v5 from <code>workspaceId</code>, parallel to
+<span class="file">src/data/propertiesPage.ts</span>) hosts these blocks as children. Users navigate to it, see the
+list of types, click into one to edit name / description / property set.
+</p>
+
+<figure>
+  <svg viewBox="0 0 760 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Workspace structure">
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M0,0 L10,5 L0,10 z" fill="#555"/>
+      </marker>
+    </defs>
+
+    <text x="380" y="20" class="diag-label" text-anchor="middle">workspace root</text>
+    <line x1="380" y1="28" x2="380" y2="48" class="diag-arrow"/>
+
+    <rect x="140" y="50" width="160" height="36" rx="6" class="diag-box diag-box-kernel"/>
+    <text x="220" y="73" class="diag-text" text-anchor="middle">Properties page</text>
+
+    <rect x="460" y="50" width="160" height="36" rx="6" class="diag-box diag-box-kernel"/>
+    <text x="540" y="73" class="diag-text" text-anchor="middle">Types page</text>
+
+    <line x1="220" y1="88" x2="220" y2="108" class="diag-arrow"/>
+    <line x1="540" y1="88" x2="540" y2="108" class="diag-arrow"/>
+
+    <rect x="60"  y="110" width="160" height="32" rx="6" class="diag-box"/>
+    <rect x="60"  y="148" width="160" height="32" rx="6" class="diag-box"/>
+    <rect x="220" y="110" width="160" height="32" rx="6" class="diag-box"/>
+    <text x="140" y="131" class="diag-text" text-anchor="middle">property-schema: status</text>
+    <text x="140" y="169" class="diag-text" text-anchor="middle">property-schema: dob</text>
+    <text x="300" y="131" class="diag-text" text-anchor="middle">property-schema: email</text>
+
+    <rect x="400" y="110" width="160" height="32" rx="6" class="diag-box"/>
+    <rect x="400" y="148" width="160" height="32" rx="6" class="diag-box"/>
+    <rect x="560" y="110" width="160" height="32" rx="6" class="diag-box"/>
+    <text x="480" y="131" class="diag-text" text-anchor="middle">block-type: Person</text>
+    <text x="480" y="169" class="diag-text" text-anchor="middle">block-type: Project</text>
+    <text x="640" y="131" class="diag-text" text-anchor="middle">block-type: Meeting</text>
+  </svg>
+  <figcaption>
+    Each workspace has a kernel-bootstrapped <code>Properties</code> page and <code>Types</code> page.
+    Property-schema and block-type blocks live as their children.
+  </figcaption>
+</figure>
+
+<h3>Type id = block id, not slug</h3>
+
+<p>
+The persisted <code>block:types</code> string array (per <span class="file">docs/type-system.md</span> &sect;2)
+now mixes semantic kernel ids and block-id uuids:
+</p>
+
+<pre><code><span class="comment">// A daily note that's also tagged as a user-defined "meeting" type</span>
+block:types = ['daily-note', '7d4e2b1a-...']
+                ^kernel       ^user-defined: id of the meeting block-type block</code></pre>
+
+<p>
+Block ids are the right answer because they survive renaming the type's display label, they don't need uniqueness
+enforcement, and &mdash; load-bearing for Roam adoption &mdash; <code>roam:isa = [[Person]]</code> already resolves
+to the Person page's block id via refList. Promotion becomes mechanical (see &sect;Roam isa adoption).
+The picker UI shows <code>blockTypeLabelProp</code>, never the id.
+</p>
+
+<div class="callout muted">
+  <h4>Alternative rejected: slug ids in a <code>block-type:id</code> field</h4>
+  <p style="margin:0">
+    Readable in logs, but every alternative has at least one of: brittle on rename, requires global uniqueness
+    enforcement, makes adoption from <code>roam:isa</code> non-mechanical (refs are by block id, slugs aren't),
+    and forces a second registry of "id &rarr; block." Block ids win on every axis except eyeballing
+    <code>block:types</code> in raw JSON, and the picker UI takes care of that.
+  </p>
+</div>
+
+<h2>UserTypesService</h2>
+
+<p>
+Near-clone of <code>UserSchemasService</code> (<span class="file">src/data/userSchemasService.ts</span>),
+adapted for the type-contribution shape:
+</p>
+
+<pre><code><span class="comment">// src/data/userTypesService.ts (new)</span>
+export class UserTypesService {
+  private contributions: readonly TypeContribution[] = []
+  private nameToBlockId = new Map&lt;string, string&gt;()
+  private subscriptionDisposer: Unsubscribe | null = null
+  private schemasListenerDisposer: (() =&gt; void) | null = null
+
+  constructor(private readonly repo: Repo) {}
+
+  start(): () =&gt; void {
+    const rebuildFromBlocks = (blocks: readonly Block[]) =&gt; {
+      const schemas = this.repo.propertySchemas
+      const next: TypeContribution[] = []
+      for (const block of blocks) {
+        const built = this.tryBuildType(block, schemas)
+        if (built) next.push(built)
+      }
+      this.contributions = next
+      this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
+    }
+
+    this.subscriptionDisposer = this.repo.subscribeBlocks(
+      {types: [BLOCK_TYPE_TYPE]},
+      blocks =&gt; rebuildFromBlocks(blocks.map(b =&gt; this.repo.block(b.id))),
+    )
+    <span class="comment">// Re-resolve when the merged schema map changes &mdash; a newly-loaded</span>
+    <span class="comment">// property schema makes previously-unresolvable refs in</span>
+    <span class="comment">// block-type:properties suddenly resolvable. Mirrors</span>
+    <span class="comment">// onValuePresetsChange in UserSchemasService.</span>
+    this.schemasListenerDisposer = this.repo.onPropertySchemasChange(() =&gt; rebuild())
+
+    return () =&gt; this.dispose()
+  }
+
+  private tryBuildType(
+    block: Block,
+    schemas: ReadonlyMap&lt;string, AnyPropertySchema&gt;,
+  ): TypeContribution | null {
+    const label = block.peekProperty(blockTypeLabelProp) ?? ''
+    if (!label) {
+      console.warn(`[UserTypesService] block ${block.id} has empty label; skipping`)
+      return null
+    }
+    const refIds = block.peekProperty(blockTypePropertiesProp) ?? []
+    const properties: AnyPropertySchema[] = []
+    for (const refId of refIds) {
+      const schemaBlock = this.repo.peek(refId)
+      const name = schemaBlock?.properties[propertyNameProp.name]
+      if (typeof name !== 'string') continue            <span class="comment">// schema block not yet synced</span>
+      const schema = schemas.get(name)
+      if (schema) properties.push(schema)
+    }
+    const extendsId = block.peekProperty(blockTypeExtendsProp)
+    if (extendsId) {
+      return {kind: 'override', target: extendsId, label, properties} as TypeOverride
+    }
+    return {
+      id: block.id,
+      label,
+      description: block.peekProperty(blockTypeDescriptionProp),
+      properties,
+    }
+  }
+}</code></pre>
+
+<p>
+The bootstrap path (<code>repo</code> construction in <span class="file">src/data/repo.ts</span>) starts the service
+after the workspace's <code>Types</code> page is ensured &mdash; same wiring as <code>UserSchemasService</code>.
+</p>
+
+<h2>Overriding kernel types via <code>extends</code></h2>
+
+<p>
+Plausible use case: a user wants <code>daily-note</code> blocks to surface <code>weather</code> and <code>mood</code>
+slots in the property panel. They author a <code>block-type</code> block with
+<code>block-type:extends = 'daily-note'</code> and <code>block-type:properties = [weather, mood]</code>.
+</p>
+
+<p>
+The naive path &mdash; let <code>typesFacet.combine</code>'s last-wins-on-id resolve it &mdash; is destructive:
+the user's contribution would <i>replace</i> the kernel <code>daily-note</code> entry, wiping
+<code>label</code>, kernel <code>properties[]</code>, and (if it existed) <code>setup</code>. That's not what
+they meant.
+</p>
+
+<p>
+The clean path: distinguish full contributions from <i>override</i> contributions. The
+<code>typesFacet.of(...)</code> contribution stays as-is for full types; user-defined override contributions arrive
+through the same <code>'user-data'</code> source bucket but as a different shape, and the rebuild step in
+<code>setFacetRuntime</code> (<span class="file">src/data/repo.ts:1783</span>) folds them in <i>after</i> combine:
+</p>
+
+<figure>
+  <svg viewBox="0 0 760 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Override merge">
+    <defs>
+      <marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M0,0 L10,5 L0,10 z" fill="#555"/>
+      </marker>
+    </defs>
+
+    <rect x="20" y="20" width="220" height="100" rx="6" class="diag-box diag-box-kernel"/>
+    <text x="130" y="38" class="diag-label" text-anchor="middle">kernel contribution</text>
+    <text x="30" y="58" class="diag-text">id: 'daily-note'</text>
+    <text x="30" y="76" class="diag-text">label: 'Daily note'</text>
+    <text x="30" y="94" class="diag-text">properties: [journalDate]</text>
+    <text x="30" y="112" class="diag-text">setup: createTemplate()</text>
+
+    <rect x="20" y="140" width="220" height="80" rx="6" class="diag-box diag-box-user"/>
+    <text x="130" y="158" class="diag-label" text-anchor="middle">user override</text>
+    <text x="30" y="178" class="diag-text">extends: 'daily-note'</text>
+    <text x="30" y="196" class="diag-text">label: undefined</text>
+    <text x="30" y="214" class="diag-text">properties: [weather, mood]</text>
+
+    <line x1="245" y1="120" x2="370" y2="135" class="diag-arrow"/>
+    <line x1="245" y1="180" x2="370" y2="155" class="diag-arrow"/>
+    <text x="305" y="105" class="diag-label" text-anchor="middle">merge</text>
+    <text x="305" y="200" class="diag-label" text-anchor="middle">at rebuild step</text>
+
+    <rect x="380" y="80" width="360" height="130" rx="6" class="diag-box diag-box-merged"/>
+    <text x="560" y="98" class="diag-label" text-anchor="middle">merged contribution (visible to consumers)</text>
+    <text x="390" y="120" class="diag-text">id: 'daily-note'</text>
+    <text x="390" y="138" class="diag-text">label: 'Daily note'           <tspan fill="#888">(kernel wins; user unset)</tspan></text>
+    <text x="390" y="156" class="diag-text">properties: [journalDate, weather, mood]</text>
+    <text x="390" y="174" class="diag-text">setup: createTemplate()        <tspan fill="#888">(kernel; user cannot)</tspan></text>
+    <text x="390" y="194" class="diag-text">_overriddenBy: ['user-data']   <tspan fill="#888">(audit trail)</tspan></text>
+  </svg>
+  <figcaption>Override merge: union <code>properties[]</code>, user-wins-if-set for <code>label</code> / <code>description</code>, kernel-only for behavioral fields.</figcaption>
+</figure>
+
+<p>The merge rules:</p>
+<ul class="tight">
+  <li><code>properties[]</code> &mdash; <b>union</b> with the kernel list, dedup by name via the existing object-identity rule in <code>mergeLiftedSchemas</code> (<span class="file">src/data/repo.ts:178</span>).</li>
+  <li><code>label</code> / <code>description</code> &mdash; <b>user wins if set</b>, else kernel.</li>
+  <li>Any behavioral field (today: <code>setup</code>) &mdash; <b>kernel only</b>. User-defined types ship no code, so this isn't a regression from the user's side; it's an architectural invariant.</li>
+</ul>
+
+<div class="callout">
+  <h4>Why not a separate <code>typeOverridesFacet</code></h4>
+  <p style="margin:0">
+    Tempting &mdash; the "clean Tana" answer is a parallel facet keyed by target type id. But it adds a service,
+    a publish path, and a rebuild step for one anticipated use case. The single-block-type-with-<code>extends</code>
+    shape is strictly less surface; if overrides grow real complexity later (per-type render overrides, chained
+    setups, etc.) extracting the facet is mechanical. Don't pre-extract.
+  </p>
+</div>
+
+<h2>Replace <code>setup</code> with same-tx processors</h2>
+
+<p>
+<code>setup</code> (<span class="file">docs/type-system.md:60-89</span>) was designed before same-tx processors
+existed (<span class="file">src/data/api/sameTxProcessor.ts</span>). With same-tx processors now a real
+primitive, <code>setup</code> is redundant.
+</p>
+
+<p>What <code>setup</code> provides today:</p>
+<ul class="tight">
+  <li>Fires inside <code>repo.addType</code> after <code>initialValues</code> are written, in the same tx.</li>
+  <li>Use cases: child-block templates (meeting &rarr; Attendees / Agenda / Action items), computed initial values (<code>due = now() + 7 days</code>), cross-block wiring at add time.</li>
+</ul>
+
+<p>What a same-tx processor watching the <code>properties</code> field provides:</p>
+<ul class="tight">
+  <li>Sees <code>before</code> and <code>after</code> <code>BlockData</code> per touched row.</li>
+  <li>Writes via <code>ctx.tx.update/setProperty</code>, amending the same tx; one undo entry covers everything.</li>
+  <li>Rejects via <code>throw new ProcessorRejection(code, meta)</code>, rolling the user's tx back atomically.</li>
+  <li>Already has access to merged <code>propertySchemas</code> on <code>ctx</code>.</li>
+</ul>
+
+<h3>Why same-tx wins</h3>
+
+<table>
+  <tr><th>Concern</th><th><code>setup</code></th><th>Same-tx processor</th></tr>
+  <tr>
+    <td><b>Bypass surface</b></td>
+    <td>
+      Skipped by raw <code>tx.update(typesProp)</code>, <code>addBlockTypeToProperties</code> (fixtures / plan code),
+      sync apply from another device. <span class="file">docs/type-system.md</span> warns about this in three
+      separate paragraphs (&sect;3-pure, &sect;3a, &sect;3a-setup).
+    </td>
+    <td>
+      Catches every write uniformly &mdash; sync, raw, plan, orchestrated. The bypass footgun becomes
+      architecturally impossible.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Removal symmetry</b></td>
+    <td>
+      <code>removeType</code> has no teardown today (open question at <span class="file">type-system.md:1275</span>).
+    </td>
+    <td>
+      Free: <code>removedTypes(event)</code> falls out of the same before/after diff. Cleanup on type removal stops
+      needing a new mechanism.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Composability</b></td>
+    <td>One callback per type contribution. Multiple plugins reacting to <code>todo</code>-add can't both ship setups.</td>
+    <td>Multiple processors fire in registration order; one-way fixpoint (each sees earlier processors' writes).</td>
+  </tr>
+  <tr>
+    <td><b>User-defined-types parity</b></td>
+    <td>
+      Code-only. <code>extends</code>-overrides can't change it. Creates a "user types are second-class on
+      <code>setup</code>" carveout in the design.
+    </td>
+    <td>
+      Nobody ships behavior via the contribution &mdash; not kernel, not plugins, not users. Type contributions
+      become pure metadata. The override path stops having a carveout.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Locality</b> <span class="tag bad">cost</span></td>
+    <td>
+      Inline with the type definition. "What happens when I add a <code>meeting</code>?" is one-look discoverable.
+    </td>
+    <td>
+      Processor lives in its own facet contribution and filters by type id from the event diff. Mitigation is
+      conventional, not structural: colocate the processor file next to the type definition.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Rejection</b></td>
+    <td>Throw bubbles through <code>repo.tx</code>'s error path. Ad-hoc.</td>
+    <td><code>ProcessorRejection</code> with stable <code>code</code> + <code>meta</code> routes to the toast layer cleanly.</td>
+  </tr>
+</table>
+
+<h3>Lifecycle: addType before vs after</h3>
+
+<figure>
+  <svg viewBox="0 0 760 290" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="addType lifecycle comparison">
+    <defs>
+      <marker id="arrow3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M0,0 L10,5 L0,10 z" fill="#555"/>
+      </marker>
+    </defs>
+
+    <text x="190" y="20" class="diag-label" text-anchor="middle" font-weight="bold">Today: setup keyed by type id</text>
+    <rect x="40"  y="38" width="300" height="32" rx="4" class="diag-box"/>
+    <text x="190" y="58" class="diag-text" text-anchor="middle">caller: repo.addType(id, 'meeting', initial)</text>
+    <line x1="190" y1="72" x2="190" y2="92" class="diag-arrow"/>
+    <rect x="40"  y="94" width="300" height="32" rx="4" class="diag-box diag-box-kernel"/>
+    <text x="190" y="114" class="diag-text" text-anchor="middle">addType: write initial, append 'meeting'</text>
+    <line x1="190" y1="128" x2="190" y2="148" class="diag-arrow"/>
+    <rect x="40"  y="150" width="300" height="32" rx="4" class="diag-box diag-box-kernel"/>
+    <text x="190" y="170" class="diag-text" text-anchor="middle">addType: lookup setup, run it</text>
+    <line x1="190" y1="184" x2="190" y2="204" class="diag-arrow"/>
+    <rect x="40"  y="206" width="300" height="32" rx="4" class="diag-box"/>
+    <text x="190" y="226" class="diag-text" text-anchor="middle">commit</text>
+    <text x="190" y="260" class="diag-label" text-anchor="middle" font-style="italic" fill="#a44">raw tx.update(typesProp) skips the setup step</text>
+
+    <text x="570" y="20" class="diag-label" text-anchor="middle" font-weight="bold">Proposed: field-watching processor</text>
+    <rect x="420" y="38" width="300" height="32" rx="4" class="diag-box"/>
+    <text x="570" y="58" class="diag-text" text-anchor="middle">caller: any write touching properties_json</text>
+    <line x1="570" y1="72" x2="570" y2="92" class="diag-arrow"/>
+    <rect x="420" y="94" width="300" height="32" rx="4" class="diag-box"/>
+    <text x="570" y="114" class="diag-text" text-anchor="middle">user fn finishes writing</text>
+    <line x1="570" y1="128" x2="570" y2="148" class="diag-arrow"/>
+    <rect x="420" y="150" width="300" height="32" rx="4" class="diag-box diag-box-merged"/>
+    <text x="570" y="170" class="diag-text" text-anchor="middle">same-tx processor: addedTypes diff &rarr; apply</text>
+    <line x1="570" y1="184" x2="570" y2="204" class="diag-arrow"/>
+    <rect x="420" y="206" width="300" height="32" rx="4" class="diag-box"/>
+    <text x="570" y="226" class="diag-text" text-anchor="middle">commit</text>
+    <text x="570" y="260" class="diag-label" text-anchor="middle" font-style="italic" fill="#2a7">every write path goes through the same step</text>
+  </svg>
+  <figcaption>
+    Left: today's <code>setup</code> path. Right: same-tx processor path. The processor sees every property write,
+    not just orchestrated <code>addType</code> calls, so sync / raw / plan paths get the same behavior as direct
+    calls. <code>repo.addType</code> shrinks to "encode <code>initialValues</code>, append to <code>typesProp</code>";
+    everything downstream rides the processor stream.
+  </figcaption>
+</figure>
+
+<h3>Sketch of a per-type processor</h3>
+
+<pre><code><span class="comment">// src/plugins/meeting/typeOnAdd.ts</span>
+import {createChild} from '@/data/internals/kernelMutators'
+import {addedTypes} from '@/data/properties'
+
+export const meetingOnAdd = defineSameTxProcessor({
+  name: 'meeting.onAdd',
+  watches: {kind: 'field', table: 'blocks', fields: ['properties']},
+  apply: async (event, ctx) =&gt; {
+    for (const row of event.changedRows) {
+      if (!addedTypes(row).includes('meeting')) continue
+
+      <span class="comment">// init-if-missing for type-defined computed initial values</span>
+      if (row.after.properties[meetingDateProp.name] === undefined) {
+        await ctx.tx.setProperty(row.after.id, meetingDateProp, today())
+      }
+
+      <span class="comment">// child-block template</span>
+      for (const label of ['Attendees:', 'Agenda:', 'Action items:']) {
+        const childId = await ctx.tx.run(createChild, {
+          parentId: row.after.id,
+          position: {kind: 'last'},
+        })
+        await ctx.tx.update(childId, {content: label})
+      }
+    }
+  },
+})
+
+<span class="comment">// Registered alongside the type contribution:</span>
+sameTxProcessorsFacet.of(meetingOnAdd, {source: 'meeting'})
+typesFacet.of(meetingType, {source: 'meeting'})</code></pre>
+
+<h3>What needs to be added</h3>
+
+<p>One small ergonomic piece &mdash; a delta helper so every processor isn't reimplementing the diff:</p>
+
+<pre><code><span class="comment">// src/data/properties.ts (additions)</span>
+export const addedTypes = (row: ChangedRow): readonly string[] =&gt; {
+  const before = row.before ? getBlockTypes(row.before) : []
+  const after  = getBlockTypes(row.after)
+  return after.filter(t =&gt; !before.includes(t))
+}
+
+export const removedTypes = (row: ChangedRow): readonly string[] =&gt; {
+  const before = row.before ? getBlockTypes(row.before) : []
+  const after  = getBlockTypes(row.after)
+  return before.filter(t =&gt; !after.includes(t))
+}</code></pre>
+
+<h3>What <code>repo.addType</code> becomes</h3>
+
+<p>
+Without <code>setup</code> in the picture, the orchestration shrinks to: encode <code>initialValues</code> through
+their schemas' codecs, append the type id to <code>typesProp</code>. That's mutator-shaped work; it might even fold
+into a regular registered mutator. The <code>_types</code> retention on <code>Repo</code> stays useful for the
+property-panel section grouping (&sect;3c in <span class="file">type-system.md</span>) and the
+"is this id registered?" guard, but <code>setFacetRuntime</code>'s <code>_types</code> snapshot is no longer
+load-bearing for <i>behavior</i> &mdash; behavior is in the processor stream now.
+</p>
+
+<div class="callout warn">
+  <h4>Migration moment</h4>
+  <p style="margin:0">
+    Kill <code>setup</code> <i>now</i>, before existing kernel use cases migrate into it. Today the only real user
+    is the deferred daily-note template (<span class="file">type-system.md:678</span>), and it's still being
+    designed. Once <code>daily-note</code>'s setup is written, the rewrite has cost; right now it doesn't.
+    Same reasoning that landed user-defined properties before too many ad-hoc <code>adhocSchema</code> call sites
+    were live.
+  </p>
+</div>
+
+<h2>Roam <code>isa</code> adoption</h2>
+
+<p>
+The import already does the survey work. <span class="file">src/plugins/roam-import/typeCandidates.ts</span> walks
+<code>roam:isa</code> values per imported block, groups by alias, ranks by occurrence count and common-property
+frequency, and emits a report:
+</p>
+
+<pre><code>[[Person]] -&gt; type "person" (53 nodes); common props: dob 41/53 (77%), email 38/53 (72%)
+[[Project]] -&gt; type "project" (12 nodes); common props: status 10/12 (83%), owner 9/12 (75%)</code></pre>
+
+<p>
+What's missing is <b>promotion</b> &mdash; the action that turns a Roam page (which is currently the target of
+<code>roam:isa</code> refs) into a real <code>block-type</code> block and re-tags the referencing blocks.
+</p>
+
+<h3>The promotion primitive</h3>
+
+<p>One action, two call sites:</p>
+
+<pre><code>async function promoteToType(args: {
+  targetBlockId: string                  <span class="comment">// the Roam page that's the isa target</span>
+  label: string                          <span class="comment">// pre-filled from the page's alias</span>
+  propertySchemaIds: readonly string[]   <span class="comment">// chosen from the candidate report's common-prop list</span>
+  rewriteIsaReferences?: boolean         <span class="comment">// default false &mdash; leave roam:isa intact for review</span>
+}): Promise&lt;void&gt;</code></pre>
+
+<figure>
+  <svg viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Roam isa adoption flow">
+    <defs>
+      <marker id="arrow4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M0,0 L10,5 L0,10 z" fill="#555"/>
+      </marker>
+    </defs>
+
+    <text x="380" y="22" class="diag-label" text-anchor="middle" font-weight="bold">Before promotion</text>
+    <rect x="60" y="34" width="220" height="46" rx="6" class="diag-box"/>
+    <text x="170" y="52" class="diag-text" text-anchor="middle">"Person" page</text>
+    <text x="170" y="68" class="diag-text" text-anchor="middle">block:types = ['page']</text>
+
+    <rect x="480" y="34" width="220" height="46" rx="6" class="diag-box"/>
+    <text x="590" y="52" class="diag-text" text-anchor="middle">Alice (instance)</text>
+    <text x="590" y="68" class="diag-text" text-anchor="middle">roam:isa = [[Person]] (refList)</text>
+
+    <line x1="480" y1="56" x2="285" y2="56" class="diag-arrow" stroke="#888"/>
+    <text x="380" y="50" class="diag-label" text-anchor="middle">roam:isa ref</text>
+
+    <line x1="380" y1="100" x2="380" y2="130" class="diag-arrow"/>
+    <text x="380" y="120" class="diag-label" text-anchor="middle">promoteToType("Person", ['dob','email'])</text>
+
+    <text x="380" y="158" class="diag-label" text-anchor="middle" font-weight="bold">After promotion</text>
+    <rect x="60" y="170" width="220" height="74" rx="6" class="diag-box diag-box-merged"/>
+    <text x="170" y="190" class="diag-text" text-anchor="middle">"Person" page (now a type)</text>
+    <text x="170" y="208" class="diag-text" text-anchor="middle">block:types = ['page', 'block-type']</text>
+    <text x="170" y="226" class="diag-text" text-anchor="middle">block-type:label = 'Person'</text>
+    <text x="170" y="241" class="diag-text" text-anchor="middle">block-type:properties = [dob, email]</text>
+
+    <rect x="480" y="170" width="220" height="74" rx="6" class="diag-box diag-box-merged"/>
+    <text x="590" y="190" class="diag-text" text-anchor="middle">Alice (instance)</text>
+    <text x="590" y="208" class="diag-text" text-anchor="middle">block:types = ['page', &lt;Person-id&gt;]</text>
+    <text x="590" y="226" class="diag-text" text-anchor="middle">roam:isa = [[Person]]</text>
+    <text x="590" y="241" class="diag-text" text-anchor="middle" fill="#888">(left intact unless rewrite=true)</text>
+
+    <text x="380" y="280" class="diag-label" text-anchor="middle">
+      Same-tx processor sees addedTypes(row) = [&lt;Person-id&gt;]
+    </text>
+    <text x="380" y="298" class="diag-label" text-anchor="middle">
+      and fires whatever the Person type's "on add" processor declared (if any).
+    </text>
+  </svg>
+  <figcaption>Roam <code>roam:isa</code> adoption is mechanical because the type id is the target block's id &mdash; the same id Roam <code>[[Person]]</code> references already resolve to.</figcaption>
+</figure>
+
+<p>Steps inside one <code>repo.tx</code>:</p>
+<ol>
+  <li>
+    <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code> on the Person page, materializing
+    <code>block-type:label</code> and <code>block-type:properties</code> from the action args.
+  </li>
+  <li>
+    Query <code>repo.queryBlocks({referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code> &mdash; the
+    <code>block_references</code> edge index from <span class="file">type-system.md</span> &sect;6b already gives
+    this answer in one EXISTS.
+  </li>
+  <li>
+    For each referencing block, <code>repo.addTypeInTx(tx, instanceId, targetBlockId, {})</code> &mdash; appending
+    the new type id (= target's block id) to <code>block:types</code>. Any <code>sameTxProcessor</code> watching the
+    field fires per row.
+  </li>
+  <li>
+    If <code>rewriteIsaReferences</code>: rewrite the <code>roam:isa</code> refList on each instance, dropping the
+    promoted alias. Default off &mdash; users typically want both for a while.
+  </li>
+</ol>
+
+<p>Two surfaces use the primitive:</p>
+<ul class="tight">
+  <li>
+    <b>Auto-suggest at import time.</b> The existing type-candidate report
+    (<span class="file">src/plugins/roam-import/report.ts:492</span>) gets an "Adopt as type" button per candidate.
+    Property checkboxes default to the common-prop list. Same code path.
+  </li>
+  <li>
+    <b>After-the-fact.</b> "Promote this page to a type" action on any page that's a <code>roam:isa</code> target.
+    Surfaced through the same action infrastructure that handles other context-actions on pages.
+  </li>
+</ul>
+
+<h2>Phasing</h2>
+
+<p>Each phase ships independently. Earlier phases don't depend on the deferred follow-ups in
+<span class="file">type-system.md</span>.</p>
+
+<h3>Phase 1 &mdash; <code>block-type</code> kernel type + Types page + UserTypesService</h3>
+<ul class="tight">
+  <li>Add <code>blockTypeLabelProp</code>, <code>blockTypeDescriptionProp</code>, <code>blockTypePropertiesProp</code> to <span class="file">src/data/properties.ts</span>.</li>
+  <li>Add <code>BLOCK_TYPE_TYPE</code> and <code>TYPES_PAGE_TYPE</code> to <span class="file">src/data/blockTypes.ts</span>; lift the three props onto the contribution.</li>
+  <li><span class="file">src/data/typesPage.ts</span> new &mdash; bootstrap helper near-clone of <span class="file">src/data/propertiesPage.ts</span>.</li>
+  <li><span class="file">src/data/userTypesService.ts</span> new &mdash; subscribe, build contributions, publish to <code>typesFacet</code>'s <code>'user-data'</code> bucket.</li>
+  <li>Start <code>UserTypesService</code> in <code>Repo</code> bootstrap, right after <code>UserSchemasService</code>.</li>
+  <li>Block renderer for <code>block-type</code> blocks (parallel to <span class="file">src/components/renderer/PropertySchemaBlockRenderer.tsx</span>): label / description / property-ref multi-picker.</li>
+  <li>"New type" command on the Types page.</li>
+</ul>
+<p><b>Acceptance:</b> creating a type block surfaces a new entry in the property panel's type picker; tagging a block with it shows the chosen properties as panel slots.</p>
+
+<h3>Phase 2 &mdash; <code>extends</code> overrides</h3>
+<ul class="tight">
+  <li>Add <code>blockTypeExtendsProp</code> to <span class="file">src/data/properties.ts</span>.</li>
+  <li>Extend <code>UserTypesService.tryBuildType</code> to emit override records when <code>extends</code> is set.</li>
+  <li>Extend the rebuild step at <span class="file">src/data/repo.ts:1783</span> to fold overrides into the base contribution post-combine. Drop overrides whose <code>extends</code> target doesn't resolve, log a diagnostic.</li>
+  <li>Renderer surfaces an "extends" picker; tested against a kernel type (e.g., <code>daily-note</code>) plus a user type.</li>
+</ul>
+<p><b>Acceptance:</b> an override block extending <code>daily-note</code> with <code>[weather, mood]</code> adds those slots to every daily-note panel; kernel-defined behavior on daily-note is unchanged.</p>
+
+<h3>Phase 3 &mdash; replace <code>setup</code> with same-tx processors</h3>
+<ul class="tight">
+  <li>Add <code>addedTypes</code> / <code>removedTypes</code> helpers to <span class="file">src/data/properties.ts</span>.</li>
+  <li>Strip <code>setup</code> from <code>TypeContribution</code>; remove the orchestration calls in <code>repo.addType</code> / <code>addTypeInTx</code>.</li>
+  <li>Update <span class="file">docs/type-system.md</span> &sect;3a, &sect;3a-setup, &sect;5 to match.</li>
+  <li>Migrate any existing in-code <code>setup</code> use to <code>sameTxProcessorsFacet</code> contributions (kernel today: none, per audit).</li>
+</ul>
+<p><b>Acceptance:</b> existing kernel + plugin behavior unchanged. Raw <code>tx.update(typesProp)</code> from a fixture now triggers the same processor flow as a <code>repo.addType</code> call.</p>
+
+<h3>Phase 4 &mdash; Roam <code>isa</code> adoption</h3>
+<ul class="tight">
+  <li><code>promoteToType</code> action in <span class="file">src/plugins/roam-import/</span>.</li>
+  <li>UI: "Adopt as type" button per high-confidence candidate in the import report; column of property checkboxes pre-checked at <code>&ge;50%</code> frequency.</li>
+  <li>Standalone action on any page registered as a <code>roam:isa</code> target.</li>
+  <li>Optional <code>rewriteIsaReferences</code> flag; default off.</li>
+</ul>
+<p><b>Acceptance:</b> on a Roam import with 53 blocks tagged <code>is a [[Person]]</code>, promoting Person turns the page into a <code>block-type</code> and re-tags all 53 instances; the Person panel section in the property panel reflects the chosen schemas.</p>
+
+<h2>What's deferred</h2>
+<ul class="tight">
+  <li><b>Type templates as data.</b> A subtree to materialize on instance creation, declared on the type-definition block via a <code>block-type:template</code> refList. Once the same-tx processor pattern is established, a single generic <code>typeTemplateProcessor</code> can dispatch from data. Defer until at least one type wants this in practice.</li>
+  <li><b>Type inheritance for user types.</b> A user type extending <i>another user type</i> rather than a kernel type. The override merge already handles "child extends parent" semantics; only the resolver loop guard (cycle detection) is missing.</li>
+  <li><b>Required-field validation on add.</b> A type-definition block lists which of its <code>properties[]</code> are required; a same-tx processor rejects writes that leave them unset. Easy once Phase 3 lands.</li>
+  <li><b>Property-schema authoring inline with the type.</b> Today the user creates schemas on the Properties page, then refs them from a type on the Types page. A combined "type editor" surface that creates schemas as side-effects of editing a type is ergonomic but not necessary for v1.</li>
+  <li><b>Bulk reimport-time auto-promotion.</b> The import currently <i>suggests</i>; this design's promotion stays user-triggered. Heuristic-based auto-promotion at import time is plausible but a separate UX call.</li>
+</ul>
+
+<h2>Decisions locked in</h2>
+<ul class="tight">
+  <li>User-defined types are blocks of kernel type <code>block-type</code>, hosted on a per-workspace Types page.</li>
+  <li>Type id is the block id. Display label is <code>block-type:label</code>. The picker shows the label; <code>block:types</code> arrays carry ids.</li>
+  <li>Override existing types via <code>block-type:extends</code>; merge at the rebuild step, never destructive.</li>
+  <li>Behavioral fields (today: <code>setup</code>) cannot come from data. The merge rule is "kernel only" for those.</li>
+  <li>Replace <code>setup</code> with same-tx processors. Type contributions become pure metadata. Do this before any current kernel use lands.</li>
+  <li>Roam <code>isa</code> adoption rides one primitive (<code>promoteToType</code>) usable from import time or after-the-fact.</li>
+</ul>
+
+</body>
+</html>

--- a/docs/user-defined-types.html
+++ b/docs/user-defined-types.html
@@ -281,10 +281,7 @@ export class UserTypesService {
     schemas: ReadonlyMap&lt;string, AnyPropertySchema&gt;,
   ): TypeContribution | null {
     const label = block.peekProperty(blockTypeLabelProp) ?? ''
-    if (!label) {
-      console.warn(`[UserTypesService] block ${block.id} has empty label; skipping`)
-      return null
-    }
+    const extendsId = block.peekProperty(blockTypeExtendsProp)
     const refIds = block.peekProperty(blockTypePropertiesProp) ?? []
     const properties: AnyPropertySchema[] = []
     for (const refId of refIds) {
@@ -294,9 +291,21 @@ export class UserTypesService {
       const schema = schemas.get(name)
       if (schema) properties.push(schema)
     }
-    const extendsId = block.peekProperty(blockTypeExtendsProp)
     if (extendsId) {
-      return {kind: 'override', target: extendsId, label, properties} as TypeOverride
+      <span class="comment">// Overrides may legitimately omit label/description &mdash; the merge</span>
+      <span class="comment">// rule is "user wins if set, else kernel" (see &sect;Overriding kernel</span>
+      <span class="comment">// types). Pass undefined through so the rebuild step picks the</span>
+      <span class="comment">// kernel value rather than overwriting with empty string.</span>
+      return {
+        kind: 'override',
+        target: extendsId,
+        label: label || undefined,
+        properties,
+      } as TypeOverride
+    }
+    if (!label) {
+      console.warn(`[UserTypesService] block ${block.id} has empty label; skipping`)
+      return null
     }
     return {
       id: block.id,
@@ -422,8 +431,12 @@ primitive, <code>setup</code> is redundant.
       separate paragraphs (&sect;3-pure, &sect;3a, &sect;3a-setup).
     </td>
     <td>
-      Catches every write uniformly &mdash; sync, raw, plan, orchestrated. The bypass footgun becomes
-      architecturally impossible.
+      Catches every <i>local</i> write &mdash; raw, plan, orchestrated &mdash; uniformly through the commit
+      pipeline (<span class="file">src/data/internals/commitPipeline.ts:263</span>). The
+      <code>addBlockTypeToProperties</code> and raw-<code>tx.update</code> bypass footgun becomes architecturally
+      impossible. <b>Sync-applied writes are still a gap</b>: PowerSync's CRUD-apply path lands writes in SQLite
+      without going through <code>repo.tx</code>, so neither <code>setup</code> nor same-tx processors fire on
+      sync apply. See "Sync-apply gap" below.
     </td>
   </tr>
   <tr>
@@ -505,13 +518,14 @@ primitive, <code>setup</code> is redundant.
     <line x1="570" y1="184" x2="570" y2="204" class="diag-arrow"/>
     <rect x="420" y="206" width="300" height="32" rx="4" class="diag-box"/>
     <text x="570" y="226" class="diag-text" text-anchor="middle">commit</text>
-    <text x="570" y="260" class="diag-label" text-anchor="middle" font-style="italic" fill="#2a7">every write path goes through the same step</text>
+    <text x="570" y="260" class="diag-label" text-anchor="middle" font-style="italic" fill="#2a7">every local write goes through the same step</text>
   </svg>
   <figcaption>
-    Left: today's <code>setup</code> path. Right: same-tx processor path. The processor sees every property write,
-    not just orchestrated <code>addType</code> calls, so sync / raw / plan paths get the same behavior as direct
-    calls. <code>repo.addType</code> shrinks to "encode <code>initialValues</code>, append to <code>typesProp</code>";
-    everything downstream rides the processor stream.
+    Left: today's <code>setup</code> path. Right: same-tx processor path. The processor sees every local property
+    write, not just orchestrated <code>addType</code> calls, so raw <code>tx.update</code> and plan-code paths get
+    the same behavior as direct calls. <code>repo.addType</code> shrinks to "encode <code>initialValues</code>,
+    append to <code>typesProp</code>"; everything downstream rides the processor stream. (Sync-applied writes
+    from other devices bypass <code>repo.tx</code> entirely &mdash; see below.)
   </figcaption>
 </figure>
 
@@ -548,6 +562,50 @@ export const meetingOnAdd = defineSameTxProcessor({
 <span class="comment">// Registered alongside the type contribution:</span>
 sameTxProcessorsFacet.of(meetingOnAdd, {source: 'meeting'})
 typesFacet.of(meetingType, {source: 'meeting'})</code></pre>
+
+<h3>Sync-apply gap</h3>
+
+<p>
+Local <code>repo.tx</code> writes (orchestrated, raw, plan) all flow through the commit pipeline at
+<span class="file">src/data/internals/commitPipeline.ts:263</span>, which is where same-tx processors fire.
+PowerSync-applied writes from another device take a different path entirely: they land in SQLite via the CRUD-apply
+mechanism, never set <code>tx_context.source</code>, and surface to the rest of the app via the
+<code>row_events</code> tail (<span class="file">src/data/internals/rowEventsTail.ts:1-32</span>) which updates the
+cache and fires invalidations but does <i>not</i> run same-tx or post-commit processors.
+</p>
+
+<p>
+So replacing <code>setup</code> with a same-tx processor doesn't <i>introduce</i> a sync-apply gap &mdash;
+<code>setup</code> has exactly the same gap (it only runs inside <code>repo.addType</code>, which is local).
+But it doesn't <i>close</i> it either, which is what the earlier "every write uniformly" framing implied.
+</p>
+
+<p>The honest comparison:</p>
+
+<ul class="tight">
+  <li><b>Local raw <code>tx.update</code> / <code>addBlockTypeToProperties</code> / plan code:</b> <code>setup</code> misses these; same-tx processor catches them. Strictly better.</li>
+  <li><b>Sync-applied writes from another device:</b> both miss. Equal.</li>
+</ul>
+
+<p>
+For behaviors that <i>must</i> run on cross-device type changes (e.g., maintaining a derived side-index for typed
+queries when another client tags a block), the right tool is a separate processor wired to the row_events tail
+&mdash; the same mechanism <code>parseReferences</code> already uses for sync-applied content changes
+(<span class="file">src/plugins/references/referencesProcessor.ts:230</span>). That's out of scope for replacing
+<code>setup</code>, but worth flagging: "type-add behavior" splits into two kinds.
+</p>
+
+<ul class="tight">
+  <li><b>Atomic with the originating write</b> (child templates, computed initial values, rejecting writes that violate type-level constraints) &rarr; same-tx processor. Local-only by construction.</li>
+  <li><b>Eventually-consistent</b> (side-index maintenance, downstream notifications, cleanup) &rarr; post-commit processor on the row_events path. Catches sync apply too.</li>
+</ul>
+
+<p>
+Most current <code>setup</code> use cases (templates, computed initials) are the first kind &mdash; users adding
+types from another device shouldn't get child templates materialized retroactively without their consent. The
+sync-apply gap is the right behavior for that class. The second kind didn't have an analog in <code>setup</code>
+anyway.
+</p>
 
 <h3>What needs to be added</h3>
 
@@ -755,7 +813,7 @@ What's missing is <b>promotion</b> &mdash; the action that turns a Roam page (wh
   <li>Type id is the block id. Display label is <code>block-type:label</code>. The picker shows the label; <code>block:types</code> arrays carry ids.</li>
   <li>Override existing types via <code>block-type:extends</code>; merge at the rebuild step, never destructive.</li>
   <li>Behavioral fields (today: <code>setup</code>) cannot come from data. The merge rule is "kernel only" for those.</li>
-  <li>Replace <code>setup</code> with same-tx processors. Type contributions become pure metadata. Do this before any current kernel use lands.</li>
+  <li>Replace <code>setup</code> with same-tx processors for atomic per-add behavior. Type contributions become pure metadata. Do this before any current kernel use lands. Behaviors that must run on sync-applied type changes from other devices use a separate post-commit processor on the row_events tail (same path <code>parseReferences</code> uses).</li>
   <li>Roam <code>isa</code> adoption rides one primitive (<code>promoteToType</code>) usable from import time or after-the-fact.</li>
 </ul>
 

--- a/docs/user-defined-types.html
+++ b/docs/user-defined-types.html
@@ -777,18 +777,37 @@ service needs the same synchronous-append escape hatch <code>UserSchemasService<
     (taken inside the tx) sees it.
   </li>
   <li>
+    <b>Still before the tx</b> &mdash; resolve the target's workspace and prefilter the instance set.
+    Read the target block to capture its <code>workspaceId</code>, then call
+    <code>repo.queryBlocks({workspaceId, referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code>
+    to get the candidate instance ids. The <code>block_references</code> edge index from
+    <span class="file">type-system.md</span> &sect;6b answers this in one EXISTS. Two reasons this runs <i>outside</i>
+    the tx (see callout):
+    <ul class="tight">
+      <li>
+        <code>repo.queryBlocks</code> reads via <code>ctx.db.getAll</code>, not the active write-tx lock context.
+        Running it inside <code>repo.tx</code> reintroduces the PowerSync queue deadlock documented in
+        <span class="file">tasks/processor-tx-deadlock.md</span> and called out at
+        <span class="file">docs/follow-ups.md:19-21</span>.
+      </li>
+      <li>
+        Explicit <code>workspaceId</code> avoids <code>queryBlocks</code> falling back to
+        <code>activeWorkspaceId</code>, which can differ from the target's workspace during background flows /
+        import runs / UI workspace switches and would silently mis-scope the retag set.
+      </li>
+    </ul>
+  </li>
+  <li>
     Open the tx <i>under a try/catch</i>. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code>
     on the Person page, materializing <code>block-type:label</code> and <code>block-type:properties</code>.
   </li>
   <li>
-    Query <code>repo.queryBlocks({referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code> &mdash; the
-    <code>block_references</code> edge index from <span class="file">type-system.md</span> &sect;6b already gives
-    this answer in one EXISTS.
-  </li>
-  <li>
-    For each referencing block, <code>repo.addTypeInTx(tx, instanceId, targetBlockId, {})</code> &mdash; appending
-    the new type id (= target's block id) to <code>block:types</code>. The id resolves because step 1 already
-    registered it. Any <code>sameTxProcessor</code> watching the field fires per row.
+    For each prefiltered instance id, re-read in-tx via <code>tx.get(instanceId)</code> (cheap; the writer slot
+    is already held) and skip if the row is gone or no longer carries the <code>roam:isa</code> ref to the target
+    &mdash; the TOCTOU narrow guard. For survivors,
+    <code>repo.addTypeInTx(tx, instanceId, targetBlockId, {})</code> appends the new type id to
+    <code>block:types</code>. The id resolves because step 1 already registered it. Any
+    <code>sameTxProcessor</code> watching the field fires per row.
   </li>
   <li>
     If <code>rewriteIsaReferences</code>: rewrite the <code>roam:isa</code> refList on each instance, dropping the
@@ -800,13 +819,23 @@ service needs the same synchronous-append escape hatch <code>UserSchemasService<
   </li>
 </ol>
 
-<pre><code>userTypesService.appendUserType(contribution, targetBlockId)
+<pre><code>const target = await repo.load(targetBlockId)
+const workspaceId = target.workspaceId
+const candidates = await repo.queryBlocks({
+  workspaceId,
+  referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP},
+})
+
+userTypesService.appendUserType(contribution, targetBlockId)
 try {
   await repo.tx(async tx =&gt; {
     await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})
-    const instances = await repo.queryBlocks({referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})
-    for (const instance of instances) {
-      await repo.addTypeInTx(tx, instance.id, targetBlockId, {})
+    for (const candidate of candidates) {
+      const row = await tx.get(candidate.id)
+      if (!row) continue                          <span class="comment">// deleted between prefilter and tx</span>
+      const isaRefs = row.properties[ROAM_ISA_PROP] ?? []
+      if (!resolveRoamIsaTargets(isaRefs).includes(targetBlockId)) continue   <span class="comment">// no longer references target</span>
+      await repo.addTypeInTx(tx, candidate.id, targetBlockId, {})
     }
     if (rewriteIsaReferences) <span class="comment">/* ... */</span>
   })
@@ -814,6 +843,25 @@ try {
   userTypesService.removeUserType(targetBlockId)
   throw err
 }</code></pre>
+
+<div class="callout warn">
+  <h4>Why the query lives outside the tx</h4>
+  <p style="margin:0 0 .4rem">
+    <code>repo.queryBlocks</code> and other typed-query reads route through <code>ctx.db.getAll</code> on the read
+    DB handle, not through <code>tx</code>'s write-transaction lock. Under PowerSync's serialized single-connection
+    config, holding a writer slot while issuing a bare DB read deadlocks the queue &mdash; the read can't progress
+    until the writer releases, and the writer is blocked on the read. The kernel's <code>parseReferences</code>
+    and <code>cleanupOrphanAliases</code> processors paid the same cost and moved their broad reads outside the
+    write tx (<span class="file">docs/follow-ups.md:19</span>); the promotion flow follows the same shape.
+  </p>
+  <p style="margin:0">
+    The TOCTOU window opened by reading outside the tx is narrow and the in-tx re-read closes it:
+    instances may be deleted or have their <code>roam:isa</code> rewritten between the prefilter and the tx,
+    which the in-tx <code>tx.get</code> + property check catches. Conversely, instances that gained an
+    <code>isa</code> ref during the window are silently missed by this promotion &mdash; conservative miss is
+    fine; the user can re-run promotion.
+  </p>
+</div>
 
 <div class="callout warn">
   <h4>Why explicit rollback &mdash; subscription rebuild isn't enough</h4>

--- a/docs/user-defined-types.html
+++ b/docs/user-defined-types.html
@@ -296,10 +296,12 @@ export class UserTypesService {
       <span class="comment">// rule is "user wins if set, else kernel" (see &sect;Overriding kernel</span>
       <span class="comment">// types). Pass undefined through so the rebuild step picks the</span>
       <span class="comment">// kernel value rather than overwriting with empty string.</span>
+      const description = block.peekProperty(blockTypeDescriptionProp)
       return {
         kind: 'override',
         target: extendsId,
         label: label || undefined,
+        description: description || undefined,
         properties,
       } as TypeOverride
     }
@@ -313,6 +315,22 @@ export class UserTypesService {
       description: block.peekProperty(blockTypeDescriptionProp),
       properties,
     }
+  }
+
+  <span class="comment">// Synchronous append used by callers that need a freshly-built</span>
+  <span class="comment">// type to be registered BEFORE their next write (e.g. Roam</span>
+  <span class="comment">// promotion's bulk re-tag step). Mirrors</span>
+  <span class="comment">// UserSchemasService.appendUserSchema at userSchemasService.ts:167.</span>
+  <span class="comment">// The block-write that backs `contribution` is the caller's</span>
+  <span class="comment">// responsibility &mdash; this only updates the runtime bucket so the</span>
+  <span class="comment">// id resolves in addTypeInTx's registry check.</span>
+  appendUserType(contribution: TypeContribution, blockId: string): void {
+    this.contributions = [
+      ...this.contributions.filter(t =&gt; t.id !== contribution.id),
+      contribution,
+    ]
+    this.nameToBlockId.set(contribution.id, blockId)
+    this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
   }
 }</code></pre>
 
@@ -719,11 +737,27 @@ What's missing is <b>promotion</b> &mdash; the action that turns a Roam page (wh
   <figcaption>Roam <code>roam:isa</code> adoption is mechanical because the type id is the target block's id &mdash; the same id Roam <code>[[Person]]</code> references already resolve to.</figcaption>
 </figure>
 
-<p>Steps inside one <code>repo.tx</code>:</p>
+<p>Order matters here. <code>repo.addTypeInTx</code> verifies the type id is in the merged registry and throws on
+unknown ids (<span class="file">docs/type-system.md</span> &sect;3a, <code>[addType] type id ... is not registered</code>);
+the brand-new <code>targetBlockId</code> isn't in the registry yet at the moment we want to retag instances with it,
+because <code>UserTypesService</code>'s subscription publishes the contribution after the tx commits. The
+service needs the same synchronous-append escape hatch <code>UserSchemasService</code> has
+(<code>appendUserSchema</code> at <span class="file">src/data/userSchemasService.ts:167</span>) &mdash; call it
+<code>appendUserType(contribution, blockId)</code>, same shape, updating the user-data bucket on
+<code>typesFacet</code> synchronously via <code>setRuntimeContributions</code>.</p>
+
+<p>With that primitive in place:</p>
 <ol>
   <li>
-    <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code> on the Person page, materializing
-    <code>block-type:label</code> and <code>block-type:properties</code> from the action args.
+    <b>Before opening the tx</b> &mdash; build the <code>TypeContribution</code> from the action args
+    (<code>id = targetBlockId</code>, <code>label</code>, <code>properties</code> = resolved schemas for
+    <code>propertySchemaIds</code>), then <code>userTypesService.appendUserType(contribution, targetBlockId)</code>.
+    <code>repo.types</code> now includes <code>targetBlockId</code>; the next <code>repo.snapshotTypeRegistries()</code>
+    (taken inside the tx) sees it.
+  </li>
+  <li>
+    Open the tx. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code> on the Person page,
+    materializing <code>block-type:label</code> and <code>block-type:properties</code>.
   </li>
   <li>
     Query <code>repo.queryBlocks({referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code> &mdash; the
@@ -732,14 +766,25 @@ What's missing is <b>promotion</b> &mdash; the action that turns a Roam page (wh
   </li>
   <li>
     For each referencing block, <code>repo.addTypeInTx(tx, instanceId, targetBlockId, {})</code> &mdash; appending
-    the new type id (= target's block id) to <code>block:types</code>. Any <code>sameTxProcessor</code> watching the
-    field fires per row.
+    the new type id (= target's block id) to <code>block:types</code>. The id resolves because step 1 already
+    registered it. Any <code>sameTxProcessor</code> watching the field fires per row.
   </li>
   <li>
     If <code>rewriteIsaReferences</code>: rewrite the <code>roam:isa</code> refList on each instance, dropping the
     promoted alias. Default off &mdash; users typically want both for a while.
   </li>
 </ol>
+
+<div class="callout muted">
+  <h4>Crash / abort behavior</h4>
+  <p style="margin:0">
+    If the tx fails after step 1, the runtime carries a registration for a type whose block doesn't exist on
+    disk. Same property <code>addSchema</code> has: the next subscription rebuild reads from blocks, finds no
+    backing one, drops the orphan. Transient, self-healing. The alternative &mdash; appending only after the tx
+    commits &mdash; can't work here because steps 4's <code>addTypeInTx</code> calls need the registration
+    in-tx. The asymmetry vs. <code>addSchema</code> is justified by the in-tx dependency.
+  </p>
+</div>
 
 <p>Two surfaces use the primitive:</p>
 <ul class="tight">

--- a/docs/user-defined-types.html
+++ b/docs/user-defined-types.html
@@ -332,6 +332,17 @@ export class UserTypesService {
     this.nameToBlockId.set(contribution.id, blockId)
     this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
   }
+
+  <span class="comment">// Symmetric rollback for the synchronous-append path. Callers that</span>
+  <span class="comment">// append before opening a tx use this in a catch arm so a tx</span>
+  <span class="comment">// failure can't leave an orphan in the runtime. The subscription</span>
+  <span class="comment">// would only reconcile on the next block-write, which never fires</span>
+  <span class="comment">// if the tx aborted before writing any block.</span>
+  removeUserType(typeId: string): void {
+    this.contributions = this.contributions.filter(t =&gt; t.id !== typeId)
+    this.nameToBlockId.delete(typeId)
+    this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
+  }
 }</code></pre>
 
 <p>
@@ -630,17 +641,27 @@ anyway.
 <p>One small ergonomic piece &mdash; a delta helper so every processor isn't reimplementing the diff:</p>
 
 <pre><code><span class="comment">// src/data/properties.ts (additions)</span>
+<span class="comment">// ChangedRow.before is null for inserts; ChangedRow.after is null</span>
+<span class="comment">// for hard-deletes (`src/data/api/processor.ts:70-73`). Both helpers</span>
+<span class="comment">// must accept either null without throwing, otherwise any processor</span>
+<span class="comment">// using them aborts insert / hard-delete txs.</span>
 export const addedTypes = (row: ChangedRow): readonly string[] =&gt; {
   const before = row.before ? getBlockTypes(row.before) : []
-  const after  = getBlockTypes(row.after)
+  const after  = row.after  ? getBlockTypes(row.after)  : []
   return after.filter(t =&gt; !before.includes(t))
 }
 
 export const removedTypes = (row: ChangedRow): readonly string[] =&gt; {
   const before = row.before ? getBlockTypes(row.before) : []
-  const after  = getBlockTypes(row.after)
+  const after  = row.after  ? getBlockTypes(row.after)  : []
   return before.filter(t =&gt; !after.includes(t))
 }</code></pre>
+
+<p>
+With the helpers null-safe, the example processor above is also safe on hard-delete events: a deleted block returns
+<code>addedTypes(row) === []</code> for any type id, the loop body skips, and <code>row.after</code> is never
+dereferenced. Processors that genuinely care about removal switch on <code>removedTypes(row)</code> instead.
+</p>
 
 <h3>What <code>repo.addType</code> becomes</h3>
 
@@ -746,7 +767,7 @@ service needs the same synchronous-append escape hatch <code>UserSchemasService<
 <code>appendUserType(contribution, blockId)</code>, same shape, updating the user-data bucket on
 <code>typesFacet</code> synchronously via <code>setRuntimeContributions</code>.</p>
 
-<p>With that primitive in place:</p>
+<p>With that primitive in place, plus a symmetric <code>removeUserType(typeId)</code> for cleanup:</p>
 <ol>
   <li>
     <b>Before opening the tx</b> &mdash; build the <code>TypeContribution</code> from the action args
@@ -756,8 +777,8 @@ service needs the same synchronous-append escape hatch <code>UserSchemasService<
     (taken inside the tx) sees it.
   </li>
   <li>
-    Open the tx. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code> on the Person page,
-    materializing <code>block-type:label</code> and <code>block-type:properties</code>.
+    Open the tx <i>under a try/catch</i>. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code>
+    on the Person page, materializing <code>block-type:label</code> and <code>block-type:properties</code>.
   </li>
   <li>
     Query <code>repo.queryBlocks({referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code> &mdash; the
@@ -773,16 +794,41 @@ service needs the same synchronous-append escape hatch <code>UserSchemasService<
     If <code>rewriteIsaReferences</code>: rewrite the <code>roam:isa</code> refList on each instance, dropping the
     promoted alias. Default off &mdash; users typically want both for a while.
   </li>
+  <li>
+    <b>On tx failure</b>: in the catch arm, call <code>userTypesService.removeUserType(targetBlockId)</code>
+    explicitly, then rethrow. Don't rely on the next subscription rebuild to clean up &mdash; see callout below.
+  </li>
 </ol>
 
-<div class="callout muted">
-  <h4>Crash / abort behavior</h4>
+<pre><code>userTypesService.appendUserType(contribution, targetBlockId)
+try {
+  await repo.tx(async tx =&gt; {
+    await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})
+    const instances = await repo.queryBlocks({referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})
+    for (const instance of instances) {
+      await repo.addTypeInTx(tx, instance.id, targetBlockId, {})
+    }
+    if (rewriteIsaReferences) <span class="comment">/* ... */</span>
+  })
+} catch (err) {
+  userTypesService.removeUserType(targetBlockId)
+  throw err
+}</code></pre>
+
+<div class="callout warn">
+  <h4>Why explicit rollback &mdash; subscription rebuild isn't enough</h4>
+  <p style="margin:0 0 .4rem">
+    The subscription that reconciles user-data type contributions from blocks fires <i>only on block writes</i>.
+    A tx that fails before writing any <code>block-type</code> block (validation error, mid-tx exception, abort
+    signal) doesn't trigger a subscription tick, so the provisionally-registered <code>targetBlockId</code>
+    persists in the runtime indefinitely. During that window <code>repo.addTypeInTx(_, _, targetBlockId, {})</code>
+    from any other caller would succeed, attaching an orphan type id to unrelated blocks.
+  </p>
   <p style="margin:0">
-    If the tx fails after step 1, the runtime carries a registration for a type whose block doesn't exist on
-    disk. Same property <code>addSchema</code> has: the next subscription rebuild reads from blocks, finds no
-    backing one, drops the orphan. Transient, self-healing. The alternative &mdash; appending only after the tx
-    commits &mdash; can't work here because steps 4's <code>addTypeInTx</code> calls need the registration
-    in-tx. The asymmetry vs. <code>addSchema</code> is justified by the in-tx dependency.
+    Explicit <code>removeUserType</code> on the catch arm closes the window. The asymmetry vs. <code>addSchema</code>
+    (which appends after commit and doesn't need rollback) is justified by the in-tx dependency: step 4's
+    <code>addTypeInTx</code> calls need the registration to be visible before the tx commits, so the registration
+    has to precede the writes that depend on it.
   </p>
 </div>
 

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -776,7 +776,14 @@ sees the new row, rebuilds its contribution list, and publishes via
   </li>
 </ol>
 
-<pre><code><span class="comment">// Pre-tx validation — fail fast on inputs UserTypesService.tryBuildType</span>
+<pre><code><span class="comment">// Preflight: bail before touching the DB if the caller's signal is</span>
+<span class="comment">// already aborted. waitForTypeRegistrationBounded handles abort during</span>
+<span class="comment">// the Phase A→B wait, but not before Phase A — without this guard, an</span>
+<span class="comment">// already-aborted call still commits the type-definition block and</span>
+<span class="comment">// then throws.</span>
+args.signal?.throwIfAborted()
+
+<span class="comment">// Pre-tx validation — fail fast on inputs UserTypesService.tryBuildType</span>
 <span class="comment">// would silently reject (empty label, unresolvable schema refs).</span>
 <span class="comment">// Without this, a bad-input promotion commits the type block in Phase A,</span>
 <span class="comment">// the subscription drops it, and Phase B's bounded wait surfaces</span>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -879,6 +879,18 @@ for (const schemaId of propertySchemaIds) {
 <span class="comment">// per PR #49 — throws if targetBlockId is missing/tombstoned at tx-start.</span>
 const snapshotA = repo.snapshotTypeRegistries()
 await repo.tx(async tx =&gt; {
+  <span class="comment">// In-tx re-check of each schema ref. Closes the TOCTOU window</span>
+  <span class="comment">// between preflight and tx-open: sync-applied writes can delete a</span>
+  <span class="comment">// schema block, move it cross-workspace, or strip its</span>
+  <span class="comment">// property-schema type tag. Without this, Phase A would commit</span>
+  <span class="comment">// block-type:properties pointing at a stale id and tryBuildType</span>
+  <span class="comment">// would silently drop it at runtime.</span>
+  for (const schemaId of propertySchemaIds) {
+    const row = await tx.get(schemaId)
+    if (!row || row.deleted) throw new Error(`schema ${schemaId} not live`)
+    if (row.workspaceId !== workspaceId) throw new Error(`schema ${schemaId} moved workspace`)
+    if (!hasBlockType(row, PROPERTY_SCHEMA_TYPE)) throw new Error(`schema ${schemaId} lost ${PROPERTY_SCHEMA_TYPE}`)
+  }
   await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {}, snapshotA)
   await repo.addTypeInTx(tx, targetBlockId, PAGE_TYPE, {}, snapshotA)
   <span class="comment">// setProperty (not initialValues): label/properties must overwrite</span>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -780,11 +780,25 @@ const candidates = await repo.queryBlocks({
   referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP},
 })
 
-const snapshotB = repo.snapshotTypeRegistries()
 await repo.tx(async tx =&gt; {
+  <span class="comment">// Capture the type registry snapshot INSIDE the tx body, not before.</span>
+  <span class="comment">// A pre-tx snapshot leaves a window where sync-applied writes (an</span>
+  <span class="comment">// other device deletes the type-definition block) could unregister</span>
+  <span class="comment">// the type. UserTypesService drops the contribution, but a stale</span>
+  <span class="comment">// snapshot still passes addTypeInTx's existence check and writes</span>
+  <span class="comment">// orphan ids. Capturing in-tx narrows the staleness window to a</span>
+  <span class="comment">// single event-loop tick (no other writer can interleave during</span>
+  <span class="comment">// the synchronous tx body).</span>
+  const snapshotB = repo.snapshotTypeRegistries()
+  if (!snapshotB.types.has(targetBlockId)) {
+    <span class="comment">// Belt-and-suspenders: even within the tx, sanity-check the type</span>
+    <span class="comment">// is still registered. Realistic trigger: a sync-applied delete</span>
+    <span class="comment">// of the type-definition block between Phase A and Phase B.</span>
+    throw new PromotionTypeUnregistered(targetBlockId, label)
+  }
   for (const candidate of candidates) {
     const row = await tx.get(candidate.id)
-    if (!row) continue                          <span class="comment">// deleted between prefilter and tx</span>
+    if (!row || row.deleted) continue           <span class="comment">// deleted / tombstoned between prefilter and tx</span>
     const isaRefs = row.properties[ROAM_ISA_PROP] ?? []
     if (!resolveRoamIsaTargets(isaRefs).includes(targetBlockId)) continue
     await repo.addTypeInTx(tx, candidate.id, targetBlockId, {}, snapshotB)

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -242,6 +242,18 @@ The picker UI shows <code>blockTypeLabelProp</code>, never the id.
   </p>
 </div>
 
+<div class="callout muted">
+  <h4>Asymmetry with property schemas: persisted key matches its audience</h4>
+  <p style="margin:0">
+    Property schemas use <b>name</b> as the persisted identifier (the key in <code>properties_json</code>, e.g.
+    <code>status</code>); types use <b>block id</b> (the entry in <code>block:types</code>). The asymmetry is
+    deliberate: property names are read by humans &mdash; in DB dumps, in debug tools, in raw JSON inspection
+    &mdash; so a human-readable persisted key earns its keep. Type ids are only read by the runtime (the picker
+    UI shows the label); opaque is fine. <i>Rule of thumb for future meta-types: human-readable identifier when
+    a human reads the persisted form, block id otherwise.</i>
+  </p>
+</div>
+
 <h2>UserTypesService</h2>
 
 <p>
@@ -942,7 +954,17 @@ await repo.tx(async tx =&gt; {
 <ul class="tight">
   <li>Add <code>blockTypeLabelProp</code>, <code>blockTypeDescriptionProp</code>, <code>blockTypePropertiesProp</code> to <span class="file">src/data/properties.ts</span>.</li>
   <li>Add <code>BLOCK_TYPE_TYPE</code> and <code>TYPES_PAGE_TYPE</code> to <span class="file">src/data/blockTypes.ts</span>; lift the three props onto the contribution.</li>
-  <li><span class="file">src/data/typesPage.ts</span> new &mdash; bootstrap helper near-clone of <span class="file">src/data/propertiesPage.ts</span>. <b>Type-flow pattern:</b> the Types page itself gets BOTH <code>PAGE_TYPE</code> AND <code>TYPES_PAGE_TYPE</code> tagged in its bootstrap tx, matching the convention now used by the Properties page (<span class="file">src/data/propertiesPage.ts</span>), Readwise root, plugin state, and alias user pages. Keeps the Types page navigable as a normal page while still findable via <code>block_types</code>-keyed lookups.</li>
+  <li>
+    <b>Extract a shared <code>getOrCreateKernelPage</code> helper</b> rather than cloning
+    <span class="file">src/data/propertiesPage.ts</span> verbatim. Both pages have the same shape: uuid-v5 from
+    <code>workspaceId</code>, alias-based discovery, soft-delete restore, type-flow tagging
+    (<code>PAGE_TYPE</code> + a marker type). Lift to a single helper that takes
+    <code>(repo, workspaceId, {namespace, alias, types})</code>; refactor
+    <code>getOrCreatePropertiesPage</code> to call it. The future Saved Queries page, Dashboards page,
+    Command palette page (see <span class="file">docs/follow-ups.md:153</span>) all fit the same shape; building
+    the shared helper now keeps the count at one implementation forever.
+  </li>
+  <li><span class="file">src/data/typesPage.ts</span> new &mdash; thin wrapper around <code>getOrCreateKernelPage</code> with the Types-specific args. <b>Type-flow pattern:</b> the Types page gets BOTH <code>PAGE_TYPE</code> AND <code>TYPES_PAGE_TYPE</code> tagged in its bootstrap tx, matching the convention used by the Properties page (<span class="file">src/data/propertiesPage.ts</span>), Readwise root, plugin state, and alias user pages. Keeps the Types page navigable as a normal page while still findable via <code>block_types</code>-keyed lookups.</li>
   <li><span class="file">src/data/userTypesService.ts</span> new &mdash; subscribe, build contributions, publish to <code>typesFacet</code>'s <code>'user-data'</code> bucket. Public surface: <code>start(workspaceId)</code>, <code>dispose</code>, <code>getTypeBlockId(typeId)</code>. No <code>appendUserType</code> / <code>peekContribution</code> / <code>removeUserType</code> &mdash; see &sect;Lessons.</li>
   <li>Start <code>UserTypesService</code> in <code>Repo</code> bootstrap, right after <code>UserSchemasService</code>. Pin workspace at <code>start()</code> time; restart on workspace switch.</li>
   <li>Block renderer for <code>block-type</code> blocks (parallel to <span class="file">src/components/renderer/PropertySchemaBlockRenderer.tsx</span>): label / description / property-ref multi-picker.</li>
@@ -1156,6 +1178,34 @@ documented at the primitive level (commit pipeline order, row_events tail semant
 against that documented model rather than re-deriving invariants per-feature.
 </p>
 
+<h3>Cross-service rule</h3>
+
+<p>
+The "no sync-append-with-rollback primitive" lesson isn't service-specific. It applies symmetrically to the
+existing <code>UserSchemasService</code> (<span class="file">src/data/userSchemasService.ts</span>) and any
+future user-data contribution service. Stated as a shared invariant for future maintainers:
+</p>
+
+<div class="callout warn">
+  <h4>Invariant for all user-data contribution services</h4>
+  <p style="margin:0">
+    Do not add a synchronous-append-with-rollback primitive (<code>appendUserX</code> / <code>removeUserX</code>
+    / <code>withProvisionalX</code>) to a user-data contribution service unless every consumer can prove
+    single-caller-per-key semantics AND single-tx atomicity is actually required. Default to <b>two txs bridged
+    by the subscription</b>: commit the contribution block in one tx, let the service's subscription rebuild
+    register it, then open the dependent tx. The cost is one extra undo entry; the savings are the entire class
+    of concurrent-overlap correctness bugs that <a href="https://github.com/Stvad/knowledge-medium/pull/50">
+    PR #50</a> documented.
+  </p>
+</div>
+
+<p>
+<b>Action item for the user-defined-properties doc:</b> add a cross-link from
+<span class="file">docs/user-defined-properties.md</span> &sect;7 (<code>addSchema</code>) noting that the
+post-tx <code>appendUserSchema</code> ordering is deliberate and not to be inverted into a pre-tx synchronous-
+append &mdash; PR #50's iteration sequence is the cautionary tale.
+</p>
+
 <h2>What's deferred</h2>
 <ul class="tight">
   <li><b>Type inheritance for user types.</b> A user type extending <i>another user type</i> rather than a kernel type. The override merge already handles "child extends parent" semantics; only the resolver loop guard (cycle detection) is missing.</li>
@@ -1163,6 +1213,25 @@ against that documented model rather than re-deriving invariants per-feature.
   <li><b>Property-schema authoring inline with the type.</b> Today the user creates schemas on the Properties page, then refs them from a type on the Types page. A combined "type editor" surface that creates schemas as side-effects of editing a type is ergonomic but not necessary for v1.</li>
   <li><b>Bulk reimport-time auto-promotion.</b> The import currently <i>suggests</i>; this design's promotion stays user-triggered. Heuristic-based auto-promotion at import time is plausible but a separate UX call.</li>
   <li><b>Include-root template materialization.</b> &sect;Type templates fixes descendants-only as the default. A separate slot for include-root semantics (when the template root itself should be cloned) is plausible but no current consumer.</li>
+  <li>
+    <b><code>property-schema:extends</code> for symmetry with <code>block-type:extends</code>.</b> User-defined
+    property schemas could plausibly override a kernel schema (e.g., bind a different default value to
+    <code>statusProp</code> without redefining the codec). Today this isn't possible &mdash;
+    <code>propertySchemasFacet.combine</code> is last-wins-with-warn on duplicate names, not a merge. The
+    symmetric API surface is straightforward (mirror <code>blockTypeExtendsProp</code> + the merge step), but
+    there's no current consumer. Worth proposing alongside any future "let users tweak kernel schema defaults"
+    feature.
+  </li>
+  <li>
+    <b>Shared user-contribution subscription primitive.</b> After <code>UserTypesService</code> ships, the
+    machinery shared with <code>UserSchemasService</code> (subscribe to <code>{types: [META]}</code>, build
+    contributions, publish to facet's <code>'user-data'</code> bucket, re-resolve on dependency change, pin
+    workspace at <code>start()</code>) should be lifted into a single composable
+    (<code>makeUserContributionSubscription({metaType, facet, source, tryBuild, dependsOn})</code>). Best done
+    after both services exist concretely &mdash; refactor against two real instances rather than designing the
+    abstraction upfront. Lower priority than the page-bootstrap helper because the two services genuinely diverge
+    on their dependency listeners (presets vs schemas) and per-row build logic.
+  </li>
 </ul>
 
 <h2>Decisions locked in</h2>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -861,8 +861,10 @@ const workspaceId = target.workspaceId
 <span class="comment">//   - block carries `property-schema` type tag</span>
 <span class="comment">//   - same workspace as the target</span>
 <span class="comment">//   - non-empty propertyNameProp value</span>
-<span class="comment">//   - resolved name registered in repo.propertySchemas (the merged map)</span>
-const mergedSchemas = repo.propertySchemas
+<span class="comment">//   - resolved BY BLOCK ID via userSchemas.getSchemaForBlockId — the</span>
+<span class="comment">//     same lookup tryBuildType uses. A name-only check would let a</span>
+<span class="comment">//     malformed user-schema block pass when a kernel schema with the</span>
+<span class="comment">//     same name exists; runtime would then silently drop the ref.</span>
 for (const schemaId of propertySchemaIds) {
   const schemaBlock = await repo.load(schemaId)
   if (!schemaBlock || schemaBlock.deleted) throw new Error(`...not live`)
@@ -870,7 +872,7 @@ for (const schemaId of propertySchemaIds) {
   if (!hasBlockType(schemaBlock, PROPERTY_SCHEMA_TYPE)) throw new Error(`...not a property-schema`)
   const name = schemaBlock.properties[propertyNameProp.name]
   if (typeof name !== 'string' || !name.trim()) throw new Error(`...empty propertyName`)
-  if (!mergedSchemas.has(name)) throw new Error(`...name "${name}" not registered`)
+  if (!userSchemas.getSchemaForBlockId(schemaId)) throw new Error(`...block-id not published by UserSchemasService`)
 }
 
 <span class="comment">// Phase A: commit the type-definition block. addTypeInTx is strict-by-default</span>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -763,13 +763,15 @@ await repo.tx(async tx =&gt; {
   await repo.addTypeInTx(tx, targetBlockId, PAGE_TYPE, {}, snapshotA)
 }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${label}`})
 
-<span class="comment">// Subscription rebuild publishes targetBlockId into the user-data bucket</span>
-<span class="comment">// on typesFacet, which re-runs the dependent rebuild step and fires</span>
-<span class="comment">// `repo.onTypesChange`. waitForTypeRegistration listens for that event</span>
-<span class="comment">// (no polling, no timer-based timeout). See design.ts for the helper</span>
-<span class="comment">// and the module augmentation declaring onTypesChange — Phase 1 adds</span>
-<span class="comment">// the kernel-side listener symmetric to onPropertySchemasChange.</span>
-await waitForTypeRegistration(repo, targetBlockId)
+<span class="comment">// Bridge tx A → tx B: wait for the subscription rebuild to publish</span>
+<span class="comment">// targetBlockId into the user-data bucket on typesFacet, then proceed.</span>
+<span class="comment">// Event-driven via repo.onTypesChange (added in Phase 1, symmetric to</span>
+<span class="comment">// onPropertySchemasChange). Bounded with a default 10s timeout so a</span>
+<span class="comment">// stuck registration (e.g. tryBuildType rejecting the block-type block</span>
+<span class="comment">// because a referenced property-schema doesn't resolve) surfaces a clear</span>
+<span class="comment">// PromotionRegistrationTimeout instead of hanging indefinitely. The</span>
+<span class="comment">// caller can pass its own AbortSignal for user-driven cancellation.</span>
+await waitForTypeRegistrationBounded(repo, targetBlockId, label, signal, 10_000)
 
 <span class="comment">// Phase B: retag instances. queryBlocks must run OUTSIDE the tx — bare DB reads</span>
 <span class="comment">// inside repo.tx reintroduce the PowerSync queue deadlock (follow-ups.md:19-21).</span>
@@ -815,6 +817,29 @@ await repo.tx(async tx =&gt; {
     throws <code>BlockNotFoundForTypeError</code> when the target row is missing or tombstoned. No explicit
     <code>tx.get</code> + <code>deleted</code> guard is needed before the addType call &mdash; the API surface
     encodes the invariant.
+  </p>
+</div>
+
+<div class="callout warn">
+  <h4>Partial-promotion recovery: tx A committed, registration timed out</h4>
+  <p style="margin:0 0 .4rem">
+    The Phase A&rarr;B handoff has a bounded wait (default 10s) on the subscription registering the new type id.
+    If the wait times out (real cause: the type-definition block committed in tx A, but
+    <code>UserTypesService.tryBuildType</code> is rejecting it &mdash; e.g. a referenced property-schema id doesn't
+    resolve against the current registry), <code>waitForTypeRegistrationBounded</code> throws
+    <code>PromotionRegistrationTimeout</code> <i>before</i> Phase B runs.
+  </p>
+  <p style="margin:0 0 .4rem">
+    <b>Recovery is well-defined.</b> Tx A's block-type block is on disk. The caller can re-run
+    <code>promoteToType</code> with the same args; the second run's tx A is idempotent (already-typed targets
+    re-addType to a no-op), the registration is by then live (the subscription has had time to either fire or
+    the underlying parse issue has been fixed), and Phase B runs against the now-registered type.
+  </p>
+  <p style="margin:0">
+    Caller-side cancellation works the same way: the caller passes <code>signal</code> on <code>PromoteToTypeArgs</code>;
+    aborting between Phase A and Phase B leaves the type-definition block committed and instances un-retagged.
+    The error surface tells the user "the type was created; some instances may not have been re-tagged. Re-run
+    to complete." &mdash; matches how partial bulk operations surface elsewhere in the app.
   </p>
 </div>
 

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -264,6 +264,11 @@ export class UserTypesService {
   private nameToBlockId = new Map&lt;string, string&gt;()
   private subscriptionDisposer: Unsubscribe | null = null
   private schemasListenerDisposer: (() =&gt; void) | null = null
+  <span class="comment">// Cached for the schemasListenerDisposer's re-resolve path: when</span>
+  <span class="comment">// the merged property-schema map changes, replay the last seen</span>
+  <span class="comment">// blocks against the new schemas without a fresh DB read. Mirrors</span>
+  <span class="comment">// UserSchemasService.latestBlocks.</span>
+  private latestBlocks: readonly Block[] = []
 
   constructor(private readonly repo: Repo) {}
 
@@ -272,7 +277,6 @@ export class UserTypesService {
     <span class="comment">// workspaceId required on queryBlocks / subscribeBlocks. The React</span>
     <span class="comment">// provider restarts the service on workspace switch, so capturing</span>
     <span class="comment">// here pairs the subscription's lifetime to one workspace.</span>
-    this.latestBlocks = []
 
     const rebuildFromBlocks = (blocks: readonly Block[]) =&gt; {
       this.latestBlocks = blocks
@@ -301,6 +305,13 @@ export class UserTypesService {
     return () =&gt; this.dispose()
   }
 
+  dispose(): void {
+    this.subscriptionDisposer?.()
+    this.subscriptionDisposer = null
+    this.schemasListenerDisposer?.()
+    this.schemasListenerDisposer = null
+  }
+
   private tryBuildType(
     block: Block,
     schemas: ReadonlyMap&lt;string, AnyPropertySchema&gt;,
@@ -309,7 +320,12 @@ export class UserTypesService {
     const refIds = block.peekProperty(blockTypePropertiesProp) ?? []
     const properties: AnyPropertySchema[] = []
     for (const refId of refIds) {
-      const schemaBlock = this.repo.peek(refId)
+      <span class="comment">// repo.block returns a Block facade; .peek() is the sync read</span>
+      <span class="comment">// of the row data. We then re-validate the ref against the same</span>
+      <span class="comment">// invariants the promoteToType pre-tx validation enforces (type,</span>
+      <span class="comment">// workspace, registered name) — a ref that's stale or invalid</span>
+      <span class="comment">// silently drops with a diagnostic.</span>
+      const schemaBlock = this.repo.block(refId).peek()
       const name = schemaBlock?.properties[propertyNameProp.name]
       if (typeof name !== 'string') continue            <span class="comment">// schema block not yet synced</span>
       const schema = schemas.get(name)
@@ -792,16 +808,28 @@ args.signal?.throwIfAborted()
 <span class="comment">// pre-commit so there's nothing to roll back.</span>
 const label = args.label.trim()
 if (!label) throw new Error('promoteToType: label must be a non-empty string')
-for (const schemaId of propertySchemaIds) {
-  const schemaBlock = await repo.load(schemaId)
-  if (!schemaBlock || schemaBlock.deleted) {
-    throw new Error(`promoteToType: property-schema ref ${schemaId} doesn't resolve`)
-  }
-}
 
 const target = await repo.load(targetBlockId)
-if (!target) throw new Error(`promoteToType: target ${targetBlockId} not found`)
+if (!target || target.deleted) throw new Error(`promoteToType: target ${targetBlockId} not live`)
 const workspaceId = target.workspaceId
+
+<span class="comment">// Validate each schema ref against the full set of invariants</span>
+<span class="comment">// UserTypesService.tryBuildType silently drops on:</span>
+<span class="comment">//   - block exists, not tombstoned</span>
+<span class="comment">//   - block carries `property-schema` type tag</span>
+<span class="comment">//   - same workspace as the target</span>
+<span class="comment">//   - non-empty propertyNameProp value</span>
+<span class="comment">//   - resolved name registered in repo.propertySchemas (the merged map)</span>
+const mergedSchemas = repo.propertySchemas
+for (const schemaId of propertySchemaIds) {
+  const schemaBlock = await repo.load(schemaId)
+  if (!schemaBlock || schemaBlock.deleted) throw new Error(`...not live`)
+  if (schemaBlock.workspaceId !== workspaceId) throw new Error(`...wrong workspace`)
+  if (!hasBlockType(schemaBlock, PROPERTY_SCHEMA_TYPE)) throw new Error(`...not a property-schema`)
+  const name = schemaBlock.properties[propertyNameProp.name]
+  if (typeof name !== 'string' || !name.trim()) throw new Error(`...empty propertyName`)
+  if (!mergedSchemas.has(name)) throw new Error(`...name "${name}" not registered`)
+}
 
 <span class="comment">// Phase A: commit the type-definition block. addTypeInTx is strict-by-default</span>
 <span class="comment">// per PR #49 — throws if targetBlockId is missing/tombstoned at tx-start.</span>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -97,7 +97,7 @@
 <h1>User-defined types</h1>
 <p class="lede">
 Users author types as blocks &mdash; same shape as user-defined property schemas. Code-defined types stop being special.
-Kernel types get a clean override path. Per-type behavior moves from a <code>setup</code> callback to same-tx processors.
+Per-type behavior moves from a <code>setup</code> callback to same-tx processors.
 </p>
 
 <p class="lede">
@@ -147,9 +147,7 @@ export const blockTypePropertiesProp  = defineProperty&lt;readonly string[]&gt;(
   codec: codecs.refList({targetTypes: ['property-schema']}),
   defaultValue: [],
   changeScope: ChangeScope.BlockDefault,
-})
-<span class="comment">// Optional &mdash; if present, this is an override of an existing type, not a new one.</span>
-export const blockTypeExtendsProp     = defineProperty&lt;string&gt;('block-type:extends', {...})</code></pre>
+})</code></pre>
 
 <p>
 And the type contribution itself, registered in <span class="file">src/data/blockTypes.ts</span>:
@@ -164,7 +162,6 @@ defineBlockType({
     blockTypeLabelProp,
     blockTypeDescriptionProp,
     blockTypePropertiesProp,
-    blockTypeExtendsProp,
   ],
 })</code></pre>
 
@@ -300,7 +297,6 @@ export class UserTypesService {
     schemas: ReadonlyMap&lt;string, AnyPropertySchema&gt;,
   ): TypeContribution | null {
     const label = block.peekProperty(blockTypeLabelProp) ?? ''
-    const extendsId = block.peekProperty(blockTypeExtendsProp)
     const refIds = block.peekProperty(blockTypePropertiesProp) ?? []
     const properties: AnyPropertySchema[] = []
     for (const refId of refIds) {
@@ -309,20 +305,6 @@ export class UserTypesService {
       if (typeof name !== 'string') continue            <span class="comment">// schema block not yet synced</span>
       const schema = schemas.get(name)
       if (schema) properties.push(schema)
-    }
-    if (extendsId) {
-      <span class="comment">// Overrides may legitimately omit label/description &mdash; the merge</span>
-      <span class="comment">// rule is "user wins if set, else kernel" (see &sect;Overriding kernel</span>
-      <span class="comment">// types). Pass undefined through so the rebuild step picks the</span>
-      <span class="comment">// kernel value rather than overwriting with empty string.</span>
-      const description = block.peekProperty(blockTypeDescriptionProp)
-      return {
-        kind: 'override',
-        target: extendsId,
-        label: label || undefined,
-        description: description || undefined,
-        properties,
-      } as TypeOverride
     }
     if (!label) {
       console.warn(`[UserTypesService] block ${block.id} has empty label; skipping`)
@@ -365,90 +347,6 @@ export class UserTypesService {
 The bootstrap path (<code>repo</code> construction in <span class="file">src/data/repo.ts</span>) starts the service
 after the workspace's <code>Types</code> page is ensured &mdash; same wiring as <code>UserSchemasService</code>.
 </p>
-
-<h2>Overriding kernel types via <code>extends</code></h2>
-
-<p>
-Plausible use case: a user wants <code>daily-note</code> blocks to surface <code>weather</code> and <code>mood</code>
-slots in the property panel. They author a <code>block-type</code> block with
-<code>block-type:extends = 'daily-note'</code> and <code>block-type:properties = [weather, mood]</code>.
-</p>
-
-<p>
-The naive path &mdash; let <code>typesFacet.combine</code>'s last-wins-on-id resolve it &mdash; is destructive:
-the user's contribution would <i>replace</i> the kernel <code>daily-note</code> entry, wiping
-<code>label</code>, kernel <code>properties[]</code>, and (if it existed) <code>setup</code>. That's not what
-they meant.
-</p>
-
-<p>
-The clean path: distinguish full contributions from <i>override</i> contributions. The
-<code>typesFacet.of(...)</code> contribution stays as-is for full types; user-defined override contributions arrive
-through the same <code>'user-data'</code> source bucket but as a different shape, and the rebuild step in
-<code>setFacetRuntime</code> (<span class="file">src/data/repo.ts:1783</span>) folds them in <i>after</i> combine:
-</p>
-
-<figure>
-  <svg viewBox="0 0 760 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Override merge">
-    <defs>
-      <marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M0,0 L10,5 L0,10 z" fill="#555"/>
-      </marker>
-    </defs>
-
-    <rect x="20" y="20" width="220" height="100" rx="6" class="diag-box diag-box-kernel"/>
-    <text x="130" y="38" class="diag-label" text-anchor="middle">kernel contribution</text>
-    <text x="30" y="58" class="diag-text">id: 'daily-note'</text>
-    <text x="30" y="76" class="diag-text">label: 'Daily note'</text>
-    <text x="30" y="94" class="diag-text">properties: [journalDate]</text>
-    <text x="30" y="112" class="diag-text">setup: createTemplate()</text>
-
-    <rect x="20" y="140" width="220" height="80" rx="6" class="diag-box diag-box-user"/>
-    <text x="130" y="158" class="diag-label" text-anchor="middle">user override</text>
-    <text x="30" y="178" class="diag-text">extends: 'daily-note'</text>
-    <text x="30" y="196" class="diag-text">label: undefined</text>
-    <text x="30" y="214" class="diag-text">properties: [weather, mood]</text>
-
-    <line x1="245" y1="120" x2="370" y2="135" class="diag-arrow"/>
-    <line x1="245" y1="180" x2="370" y2="155" class="diag-arrow"/>
-    <text x="305" y="105" class="diag-label" text-anchor="middle">merge</text>
-    <text x="305" y="200" class="diag-label" text-anchor="middle">at rebuild step</text>
-
-    <rect x="380" y="80" width="360" height="130" rx="6" class="diag-box diag-box-merged"/>
-    <text x="560" y="98" class="diag-label" text-anchor="middle">merged contribution (visible to consumers)</text>
-    <text x="390" y="120" class="diag-text">id: 'daily-note'</text>
-    <text x="390" y="138" class="diag-text">label: 'Daily note'           <tspan fill="#888">(kernel wins; user unset)</tspan></text>
-    <text x="390" y="156" class="diag-text">properties: [journalDate, weather, mood]</text>
-    <text x="390" y="174" class="diag-text">setup: createTemplate()        <tspan fill="#888">(kernel; user cannot)</tspan></text>
-    <text x="390" y="194" class="diag-text">_overriddenBy: ['user-data']   <tspan fill="#888">(audit trail)</tspan></text>
-  </svg>
-  <figcaption>Override merge: union <code>properties[]</code>, user-wins-if-set for <code>label</code> / <code>description</code>, kernel-only for behavioral fields.</figcaption>
-</figure>
-
-<p>The merge rules:</p>
-<ul class="tight">
-  <li><code>properties[]</code> &mdash; <b>union</b> with the kernel list, dedup by name via the existing object-identity rule in <code>mergeLiftedSchemas</code> (<span class="file">src/data/repo.ts:178</span>).</li>
-  <li><code>label</code> / <code>description</code> &mdash; <b>user wins if set</b>, else kernel.</li>
-  <li>Any behavioral field (today: <code>setup</code>) &mdash; <b>kernel only</b>. User-defined types ship no code, so this isn't a regression from the user's side; it's an architectural invariant.</li>
-  <li>
-    <code>block-type:template</code> &mdash; <b>NOT part of the contribution merge</b>. The template refList lives
-    on the source block (the type-definition block carrying the field), and the materializer (&sect;Type templates)
-    reads it directly at type-add time via <code>userTypes.getTypeBlockId(typeId)</code>. The v1 single-source-block
-    model means an override block's own template is currently ignored by the materializer; if a future caller
-    needs override-added templates, widen <code>UserTypesService</code> to track all source blocks per typeId
-    (base + overrides) and have the materializer iterate. Out of scope for Phase 5.
-  </li>
-</ul>
-
-<div class="callout">
-  <h4>Why not a separate <code>typeOverridesFacet</code></h4>
-  <p style="margin:0">
-    Tempting &mdash; the "clean Tana" answer is a parallel facet keyed by target type id. But it adds a service,
-    a publish path, and a rebuild step for one anticipated use case. The single-block-type-with-<code>extends</code>
-    shape is strictly less surface; if overrides grow real complexity later (per-type render overrides, chained
-    setups, etc.) extracting the facet is mechanical. Don't pre-extract.
-  </p>
-</div>
 
 <h2>Replace <code>setup</code> with same-tx processors</h2>
 
@@ -510,12 +408,12 @@ primitive, <code>setup</code> is redundant.
   <tr>
     <td><b>User-defined-types parity</b></td>
     <td>
-      Code-only. <code>extends</code>-overrides can't change it. Creates a "user types are second-class on
-      <code>setup</code>" carveout in the design.
+      Code-only. User-defined types can't ship a <code>setup</code> at all, leaving a "user types are
+      second-class on <code>setup</code>" asymmetry.
     </td>
     <td>
       Nobody ships behavior via the contribution &mdash; not kernel, not plugins, not users. Type contributions
-      become pure metadata. The override path stops having a carveout.
+      become pure metadata. The asymmetry disappears.
     </td>
   </tr>
   <tr>
@@ -991,16 +889,7 @@ await repo.tx(async tx =&gt; {
 </ul>
 <p><b>Acceptance:</b> creating a type block surfaces a new entry in the property panel's type picker; tagging a block with it shows the chosen properties as panel slots.</p>
 
-<h3>Phase 2 &mdash; <code>extends</code> overrides</h3>
-<ul class="tight">
-  <li>Add <code>blockTypeExtendsProp</code> to <span class="file">src/data/properties.ts</span>.</li>
-  <li>Extend <code>UserTypesService.tryBuildType</code> to emit override records when <code>extends</code> is set.</li>
-  <li>Extend the rebuild step that populates <code>_types</code> on <code>Repo</code> to fold overrides into the base contribution post-combine via <code>mergeTypeOverrides</code> (see <a href="design.ts"><code>design.ts</code></a>). Drop overrides whose <code>extends</code> target doesn't resolve, log a diagnostic.</li>
-  <li>Renderer surfaces an "extends" picker; tested against a kernel type (e.g., <code>daily-note</code>) plus a user type.</li>
-</ul>
-<p><b>Acceptance:</b> an override block extending <code>daily-note</code> with <code>[weather, mood]</code> adds those slots to every daily-note panel; kernel-defined behavior on daily-note is unchanged.</p>
-
-<h3>Phase 3 &mdash; replace <code>setup</code> with same-tx processors</h3>
+<h3>Phase 2 &mdash; replace <code>setup</code> with same-tx processors</h3>
 <ul class="tight">
   <li>Add <code>addedTypes</code> / <code>removedTypes</code> helpers to <span class="file">src/data/properties.ts</span>. Null-guard <code>row.before</code> and <code>row.after</code> &mdash; hard-deletes have <code>after === null</code>, inserts have <code>before === null</code>.</li>
   <li>Strip <code>setup</code> from <code>TypeContribution</code>; remove the orchestration calls in <code>repo.addType</code> / <code>addTypeInTx</code>.</li>
@@ -1009,7 +898,7 @@ await repo.tx(async tx =&gt; {
 </ul>
 <p><b>Acceptance:</b> existing kernel + plugin behavior unchanged. Raw <code>tx.update(typesProp)</code> from a fixture now triggers the same processor flow as a <code>repo.addType</code> call.</p>
 
-<h3>Phase 4 &mdash; Roam <code>isa</code> adoption</h3>
+<h3>Phase 3 &mdash; Roam <code>isa</code> adoption</h3>
 <ul class="tight">
   <li><code>promoteToType</code> action in <span class="file">src/plugins/roam-import/</span>, two-tx shape per &sect;Roam <code>isa</code> adoption.</li>
   <li>UI: "Adopt as type" button per high-confidence candidate in the import report; column of property checkboxes pre-checked at <code>&ge;50%</code> frequency.</li>
@@ -1018,7 +907,7 @@ await repo.tx(async tx =&gt; {
 </ul>
 <p><b>Acceptance:</b> on a Roam import with 53 blocks tagged <code>is a [[Person]]</code>, promoting Person turns the page into a <code>block-type</code> and re-tags all 53 instances; the Person panel section in the property panel reflects the chosen schemas. Locally completing a block's local edits and reattempting promotion leaves the local state untouched on the retag pass (since strict <code>addTypeInTx</code> on already-typed blocks is a no-op).</p>
 
-<h3>Phase 5 &mdash; <code>block-type:template</code> (optional, deferred until first consumer)</h3>
+<h3>Phase 4 &mdash; <code>block-type:template</code> (optional, deferred until first consumer)</h3>
 <ul class="tight">
   <li>Add <code>blockTypeTemplateProp</code> as a refList on the <code>block-type</code> contribution.</li>
   <li><code>typeTemplateMaterializer</code> same-tx processor in <span class="file">src/plugins/user-types/</span> (or a dedicated <code>user-types</code> plugin) per <a href="design.ts"><code>design.ts</code></a>. Watches <code>properties</code>; on each <code>addedTypes(row).includes(typeId)</code> match, walks the type's <code>block-type:template</code> refList and clones each root's <i>descendants</i> under the instance via <code>tx.run(createChild, ...)</code>. Idempotent per row (init-if-missing) so a re-add doesn't duplicate.</li>
@@ -1226,20 +1115,81 @@ append &mdash; PR #50's iteration sequence is the cautionary tale.
 </p>
 
 <h2>What's deferred</h2>
+
+<h3>Kernel-type overrides via <code>block-type:extends</code></h3>
+
+<p>
+The motivating use case &mdash; user wants <code>daily-note</code> blocks to surface <code>weather</code> and
+<code>mood</code> slots &mdash; is plausible but hypothetical. No concrete consumer exists today. The mechanism
+adds non-trivial complexity (a second contribution shape, a post-combine merge step, a renderer "extends"
+picker, the merge-rule matrix for user-wins-vs-kernel-wins) that's not worth carrying through v1.
+</p>
+
+<p>
+The cut is shaped so the v2 implementation slots in without re-deciding anything. The forward path:
+</p>
+
 <ul class="tight">
-  <li><b>Type inheritance for user types.</b> A user type extending <i>another user type</i> rather than a kernel type. The override merge already handles "child extends parent" semantics; only the resolver loop guard (cycle detection) is missing.</li>
-  <li><b>Required-field validation on add.</b> A type-definition block lists which of its <code>properties[]</code> are required; a same-tx processor rejects writes that leave them unset. Easy once Phase 3 lands.</li>
+  <li>
+    Add <code>blockTypeExtendsProp = defineProperty&lt;string&gt;('block-type:extends', ...)</code> to
+    <span class="file">src/data/properties.ts</span>; lift onto the <code>BLOCK_TYPE_TYPE</code> contribution.
+  </li>
+  <li>
+    Extend <code>UserTypesService.tryBuildType</code> to branch on <code>extendsId</code> &mdash; if present,
+    emit a <code>TypeOverride</code> record (<code>{kind: 'override', target, label?, description?,
+    properties[]}</code>) instead of a full <code>TypeContribution</code>.
+  </li>
+  <li>
+    Bucket overrides separately from full contributions when publishing into the user-data source on
+    <code>typesFacet</code>. The rebuild step that populates <code>_types</code> on <code>Repo</code> grows a
+    post-combine pass <code>mergeTypeOverrides(base, overrides)</code> that folds each override into its
+    target. Overrides whose target doesn't resolve get a logged diagnostic and are dropped.
+  </li>
+  <li>
+    Merge rules:
+    <ul class="tight">
+      <li><code>properties[]</code> &mdash; <b>union</b> with the kernel list, dedup by name via the object-identity rule in <code>mergeLiftedSchemas</code> (<span class="file">src/data/repo.ts:178</span>).</li>
+      <li><code>label</code> / <code>description</code> &mdash; <b>user wins if set</b>, else kernel (empty-string ⇒ undefined so kernel's value isn't blanked).</li>
+      <li>Any behavioral field (<code>setup</code>, if it ever returns) &mdash; <b>kernel only</b>.</li>
+      <li><code>block-type:template</code> &mdash; lives on the source block; out of contribution merge entirely.</li>
+    </ul>
+  </li>
+  <li>
+    Renderer surfaces an "extends" picker on the block-type block; tested against a kernel type
+    (<code>daily-note</code>) plus a user type.
+  </li>
+</ul>
+
+<div class="callout muted">
+  <h4>Why not a separate <code>typeOverridesFacet</code></h4>
+  <p style="margin:0">
+    The "clean Tana" answer is a parallel facet keyed by target type id. But it adds a service, a publish path,
+    and a rebuild step for one anticipated use case. The single-block-type-with-<code>extends</code> shape
+    above is strictly less surface; if overrides grow real complexity later (per-type render overrides, chained
+    setups, etc.) extracting the facet is mechanical. Don't pre-extract.
+  </p>
+</div>
+
+<p>
+<b>Trigger to build:</b> a real user wants per-type panel slots / labels on a kernel type, or a follow-up
+design (e.g. a "themes" or "workspace presets" mechanism) needs to customize kernel-type metadata. Until then,
+adding the same fields as their own user-defined type is workable &mdash; just not the same UX.
+</p>
+
+<h3>Other deferred items</h3>
+<ul class="tight">
+  <li><b>Type inheritance for user types.</b> A user type extending <i>another user type</i> rather than a kernel type. Same mechanism as kernel-type overrides above; only the resolver loop guard (cycle detection) is extra.</li>
+  <li><b>Required-field validation on add.</b> A type-definition block lists which of its <code>properties[]</code> are required; a same-tx processor rejects writes that leave them unset. Easy once Phase 2 lands.</li>
   <li><b>Property-schema authoring inline with the type.</b> Today the user creates schemas on the Properties page, then refs them from a type on the Types page. A combined "type editor" surface that creates schemas as side-effects of editing a type is ergonomic but not necessary for v1.</li>
   <li><b>Bulk reimport-time auto-promotion.</b> The import currently <i>suggests</i>; this design's promotion stays user-triggered. Heuristic-based auto-promotion at import time is plausible but a separate UX call.</li>
   <li><b>Include-root template materialization.</b> &sect;Type templates fixes descendants-only as the default. A separate slot for include-root semantics (when the template root itself should be cloned) is plausible but no current consumer.</li>
   <li>
-    <b><code>property-schema:extends</code> for symmetry with <code>block-type:extends</code>.</b> User-defined
-    property schemas could plausibly override a kernel schema (e.g., bind a different default value to
-    <code>statusProp</code> without redefining the codec). Today this isn't possible &mdash;
-    <code>propertySchemasFacet.combine</code> is last-wins-with-warn on duplicate names, not a merge. The
-    symmetric API surface is straightforward (mirror <code>blockTypeExtendsProp</code> + the merge step), but
-    there's no current consumer. Worth proposing alongside any future "let users tweak kernel schema defaults"
-    feature.
+    <b><code>property-schema:extends</code> for symmetry with the deferred <code>block-type:extends</code>.</b>
+    User-defined property schemas could plausibly override a kernel schema (e.g., bind a different default
+    value to <code>statusProp</code> without redefining the codec). Today this isn't possible &mdash;
+    <code>propertySchemasFacet.combine</code> is last-wins-with-warn on duplicate names, not a merge. Worth
+    proposing alongside any future "let users tweak kernel schema defaults" feature, in lockstep with the
+    types-side override mechanism above.
   </li>
   <li>
     <b>Shared user-contribution subscription primitive.</b> After <code>UserTypesService</code> ships, the
@@ -1258,10 +1208,10 @@ append &mdash; PR #50's iteration sequence is the cautionary tale.
   <li>User-defined types are blocks of kernel type <code>block-type</code>, hosted on a per-workspace Types page. The Types page itself follows the type-flow pattern: tagged with both <code>PAGE_TYPE</code> and <code>TYPES_PAGE_TYPE</code> at bootstrap.</li>
   <li>Type id is the block id. Display label is <code>block-type:label</code>. The picker shows the label; <code>block:types</code> arrays carry ids.</li>
   <li>A type-definition block is the user's block, not a hidden shadow. One block, dual role &mdash; navigable as a page, its subtree (if any) acts as the type template.</li>
-  <li>Override existing types via <code>block-type:extends</code>; merge at the rebuild step, never destructive. <code>properties[]</code> union, label/description user-wins-if-set, behavioral fields kernel-only.</li>
+  <li>Kernel-type overrides via <code>block-type:extends</code> are <i>deferred</i> &mdash; no real consumer yet. Design notes preserved under "What's deferred" so the v2 implementation has a starting point.</li>
   <li>Replace <code>setup</code> with same-tx processors for atomic per-add behavior. Type contributions become pure metadata. Do this before any current kernel use lands. Behaviors that must run on sync-applied type changes from other devices use a separate post-commit processor on the row_events tail (same path <code>parseReferences</code> uses).</li>
   <li>Roam <code>isa</code> adoption rides one primitive (<code>promoteToType</code>) usable from import time or after-the-fact. <b>Two-tx flow</b> bridged by the subscription rebuild &mdash; no <code>withProvisional</code>-style primitive (per &sect;Lessons).</li>
-  <li>Template materialization (Phase 5): refList on <code>block-type:template</code>; descendants-only clone (root not duplicated); cycle detection at tx-time via a <code>ProcessorRejection</code>.</li>
+  <li>Template materialization (Phase 4): refList on <code>block-type:template</code>; descendants-only clone (root not duplicated); cycle detection at tx-time via a <code>ProcessorRejection</code>.</li>
   <li><b>Companion <code>design.ts</code> typechecks against real codebase types.</b> Drift between this prose and the codebase fails <code>yarn tsc --noEmit --project docs/tsconfig.json</code>.</li>
 </ul>
 

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -270,9 +270,20 @@ export class UserTypesService {
   <span class="comment">// UserSchemasService.latestBlocks.</span>
   private latestBlocks: readonly Block[] = []
 
-  constructor(private readonly repo: Repo) {}
+  constructor(
+    private readonly repo: Repo,
+    private readonly userSchemas: UserSchemasService,
+  ) {}
 
   start(workspaceId: string): () =&gt; void {
+    <span class="comment">// Guard against double-start: re-entry would overwrite</span>
+    <span class="comment">// subscriptionDisposer without disposing the prior subscription,</span>
+    <span class="comment">// leaking listeners and racing two rebuild loops that publish</span>
+    <span class="comment">// competing contribution lists into the user-data bucket. Match</span>
+    <span class="comment">// UserSchemasService.start at src/data/userSchemasService.ts:67-69.</span>
+    if (this.subscriptionDisposer !== null) {
+      throw new Error('[UserTypesService] already started')
+    }
     <span class="comment">// Pin the workspace at start() time — required since PR #48 made</span>
     <span class="comment">// workspaceId required on queryBlocks / subscribeBlocks. The React</span>
     <span class="comment">// provider restarts the service on workspace switch, so capturing</span>
@@ -282,11 +293,22 @@ export class UserTypesService {
       this.latestBlocks = blocks
       const schemas = this.repo.propertySchemas
       const next: TypeContribution[] = []
+      const nextNameToBlockId = new Map&lt;string, string&gt;()
       for (const block of blocks) {
         const built = this.tryBuildType(block, schemas)
-        if (built) next.push(built)
+        if (built) {
+          next.push(built)
+          <span class="comment">// Type id = block id (§"Type id = block id"), so the registry</span>
+          <span class="comment">// key matches the source block id directly. Rebuilding here</span>
+          <span class="comment">// keeps getTypeBlockId in sync with contributions; without</span>
+          <span class="comment">// this the map would be stale for newly-created/edited types</span>
+          <span class="comment">// and any UI flow navigating from block:types back to the</span>
+          <span class="comment">// type-definition block would silently fail.</span>
+          nextNameToBlockId.set(built.id, block.id)
+        }
       }
       this.contributions = next
+      this.nameToBlockId = nextNameToBlockId
       this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
     }
 
@@ -314,21 +336,34 @@ export class UserTypesService {
 
   private tryBuildType(
     block: Block,
-    schemas: ReadonlyMap&lt;string, AnyPropertySchema&gt;,
+    _schemas: ReadonlyMap&lt;string, AnyPropertySchema&gt;,
   ): TypeContribution | null {
     const label = block.peekProperty(blockTypeLabelProp) ?? ''
     const refIds = block.peekProperty(blockTypePropertiesProp) ?? []
     const properties: AnyPropertySchema[] = []
     for (const refId of refIds) {
-      <span class="comment">// repo.block returns a Block facade; .peek() is the sync read</span>
-      <span class="comment">// of the row data. We then re-validate the ref against the same</span>
-      <span class="comment">// invariants the promoteToType pre-tx validation enforces (type,</span>
-      <span class="comment">// workspace, registered name) — a ref that's stale or invalid</span>
-      <span class="comment">// silently drops with a diagnostic.</span>
-      const schemaBlock = this.repo.block(refId).peek()
-      const name = schemaBlock?.properties[propertyNameProp.name]
-      if (typeof name !== 'string') continue            <span class="comment">// schema block not yet synced</span>
-      const schema = schemas.get(name)
+      <span class="comment">// Route through UserSchemasService rather than peeking the</span>
+      <span class="comment">// schema block directly. Two reasons:</span>
+      <span class="comment">//</span>
+      <span class="comment">//   1. Cold-start hydration: this.repo.block(refId).peek() returns</span>
+      <span class="comment">//      undefined for rows the BlockCache hasn't loaded yet. Our</span>
+      <span class="comment">//      subscribeBlocks watches {types: [BLOCK_TYPE_TYPE]}; it does</span>
+      <span class="comment">//      NOT hydrate property-schema blocks. Using peek would silently</span>
+      <span class="comment">//      drop refs to schemas that exist on disk but aren't yet in</span>
+      <span class="comment">//      the cache — Phase 1 user types would register with missing</span>
+      <span class="comment">//      panel slots until something else triggered hydration.</span>
+      <span class="comment">//   2. Validation: UserSchemasService only publishes contributions</span>
+      <span class="comment">//      for blocks that pass its tryBuildSchema filter (right type,</span>
+      <span class="comment">//      workspace match via the workspace-pinned subscription, valid</span>
+      <span class="comment">//      name + config). getSchemaForBlockId returning a schema is</span>
+      <span class="comment">//      proof those invariants hold; we don't have to re-derive them.</span>
+      <span class="comment">//</span>
+      <span class="comment">// Eventual consistency: refs to schemas that aren't yet published</span>
+      <span class="comment">// drop silently here AND fire onPropertySchemasChange when they</span>
+      <span class="comment">// land, which rebuildFromBlocks listens for. So a type starts with</span>
+      <span class="comment">// partial properties on cold start, then fills in as schemas</span>
+      <span class="comment">// register. Documented; not a "permanently missing slot" footgun.</span>
+      const schema = this.userSchemas.getSchemaForBlockId(refId)
       if (schema) properties.push(schema)
     }
     if (!label) {
@@ -835,11 +870,14 @@ for (const schemaId of propertySchemaIds) {
 <span class="comment">// per PR #49 — throws if targetBlockId is missing/tombstoned at tx-start.</span>
 const snapshotA = repo.snapshotTypeRegistries()
 await repo.tx(async tx =&gt; {
-  await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {
-    [blockTypeLabelProp.name]: label,
-    [blockTypePropertiesProp.name]: propertySchemaIds,
-  }, snapshotA)
+  await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {}, snapshotA)
   await repo.addTypeInTx(tx, targetBlockId, PAGE_TYPE, {}, snapshotA)
+  <span class="comment">// setProperty (not initialValues): label/properties must overwrite</span>
+  <span class="comment">// on retry. initialValues is init-if-missing per type-system.md §3a;</span>
+  <span class="comment">// a retry with a corrected label or different property set would</span>
+  <span class="comment">// otherwise silently keep the stale values.</span>
+  await tx.setProperty(targetBlockId, blockTypeLabelProp, label)
+  await tx.setProperty(targetBlockId, blockTypePropertiesProp, propertySchemaIds)
 }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${label}`})
 
 <span class="comment">// Bridge tx A → tx B: wait for the subscription rebuild to publish</span>
@@ -1000,8 +1038,14 @@ await repo.tx(async tx =&gt; {
     the shared helper now keeps the count at one implementation forever.
   </li>
   <li><span class="file">src/data/typesPage.ts</span> new &mdash; thin wrapper around <code>getOrCreateKernelPage</code> with the Types-specific args. <b>Type-flow pattern:</b> the Types page gets BOTH <code>PAGE_TYPE</code> AND <code>TYPES_PAGE_TYPE</code> tagged in its bootstrap tx, matching the convention used by the Properties page (<span class="file">src/data/propertiesPage.ts</span>), Readwise root, plugin state, and alias user pages. Keeps the Types page navigable as a normal page while still findable via <code>block_types</code>-keyed lookups.</li>
+  <li>
+    Extend <code>UserSchemasService</code> with <code>getSchemaForBlockId(blockId): AnyPropertySchema | undefined</code>
+    and an internal <code>blockIdToName: Map&lt;string, string&gt;</code> populated alongside <code>nameToBlockId</code>
+    during rebuild + <code>appendUserSchema</code>. <code>UserTypesService.tryBuildType</code> uses this to resolve
+    <code>block-type:properties</code> refs to live schemas without cache-hydration races (see <a href="#typesservice"><code>UserTypesService</code> sketch</a>). Cheap O(1) lookup; the reverse map mirrors what the service already maintains.
+  </li>
   <li><span class="file">src/data/userTypesService.ts</span> new &mdash; subscribe, build contributions, publish to <code>typesFacet</code>'s <code>'user-data'</code> bucket. Public surface: <code>start(workspaceId)</code>, <code>dispose</code>, <code>getTypeBlockId(typeId)</code>. No <code>appendUserType</code> / <code>peekContribution</code> / <code>removeUserType</code> &mdash; see &sect;Lessons.</li>
-  <li>Start <code>UserTypesService</code> in <code>Repo</code> bootstrap, right after <code>UserSchemasService</code>. Pin workspace at <code>start()</code> time; restart on workspace switch.</li>
+  <li>Start <code>UserTypesService</code> in <code>Repo</code> bootstrap, right after <code>UserSchemasService</code>. Pass the existing <code>UserSchemasService</code> instance to the constructor (UserTypesService depends on it for the block-id&rarr;schema lookup). Pin workspace at <code>start()</code> time; restart on workspace switch.</li>
   <li>Block renderer for <code>block-type</code> blocks (parallel to <span class="file">src/components/renderer/PropertySchemaBlockRenderer.tsx</span>): label / description / property-ref multi-picker.</li>
   <li>"New type" command on the Types page.</li>
 </ul>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -267,8 +267,15 @@ export class UserTypesService {
 
   constructor(private readonly repo: Repo) {}
 
-  start(): () =&gt; void {
+  start(workspaceId: string): () =&gt; void {
+    <span class="comment">// Pin the workspace at start() time — required since PR #48 made</span>
+    <span class="comment">// workspaceId required on queryBlocks / subscribeBlocks. The React</span>
+    <span class="comment">// provider restarts the service on workspace switch, so capturing</span>
+    <span class="comment">// here pairs the subscription's lifetime to one workspace.</span>
+    this.latestBlocks = []
+
     const rebuildFromBlocks = (blocks: readonly Block[]) =&gt; {
+      this.latestBlocks = blocks
       const schemas = this.repo.propertySchemas
       const next: TypeContribution[] = []
       for (const block of blocks) {
@@ -280,14 +287,16 @@ export class UserTypesService {
     }
 
     this.subscriptionDisposer = this.repo.subscribeBlocks(
-      {types: [BLOCK_TYPE_TYPE]},
+      {workspaceId, types: [BLOCK_TYPE_TYPE]},
       blocks =&gt; rebuildFromBlocks(blocks.map(b =&gt; this.repo.block(b.id))),
     )
     <span class="comment">// Re-resolve when the merged schema map changes &mdash; a newly-loaded</span>
     <span class="comment">// property schema makes previously-unresolvable refs in</span>
     <span class="comment">// block-type:properties suddenly resolvable. Mirrors</span>
     <span class="comment">// onValuePresetsChange in UserSchemasService.</span>
-    this.schemasListenerDisposer = this.repo.onPropertySchemasChange(() =&gt; rebuild())
+    this.schemasListenerDisposer = this.repo.onPropertySchemasChange(
+      () =&gt; rebuildFromBlocks(this.latestBlocks),
+    )
 
     return () =&gt; this.dispose()
   }
@@ -615,13 +624,32 @@ The import already does the survey work. <span class="file">src/plugins/roam-imp
 frequency, and emits a report:
 </p>
 
-<pre><code>[[Person]] -&gt; type "person" (53 nodes); common props: dob 41/53 (77%), email 38/53 (72%)
-[[Project]] -&gt; type "project" (12 nodes); common props: status 10/12 (83%), owner 9/12 (75%)</code></pre>
+<pre><code>[[Person]] -&gt; "Person" (53 nodes); common props: dob 41/53 (77%), email 38/53 (72%)
+[[Project]] -&gt; "Project" (12 nodes); common props: status 10/12 (83%), owner 9/12 (75%)</code></pre>
 
 <p>
 What's missing is <b>promotion</b> &mdash; the action that turns a Roam page (which is currently the target of
 <code>roam:isa</code> refs) into a real <code>block-type</code> block and re-tags the referencing blocks.
 </p>
+
+<div class="callout warn">
+  <h4>Candidate model needs a <code>targetBlockId</code>, not a slug</h4>
+  <p style="margin:0 0 .4rem">
+    Today <code>typeCandidates.ts</code> emits a <code>typeId: string</code> derived from the alias via
+    <code>typeIdFromIsaAlias</code> (lowercased / dashed slug). That worked when the design imagined kernel-style
+    semantic type ids. With this design's <b>type id = block id</b> decision, the slug is wrong &mdash;
+    <code>promoteToType</code> needs the alias's resolved block id.
+  </p>
+  <p style="margin:0">
+    Phase 3's deliverables include updating <code>RoamTypeCandidate</code> to carry
+    <code>targetBlockId: string | null</code> (null when the alias has no live target in the workspace yet,
+    e.g. a Roam-isa-only alias whose seat hasn't been materialized). The importer resolves the alias to its
+    block id during candidate collection &mdash; the alias index is already populated by the seat-materialization
+    pass that runs before this. The report's display still shows the alias for human readability; the action
+    payload carries the block id. Candidates whose <code>targetBlockId</code> is null get a disabled "Adopt as
+    type" button with a hover-tooltip explaining the unresolved alias.
+  </p>
+</div>
 
 <h3>The promotion primitive</h3>
 
@@ -748,7 +776,23 @@ sees the new row, rebuilds its contribution list, and publishes via
   </li>
 </ol>
 
-<pre><code>const target = await repo.load(targetBlockId)
+<pre><code><span class="comment">// Pre-tx validation — fail fast on inputs UserTypesService.tryBuildType</span>
+<span class="comment">// would silently reject (empty label, unresolvable schema refs).</span>
+<span class="comment">// Without this, a bad-input promotion commits the type block in Phase A,</span>
+<span class="comment">// the subscription drops it, and Phase B's bounded wait surfaces</span>
+<span class="comment">// PromotionRegistrationTimeout 10s later — a half-promotion the caller</span>
+<span class="comment">// has to clean up manually. Validating upfront keeps the failure</span>
+<span class="comment">// pre-commit so there's nothing to roll back.</span>
+const label = args.label.trim()
+if (!label) throw new Error('promoteToType: label must be a non-empty string')
+for (const schemaId of propertySchemaIds) {
+  const schemaBlock = await repo.load(schemaId)
+  if (!schemaBlock || schemaBlock.deleted) {
+    throw new Error(`promoteToType: property-schema ref ${schemaId} doesn't resolve`)
+  }
+}
+
+const target = await repo.load(targetBlockId)
 if (!target) throw new Error(`promoteToType: target ${targetBlockId} not found`)
 const workspaceId = target.workspaceId
 
@@ -939,8 +983,22 @@ await repo.tx(async tx =&gt; {
 
 <h3>Phase 3 &mdash; Roam <code>isa</code> adoption</h3>
 <ul class="tight">
-  <li><code>promoteToType</code> action in <span class="file">src/plugins/roam-import/</span>, two-tx shape per &sect;Roam <code>isa</code> adoption.</li>
-  <li>UI: "Adopt as type" button per high-confidence candidate in the import report; column of property checkboxes pre-checked at <code>&ge;50%</code> frequency.</li>
+  <li>
+    <b>Update <code>RoamTypeCandidate</code> shape</b> in
+    <span class="file">src/plugins/roam-import/typeCandidates.ts:16</span>. Drop the
+    <code>typeId: string</code> slug field (was <code>typeIdFromIsaAlias(alias)</code>); add
+    <code>targetBlockId: string | null</code>. The importer's candidate collection pass resolves each alias
+    against the alias index that the seat-materialization pass populates; aliases with no live target return
+    null. The slug-form id was load-bearing for the previous "semantic kernel id" design; this design's
+    block-id-as-type-id makes the slug redundant.
+  </li>
+  <li>
+    <b>Update <code>formatTypeCandidateLines</code> / <code>typeCandidateLine</code></b>
+    (<span class="file">src/plugins/roam-import/typeCandidates.ts:161</span>) to show the alias as the human
+    label and the block id only as metadata; the slug disappears from the report.
+  </li>
+  <li><code>promoteToType</code> action in <span class="file">src/plugins/roam-import/</span>, two-tx shape per &sect;Roam <code>isa</code> adoption. Pre-tx validation of <code>label</code> and <code>propertySchemaIds</code> per the code sample above.</li>
+  <li>UI: "Adopt as type" button per high-confidence candidate in the import report; column of property checkboxes pre-checked at <code>&ge;50%</code> frequency. Action payload carries the candidate's <code>targetBlockId</code> (not the alias) into <code>promoteToType</code>. Candidates with <code>targetBlockId = null</code> get a disabled button with a tooltip explaining the unresolved alias.</li>
   <li>Standalone action on any page registered as a <code>roam:isa</code> target.</li>
   <li>Optional <code>rewriteIsaReferences</code> flag; default off.</li>
 </ul>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -100,6 +100,13 @@ Users author types as blocks &mdash; same shape as user-defined property schemas
 Kernel types get a clean override path. Per-type behavior moves from a <code>setup</code> callback to same-tx processors.
 </p>
 
+<p class="lede">
+<b>Companion file:</b> <a href="design.ts"><code>design.ts</code></a> specifies the type surfaces this doc
+describes by importing real codebase types. Drift between the prose and the codebase fails
+<code>yarn tsc --noEmit --project docs/tsconfig.json</code>. Pattern follows
+<a href="../plugin-runtime-toggle/design.html"><code>plugin-runtime-toggle</code></a>.
+</p>
+
 <h2>The premise has shifted</h2>
 
 <p>
@@ -317,44 +324,30 @@ export class UserTypesService {
     }
   }
 
-  <span class="comment">// Synchronous append used by callers that need a freshly-built</span>
-  <span class="comment">// type to be registered BEFORE their next write (e.g. Roam</span>
-  <span class="comment">// promotion's bulk re-tag step). Mirrors</span>
-  <span class="comment">// UserSchemasService.appendUserSchema at userSchemasService.ts:167.</span>
-  <span class="comment">// The block-write that backs `contribution` is the caller's</span>
-  <span class="comment">// responsibility &mdash; this only updates the runtime bucket so the</span>
-  <span class="comment">// id resolves in addTypeInTx's registry check.</span>
-  <span class="comment">// Look up the current user-data contribution for an id (if any).</span>
-  <span class="comment">// Callers using the synchronous-append pattern peek before</span>
-  <span class="comment">// appending so they can restore the prior value on tx failure</span>
-  <span class="comment">// rather than blindly removing it (which would wipe a legitimate</span>
-  <span class="comment">// pre-existing registration on a retry).</span>
-  peekContribution(typeId: string): {contribution: TypeContribution; blockId: string} | undefined {
-    const contribution = this.contributions.find(t =&gt; t.id === typeId)
-    const blockId = this.nameToBlockId.get(typeId)
-    return contribution && blockId !== undefined ? {contribution, blockId} : undefined
-  }
-
-  appendUserType(contribution: TypeContribution, blockId: string): void {
-    this.contributions = [
-      ...this.contributions.filter(t =&gt; t.id !== contribution.id),
-      contribution,
-    ]
-    this.nameToBlockId.set(contribution.id, blockId)
-    this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
-  }
-
-  <span class="comment">// Symmetric rollback for the synchronous-append path. Callers that</span>
-  <span class="comment">// append before opening a tx use this in a catch arm so a tx</span>
-  <span class="comment">// failure can't leave an orphan in the runtime. The subscription</span>
-  <span class="comment">// would only reconcile on the next block-write, which never fires</span>
-  <span class="comment">// if the tx aborted before writing any block.</span>
-  removeUserType(typeId: string): void {
-    this.contributions = this.contributions.filter(t =&gt; t.id !== typeId)
-    this.nameToBlockId.delete(typeId)
-    this.repo.setRuntimeContributions(typesFacet, 'user-data', this.contributions)
+  <span class="comment">// Look up the user-data type contribution's source block id, if any.</span>
+  <span class="comment">// Used by UI surfaces that want to navigate from a `block:types` entry</span>
+  <span class="comment">// back to the type-definition block (e.g. a "edit this type" action</span>
+  <span class="comment">// on a panel section header).</span>
+  getTypeBlockId(typeId: string): string | undefined {
+    return this.nameToBlockId.get(typeId)
   }
 }</code></pre>
+
+<div class="callout muted">
+  <h4>No synchronous-append / rollback primitive in v1</h4>
+  <p style="margin:0">
+    Earlier drafts of this design included <code>appendUserType</code> / <code>removeUserType</code> /
+    <code>peekContribution</code> &mdash; a synchronous-write path symmetric to
+    <code>UserSchemasService.appendUserSchema</code>, intended to register a user-defined type before the in-tx
+    retag step of Roam-isa adoption. <a href="https://github.com/Stvad/knowledge-medium/pull/50">PR #50</a>
+    pursued the same primitive on the schemas service and found it compounds quickly under concurrent overlap
+    review (per-call CAS tokens, committed-only baselines, restore-vs-remove ordering) for a use case the
+    codebase doesn't actually produce. The two-tx Roam-isa adoption flow (&sect;Roam <code>isa</code> adoption)
+    removes the need entirely &mdash; the subscription bridges Phase A and Phase B. If a future caller can prove
+    single-caller-per-name semantics AND genuinely needs single-tx atomicity, a narrow primitive can be added
+    then with a documented contract.
+  </p>
+</div>
 
 <p>
 The bootstrap path (<code>repo</code> construction in <span class="file">src/data/repo.ts</span>) starts the service
@@ -769,132 +762,137 @@ What's missing is <b>promotion</b> &mdash; the action that turns a Roam page (wh
   <figcaption>Roam <code>roam:isa</code> adoption is mechanical because the type id is the target block's id &mdash; the same id Roam <code>[[Person]]</code> references already resolve to.</figcaption>
 </figure>
 
-<p>Order matters here. <code>repo.addTypeInTx</code> verifies the type id is in the merged registry and throws on
-unknown ids (<span class="file">docs/type-system.md</span> &sect;3a, <code>[addType] type id ... is not registered</code>);
-the brand-new <code>targetBlockId</code> isn't in the registry yet at the moment we want to retag instances with it,
-because <code>UserTypesService</code>'s subscription publishes the contribution after the tx commits. The
-service needs the same synchronous-append escape hatch <code>UserSchemasService</code> has
-(<code>appendUserSchema</code> at <span class="file">src/data/userSchemasService.ts:167</span>) &mdash; call it
-<code>appendUserType(contribution, blockId)</code>, same shape, updating the user-data bucket on
-<code>typesFacet</code> synchronously via <code>setRuntimeContributions</code>.</p>
+<p>
+The flow uses <b>two transactions</b> bridged by <code>UserTypesService</code>'s subscription, rather than a single
+tx with a synchronously-registered provisional type. The single-tx approach was explored on
+<a href="https://github.com/Stvad/knowledge-medium/pull/50">PR #50</a> (the parallel
+<code>withProvisionalSchema</code> for the property-schemas service); it compounds quickly under review &mdash;
+per-call CAS tokens, committed-only mirrors, capture-and-restore on failure &mdash; for a use case (concurrent
+overlapping calls for the same name) the codebase doesn't actually produce. Two txs trades one undo entry for a
+trivial concurrency model and a cleaner failure surface. See &sect;Lessons from <code>withProvisionalSchema</code>.
+</p>
 
-<p>With that primitive in place, plus a symmetric <code>removeUserType(typeId)</code> for cleanup:</p>
+<h4>Phase A: commit the type-definition block</h4>
 <ol>
   <li>
-    <b>Before opening the tx</b> &mdash; build the <code>TypeContribution</code> from the action args
-    (<code>id = targetBlockId</code>, <code>label</code>, <code>properties</code> = resolved schemas for
-    <code>propertySchemaIds</code>), then <code>userTypesService.appendUserType(contribution, targetBlockId)</code>.
-    <code>repo.types</code> now includes <code>targetBlockId</code>; the next <code>repo.snapshotTypeRegistries()</code>
-    (taken inside the tx) sees it.
+    Read the target block before opening the tx to capture its <code>workspaceId</code>. Background flows / import
+    runs / UI workspace switches must not silently re-scope to <code>activeWorkspaceId</code> &mdash; per the merged
+    <a href="https://github.com/Stvad/knowledge-medium/pull/48">PR #48</a> <code>repo.queryBlocks</code> now requires
+    <code>workspaceId</code> at the type level, so any code path that omits it fails to compile rather than
+    quietly mis-scoping.
   </li>
   <li>
-    <b>Still before the tx</b> &mdash; resolve the target's workspace and prefilter the instance set.
-    Read the target block to capture its <code>workspaceId</code>, then call
-    <code>repo.queryBlocks({workspaceId, referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code>
-    to get the candidate instance ids. The <code>block_references</code> edge index from
-    <span class="file">type-system.md</span> &sect;6b answers this in one EXISTS. Two reasons this runs <i>outside</i>
-    the tx (see callout):
-    <ul class="tight">
-      <li>
-        <code>repo.queryBlocks</code> reads via <code>ctx.db.getAll</code>, not the active write-tx lock context.
-        Running it inside <code>repo.tx</code> reintroduces the PowerSync queue deadlock documented in
-        <span class="file">tasks/processor-tx-deadlock.md</span> and called out at
-        <span class="file">docs/follow-ups.md:19-21</span>.
-      </li>
-      <li>
-        Explicit <code>workspaceId</code> avoids <code>queryBlocks</code> falling back to
-        <code>activeWorkspaceId</code>, which can differ from the target's workspace during background flows /
-        import runs / UI workspace switches and would silently mis-scope the retag set.
-      </li>
-    </ul>
+    Open tx A. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {label, properties: propertySchemaIds})</code>
+    materializes <code>block-type:label</code> and <code>block-type:properties</code> from the action args, plus
+    appends <code>'block-type'</code> to the target's <code>typesProp</code>. Per merged
+    <a href="https://github.com/Stvad/knowledge-medium/pull/49">PR #49</a> <code>addTypeInTx</code> is strict by
+    default &mdash; throws <code>BlockNotFoundForTypeError</code> if the target was deleted concurrently between the
+    pre-tx <code>load()</code> and tx-open, no silent no-op possible. (Sync-apply / processor paths that legitimately
+    want to no-op on tombstone use the new <code>addTypeInTxLenient</code>; promotion uses strict.)
   </li>
   <li>
-    Open the tx <i>under a try/catch</i>. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})</code>
-    on the Person page, materializing <code>block-type:label</code> and <code>block-type:properties</code>.
+    Also tag the target with <code>PAGE_TYPE</code> in the same tx if it isn't already &mdash; the "type flow" pattern
+    landed for the Properties page, Readwise root, plugin state, and alias user pages
+    (<span class="file">src/data/propertiesPage.ts</span>). The target stays navigable as a normal page; the new
+    <code>block-type</code> tag is additive, not exclusive.
+  </li>
+</ol>
+
+<h4>Subscription tick (between txs)</h4>
+
+<p>
+Tx A commits. The <code>row_events</code> machinery fires; <code>UserTypesService.subscribeBlocks({types: [BLOCK_TYPE_TYPE]})</code>
+sees the new row, rebuilds its contribution list, and publishes via
+<code>repo.setRuntimeContributions(typesFacet, 'user-data', ...)</code>. <code>repo.types</code> now contains
+<code>targetBlockId</code> as a registered type id. No synchronous-append dance; the subscription bridges the txs.
+</p>
+
+<h4>Phase B: retag isa instances</h4>
+<ol start="4">
+  <li>
+    Prefilter candidate instances OUTSIDE the tx via
+    <code>repo.queryBlocks({workspaceId, referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP}})</code>.
+    The <code>block_references</code> edge index from <span class="file">type-system.md</span> &sect;6b answers this
+    in one EXISTS. Outside-the-tx because <code>queryBlocks</code> reads via <code>ctx.db.getAll</code> on the read
+    DB handle; running it inside <code>repo.tx</code> reintroduces the PowerSync queue deadlock documented in
+    <span class="file">tasks/processor-tx-deadlock.md</span>.
   </li>
   <li>
-    For each prefiltered instance id, re-read in-tx via <code>tx.get(instanceId)</code> (cheap; the writer slot
-    is already held) and skip if the row is gone or no longer carries the <code>roam:isa</code> ref to the target
-    &mdash; the TOCTOU narrow guard. For survivors,
-    <code>repo.addTypeInTx(tx, instanceId, targetBlockId, {})</code> appends the new type id to
-    <code>block:types</code>. The id resolves because step 1 already registered it. Any
-    <code>sameTxProcessor</code> watching the field fires per row.
+    Open tx B. For each prefiltered candidate, <code>tx.get(candidateId)</code> re-checks the row (closes the
+    TOCTOU window — the candidate may have been deleted or had its <code>roam:isa</code> rewritten between the
+    pre-tx query and tx-open). If the row still references the target, <code>repo.addTypeInTx(tx, candidateId,
+    targetBlockId, {})</code> appends the new type id to <code>block:types</code>. The id resolves because the
+    subscription registered it in the interval.
   </li>
   <li>
     If <code>rewriteIsaReferences</code>: rewrite the <code>roam:isa</code> refList on each instance, dropping the
-    promoted alias. Default off &mdash; users typically want both for a while.
-  </li>
-  <li>
-    <b>On tx failure</b>: in the catch arm, call <code>userTypesService.removeUserType(targetBlockId)</code>
-    explicitly, then rethrow. Don't rely on the next subscription rebuild to clean up &mdash; see callout below.
+    promoted alias. Default off &mdash; users typically want both for a while as the promotion settles.
   </li>
 </ol>
 
 <pre><code>const target = await repo.load(targetBlockId)
+if (!target) throw new Error(`promoteToType: target ${targetBlockId} not found`)
 const workspaceId = target.workspaceId
+
+<span class="comment">// Phase A: commit the type-definition block. addTypeInTx is strict-by-default</span>
+<span class="comment">// per PR #49 — throws if targetBlockId is missing/tombstoned at tx-start.</span>
+const snapshotA = repo.snapshotTypeRegistries()
+await repo.tx(async tx =&gt; {
+  await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {
+    [blockTypeLabelProp.name]: label,
+    [blockTypePropertiesProp.name]: propertySchemaIds,
+  }, snapshotA)
+  await repo.addTypeInTx(tx, targetBlockId, PAGE_TYPE, {}, snapshotA)
+}, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${label}`})
+
+<span class="comment">// Subscription rebuild publishes targetBlockId into the user-data bucket</span>
+<span class="comment">// on typesFacet. Wait for it before opening Phase B.</span>
+await waitForTypeRegistration(repo, targetBlockId)
+
+<span class="comment">// Phase B: retag instances. queryBlocks must run OUTSIDE the tx — bare DB reads</span>
+<span class="comment">// inside repo.tx reintroduce the PowerSync queue deadlock (follow-ups.md:19-21).</span>
 const candidates = await repo.queryBlocks({
   workspaceId,
   referencedBy: {id: targetBlockId, sourceField: ROAM_ISA_PROP},
 })
 
-<span class="comment">// Capture the prior user-data contribution for this id (if any).</span>
-<span class="comment">// Restored on tx failure rather than blindly removed &mdash; see</span>
-<span class="comment">// "Rollback must preserve prior registration" callout.</span>
-const prior = userTypesService.peekContribution(targetBlockId)
-userTypesService.appendUserType(contribution, targetBlockId)
-try {
-  await repo.tx(async tx =&gt; {
-    <span class="comment">// In-tx guard: the target may have been deleted concurrently</span>
-    <span class="comment">// between our pre-tx load() and the tx opening. addTypeInTx is a</span>
-    <span class="comment">// no-op when tx.get(blockId) returns null (src/data/repo.ts) so</span>
-    <span class="comment">// without this guard the loop below would happily tag N instances</span>
-    <span class="comment">// with a type id whose backing block doesn't exist. Throwing here</span>
-    <span class="comment">// aborts the tx and triggers the rollback path below.</span>
-    const targetInTx = await tx.get(targetBlockId)
-    if (!targetInTx || targetInTx.deleted) {
-      throw new Error(`promoteToType: target ${targetBlockId} no longer exists`)
-    }
-    await repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {...})
-
-    for (const candidate of candidates) {
-      const row = await tx.get(candidate.id)
-      if (!row) continue                          <span class="comment">// deleted between prefilter and tx</span>
-      const isaRefs = row.properties[ROAM_ISA_PROP] ?? []
-      if (!resolveRoamIsaTargets(isaRefs).includes(targetBlockId)) continue   <span class="comment">// no longer references target</span>
-      await repo.addTypeInTx(tx, candidate.id, targetBlockId, {})
-    }
-    if (rewriteIsaReferences) <span class="comment">/* ... */</span>
-  })
-} catch (err) {
-  if (prior) {
-    userTypesService.appendUserType(prior.contribution, prior.blockId)   <span class="comment">// restore</span>
-  } else {
-    userTypesService.removeUserType(targetBlockId)                       <span class="comment">// drop provisional</span>
+const snapshotB = repo.snapshotTypeRegistries()
+await repo.tx(async tx =&gt; {
+  for (const candidate of candidates) {
+    const row = await tx.get(candidate.id)
+    if (!row) continue                          <span class="comment">// deleted between prefilter and tx</span>
+    const isaRefs = row.properties[ROAM_ISA_PROP] ?? []
+    if (!resolveRoamIsaTargets(isaRefs).includes(targetBlockId)) continue
+    await repo.addTypeInTx(tx, candidate.id, targetBlockId, {}, snapshotB)
   }
-  throw err
-}</code></pre>
+  if (rewriteIsaReferences) <span class="comment">/* ... */</span>
+}, {scope: ChangeScope.BlockDefault, description: `promoteToType:retag ${label}`})</code></pre>
 
-<div class="callout warn">
-  <h4>In-tx existence guard for the target</h4>
+<div class="callout">
+  <h4>Why two txs, not one</h4>
+  <p style="margin:0 0 .4rem">
+    The single-tx alternative needs to <i>register</i> the new user-defined type before <code>addTypeInTx</code>
+    sees it. That's a <code>setRuntimeContributions</code> call BEFORE opening the tx, plus a rollback on tx
+    failure. <a href="https://github.com/Stvad/knowledge-medium/pull/50">PR #50</a> explored this shape on the
+    parallel <code>UserSchemasService</code>; the rollback semantics compound under review (CAS tokens,
+    committed-only baselines, retry safety) every round, for a concurrent-overlap scenario the codebase has zero
+    callers for.
+  </p>
   <p style="margin:0">
-    <code>repo.addTypeInTx(tx, blockId, ...)</code> silently no-ops when <code>tx.get(blockId)</code> returns null
-    or a tombstone &mdash; reasonable behavior on sync-applied deletes where another device removed the row, but
-    a footgun for orchestration code that's about to fan out work tied to the target. Without the explicit
-    <code>tx.get</code> + <code>deleted</code> check, a concurrent delete between the pre-tx <code>load()</code> and
-    the tx opening would let the loop persist <code>targetBlockId</code> on every candidate's <code>block:types</code>
-    while the target itself stays a non-<code>block-type</code> tombstone. The next runtime rebuild then drops the
-    provisional registration, leaving orphan ids on N rows.
+    Two txs sidestep the entire mechanism. The cost is one extra undo entry (create-type, then retag) instead of
+    one combined entry. Acceptable: users will reasonably think of them as two operations anyway, and an undo of
+    just-the-retag leaves the type definition intact, which is the right shape if they want to redo the retag
+    with a different property set.
   </p>
 </div>
 
-<div class="callout warn">
-  <h4>Rollback must preserve prior registration</h4>
+<div class="callout">
+  <h4>In-tx existence is enforced by strict <code>addTypeInTx</code></h4>
   <p style="margin:0">
-    A retry on an already-promoted target (e.g. user re-runs promotion with a different property set) has
-    <code>peekContribution(targetBlockId)</code> returning the existing user-data contribution. An unconditional
-    <code>removeUserType</code> on tx failure would wipe that legitimate registration, breaking every block
-    currently tagged with this id until the next subscription tick reconciles. Capture-and-restore is the right
-    primitive: <code>peek &rarr; append &rarr; on-failure-restore-or-drop</code>.
+    With <a href="https://github.com/Stvad/knowledge-medium/pull/49">PR #49</a> landed, <code>addTypeInTx</code>
+    throws <code>BlockNotFoundForTypeError</code> when the target row is missing or tombstoned. No explicit
+    <code>tx.get</code> + <code>deleted</code> guard is needed before the addType call &mdash; the API surface
+    encodes the invariant.
   </p>
 </div>
 
@@ -917,23 +915,6 @@ try {
   </p>
 </div>
 
-<div class="callout warn">
-  <h4>Why explicit rollback &mdash; subscription rebuild isn't enough</h4>
-  <p style="margin:0 0 .4rem">
-    The subscription that reconciles user-data type contributions from blocks fires <i>only on block writes</i>.
-    A tx that fails before writing any <code>block-type</code> block (validation error, mid-tx exception, abort
-    signal) doesn't trigger a subscription tick, so the provisionally-registered <code>targetBlockId</code>
-    persists in the runtime indefinitely. During that window <code>repo.addTypeInTx(_, _, targetBlockId, {})</code>
-    from any other caller would succeed, attaching an orphan type id to unrelated blocks.
-  </p>
-  <p style="margin:0">
-    Explicit <code>removeUserType</code> on the catch arm closes the window. The asymmetry vs. <code>addSchema</code>
-    (which appends after commit and doesn't need rollback) is justified by the in-tx dependency: step 4's
-    <code>addTypeInTx</code> calls need the registration to be visible before the tx commits, so the registration
-    has to precede the writes that depend on it.
-  </p>
-</div>
-
 <p>Two surfaces use the primitive:</p>
 <ul class="tight">
   <li>
@@ -949,16 +930,21 @@ try {
 
 <h2>Phasing</h2>
 
-<p>Each phase ships independently. Earlier phases don't depend on the deferred follow-ups in
-<span class="file">type-system.md</span>.</p>
+<p>Each phase ships independently.</p>
+
+<p><b>Prerequisites already landed on master:</b></p>
+<ul class="tight">
+  <li><a href="https://github.com/Stvad/knowledge-medium/pull/48">PR #48</a> &mdash; <code>workspaceId</code> required on <code>repo.queryBlocks</code> / <code>subscribeBlocks</code> (active-workspace callers use <code>queryActiveWorkspace</code>). Phase 4 below depends on the explicit-workspace contract.</li>
+  <li><a href="https://github.com/Stvad/knowledge-medium/pull/49">PR #49</a> &mdash; <code>addTypeInTx</code> strict-by-default; throws <code>BlockNotFoundForTypeError</code> on missing/tombstoned blocks. The lenient variant (<code>addTypeInTxLenient</code>) is opt-in for sync-apply paths only. Phase 4 below relies on strict semantics for the in-tx existence guard.</li>
+</ul>
 
 <h3>Phase 1 &mdash; <code>block-type</code> kernel type + Types page + UserTypesService</h3>
 <ul class="tight">
   <li>Add <code>blockTypeLabelProp</code>, <code>blockTypeDescriptionProp</code>, <code>blockTypePropertiesProp</code> to <span class="file">src/data/properties.ts</span>.</li>
   <li>Add <code>BLOCK_TYPE_TYPE</code> and <code>TYPES_PAGE_TYPE</code> to <span class="file">src/data/blockTypes.ts</span>; lift the three props onto the contribution.</li>
-  <li><span class="file">src/data/typesPage.ts</span> new &mdash; bootstrap helper near-clone of <span class="file">src/data/propertiesPage.ts</span>.</li>
-  <li><span class="file">src/data/userTypesService.ts</span> new &mdash; subscribe, build contributions, publish to <code>typesFacet</code>'s <code>'user-data'</code> bucket.</li>
-  <li>Start <code>UserTypesService</code> in <code>Repo</code> bootstrap, right after <code>UserSchemasService</code>.</li>
+  <li><span class="file">src/data/typesPage.ts</span> new &mdash; bootstrap helper near-clone of <span class="file">src/data/propertiesPage.ts</span>. <b>Type-flow pattern:</b> the Types page itself gets BOTH <code>PAGE_TYPE</code> AND <code>TYPES_PAGE_TYPE</code> tagged in its bootstrap tx, matching the convention now used by the Properties page (<span class="file">src/data/propertiesPage.ts</span>), Readwise root, plugin state, and alias user pages. Keeps the Types page navigable as a normal page while still findable via <code>block_types</code>-keyed lookups.</li>
+  <li><span class="file">src/data/userTypesService.ts</span> new &mdash; subscribe, build contributions, publish to <code>typesFacet</code>'s <code>'user-data'</code> bucket. Public surface: <code>start(workspaceId)</code>, <code>dispose</code>, <code>getTypeBlockId(typeId)</code>. No <code>appendUserType</code> / <code>peekContribution</code> / <code>removeUserType</code> &mdash; see &sect;Lessons.</li>
+  <li>Start <code>UserTypesService</code> in <code>Repo</code> bootstrap, right after <code>UserSchemasService</code>. Pin workspace at <code>start()</code> time; restart on workspace switch.</li>
   <li>Block renderer for <code>block-type</code> blocks (parallel to <span class="file">src/components/renderer/PropertySchemaBlockRenderer.tsx</span>): label / description / property-ref multi-picker.</li>
   <li>"New type" command on the Types page.</li>
 </ul>
@@ -968,14 +954,14 @@ try {
 <ul class="tight">
   <li>Add <code>blockTypeExtendsProp</code> to <span class="file">src/data/properties.ts</span>.</li>
   <li>Extend <code>UserTypesService.tryBuildType</code> to emit override records when <code>extends</code> is set.</li>
-  <li>Extend the rebuild step at <span class="file">src/data/repo.ts:1783</span> to fold overrides into the base contribution post-combine. Drop overrides whose <code>extends</code> target doesn't resolve, log a diagnostic.</li>
+  <li>Extend the rebuild step that populates <code>_types</code> on <code>Repo</code> to fold overrides into the base contribution post-combine via <code>mergeTypeOverrides</code> (see <a href="design.ts"><code>design.ts</code></a>). Drop overrides whose <code>extends</code> target doesn't resolve, log a diagnostic.</li>
   <li>Renderer surfaces an "extends" picker; tested against a kernel type (e.g., <code>daily-note</code>) plus a user type.</li>
 </ul>
 <p><b>Acceptance:</b> an override block extending <code>daily-note</code> with <code>[weather, mood]</code> adds those slots to every daily-note panel; kernel-defined behavior on daily-note is unchanged.</p>
 
 <h3>Phase 3 &mdash; replace <code>setup</code> with same-tx processors</h3>
 <ul class="tight">
-  <li>Add <code>addedTypes</code> / <code>removedTypes</code> helpers to <span class="file">src/data/properties.ts</span>.</li>
+  <li>Add <code>addedTypes</code> / <code>removedTypes</code> helpers to <span class="file">src/data/properties.ts</span>. Null-guard <code>row.before</code> and <code>row.after</code> &mdash; hard-deletes have <code>after === null</code>, inserts have <code>before === null</code>.</li>
   <li>Strip <code>setup</code> from <code>TypeContribution</code>; remove the orchestration calls in <code>repo.addType</code> / <code>addTypeInTx</code>.</li>
   <li>Update <span class="file">docs/type-system.md</span> &sect;3a, &sect;3a-setup, &sect;5 to match.</li>
   <li>Migrate any existing in-code <code>setup</code> use to <code>sameTxProcessorsFacet</code> contributions (kernel today: none, per audit).</li>
@@ -984,30 +970,211 @@ try {
 
 <h3>Phase 4 &mdash; Roam <code>isa</code> adoption</h3>
 <ul class="tight">
-  <li><code>promoteToType</code> action in <span class="file">src/plugins/roam-import/</span>.</li>
+  <li><code>promoteToType</code> action in <span class="file">src/plugins/roam-import/</span>, two-tx shape per &sect;Roam <code>isa</code> adoption.</li>
   <li>UI: "Adopt as type" button per high-confidence candidate in the import report; column of property checkboxes pre-checked at <code>&ge;50%</code> frequency.</li>
   <li>Standalone action on any page registered as a <code>roam:isa</code> target.</li>
   <li>Optional <code>rewriteIsaReferences</code> flag; default off.</li>
 </ul>
-<p><b>Acceptance:</b> on a Roam import with 53 blocks tagged <code>is a [[Person]]</code>, promoting Person turns the page into a <code>block-type</code> and re-tags all 53 instances; the Person panel section in the property panel reflects the chosen schemas.</p>
+<p><b>Acceptance:</b> on a Roam import with 53 blocks tagged <code>is a [[Person]]</code>, promoting Person turns the page into a <code>block-type</code> and re-tags all 53 instances; the Person panel section in the property panel reflects the chosen schemas. Locally completing a block's local edits and reattempting promotion leaves the local state untouched on the retag pass (since strict <code>addTypeInTx</code> on already-typed blocks is a no-op).</p>
+
+<h3>Phase 5 &mdash; <code>block-type:template</code> (optional, deferred until first consumer)</h3>
+<ul class="tight">
+  <li>Add <code>blockTypeTemplateProp</code> as a refList on the <code>block-type</code> contribution.</li>
+  <li><code>typeTemplateMaterializer</code> same-tx processor in <span class="file">src/plugins/user-types/</span> (or a dedicated <code>user-types</code> plugin) per <a href="design.ts"><code>design.ts</code></a>. Watches <code>properties</code>; on each <code>addedTypes(row).includes(typeId)</code> match, walks the type's <code>block-type:template</code> refList and clones each root's <i>descendants</i> under the instance via <code>tx.run(createChild, ...)</code>. Idempotent per row (init-if-missing) so a re-add doesn't duplicate.</li>
+  <li><code>templateCycleGuard</code> same-tx processor watches <code>properties</code> + <code>parentId</code> and throws <code>ProcessorRejection('userTypes.templateCycle')</code> when a write would create a self-referential cycle (e.g., a block typed X moved into the subtree of X's template root).</li>
+  <li>Driver / consumer: the recurring-tasks design (parallel work) builds on this for its template-spawn flow.</li>
+</ul>
+<p><b>Acceptance:</b> a <code>block-type</code> with <code>block-type:template = [[Meeting template]]</code> materializes <i>Attendees</i> / <i>Agenda</i> / <i>Action items</i> children under a new instance on type-add. Moving an instance into the meeting-template subtree throws the cycle-guard rejection; the move is rolled back.</p>
+
+<h2>Type templates &mdash; <code>block-type:template</code></h2>
+
+<p>
+Some types want to materialize a structured subtree under every new instance. The Roam-imported
+&ldquo;meeting&rdquo; type wants <i>Attendees</i> / <i>Agenda</i> / <i>Action items</i> child blocks; a
+&ldquo;weekly review&rdquo; type wants its standard rubric. The replaced-setup design (&sect;Replace
+<code>setup</code> with same-tx processors) handles the materialization mechanism; what's left to specify is the
+data shape of the template itself.
+</p>
+
+<p>
+A new property on the kernel <code>block-type</code> type: <code>block-type:template</code>, a refList of root
+blocks whose subtrees act as templates. When the type is first added to an instance, a same-tx processor
+materializes those subtrees under the instance.
+</p>
+
+<h3>The type-definition block is the user's block</h3>
+
+<p>
+A user-defined type is just a block. Marking a block as a type (via the type-system UI, or via the
+recurring-tasks template flow that builds on this) turns that <i>same</i> block into the type definition. It
+remains a navigable, editable page. Its subtree, if any, is what becomes the template. <b>One block, dual
+role.</b>
+</p>
+
+<p>
+This is worth saying out loud rather than leaving implicit. The alternative shape &mdash; a hidden type-definition
+block plus a refList back to user-visible content &mdash; is a worse mental model and forces every consumer to
+thread the indirection. Naming the dual-role intent here prevents a future maintainer from "tidying up" the
+redundancy and re-introducing the indirection.
+</p>
+
+<h3>Descendants-only materialization</h3>
+
+<p>
+When the processor materializes a template, it clones <b>the children</b> of each referenced root, not the root
+itself. The new instance gets those children attached directly underneath; the template root is never
+duplicated.
+</p>
+
+<ul class="tight">
+  <li>
+    <b>Include-root would surprise.</b> A &ldquo;meeting&rdquo; instance with a duplicate
+    <code>[[Meeting]]</code>-typed root block as its first child reads as a bug, not a feature.
+  </li>
+  <li>
+    <b>Descendants-only composes with every existing child-add path.</b> <code>createChild</code> /
+    <code>tx.run(createChild, ...)</code> already appends children under a parent; the materializer is the same
+    shape repeated for each template root's children.
+  </li>
+</ul>
+
+<p>
+A future use case for include-root materialization (where you really do want the root cloned along with its
+subtree) gets a separately-named slot (<code>block-type:template-root-included</code> or similar) rather than
+flipping the semantics of the existing one. Changing this after consumers exist is painful.
+</p>
+
+<h3>Cycle detection at tx-time</h3>
+
+<p>
+Easy to construct accidentally: user drags an instance back into a template subtree, or makes a typed block
+itself a template root for its own type. Materialization then recurses indefinitely.
+</p>
+
+<p>
+Reject at the moment the cycle is created, not at materialization time. A same-tx processor watches
+<code>typesProp</code> changes and <code>parentId</code> changes. For each affected row it walks the
+parent chain looking for an ancestor B such that any of the row's current types appears in B's
+<code>block-type:template</code> refList; if found, <code>throw new ProcessorRejection('userTypes.templateCycle', ...)</code>
+with the offending pair so the toast surface can format a clear &ldquo;this block can't be moved into its own
+type's template&rdquo; message.
+</p>
+
+<p>
+Tx-time rejection is preferable to a depth-guard at materialization for the same reason most validation should
+live at the boundary: the error surface is the action the user took, not a downstream symptom. A depth-guard
+catches recursion ("hit recursion limit during template materialization") but leaves the underlying cycle
+intact. Rejecting at the move/tag-add prevents the cycle from being persisted at all.
+</p>
+
+<p>
+See <code>templateCycleGuard</code> in <a href="design.ts"><code>design.ts</code></a> for the watch surface;
+implementation goes in <span class="file">src/plugins/user-types/</span> (or wherever the user-types plugin lands).
+</p>
+
+<h2>Lessons from <code>withProvisionalSchema</code></h2>
+
+<p>
+<a href="https://github.com/Stvad/knowledge-medium/pull/50">PR #50</a> built a capture-and-restore primitive on
+<code>UserSchemasService</code> for exactly the pattern this design's earlier draft applied to the Roam-isa
+adoption flow: register a contribution synchronously before an in-tx write that depends on it, roll back the
+registration if the tx fails. The PR closed without merging; the doc was updated in this round to drop the
+analogous primitive. The reasons are worth pinning down because they apply to any future "register +
+in-tx-dependent" pattern in this codebase.
+</p>
+
+<h3>What review surfaced, in order</h3>
+
+<ol>
+  <li>
+    <b>Unconditional <code>remove</code> on rollback wipes legit prior registrations.</b> A retry on an already-
+    registered name finds the prior entry, and unconditional removal erases it.
+    <i>Fix:</i> capture prior, restore-or-remove based on what was there.
+  </li>
+  <li>
+    <b>The captured prior can be stale if a concurrent caller has already overwritten the slot.</b>
+    <i>Fix:</i> compare-and-swap on the live entry before rolling back.
+  </li>
+  <li>
+    <b>CAS by <code>blockId</code> isn't unique enough.</b> Two concurrent calls for the same
+    <code>(name, blockId)</code> (retries / dupe submits) share the field.
+    <i>Fix:</i> per-call CAS token, stored in a parallel map; every mutation generates a fresh symbol.
+  </li>
+  <li>
+    <b>The captured prior can be another in-flight provisional, not a committed entry.</b> If A appends, B starts
+    and captures A as prior, then both fail: A skips rollback (token mismatch), B "restores" A &mdash; leaving a
+    failed provisional registered with no successful tx behind it.
+    <i>Fix:</i> track a committed-only mirror updated by successful operations only; rollback uses the committed
+    baseline, not the live peek.
+  </li>
+  <li>
+    <b>Success-path token check skips committed promotion under overlap.</b> If A's tx succeeds while B's
+    provisional has overwritten A's live token, the success guard fails the CAS and never promotes A to committed.
+    A subsequent B-failure rollback then wipes A's never-committed-but-real registration.
+    <i>Fix:</i> commit-on-success regardless of token state &mdash; which then has ordering issues with intervening
+    external commits, which the next round would have found.
+  </li>
+</ol>
+
+<h3>The shape of the failure mode</h3>
+
+<p>
+Each fix above is correct. Each one made the primitive heavier, and each round of review found a deeper
+edge case &mdash; entirely because the primitive had taken on responsibility for arbitrary concurrent-overlap
+correctness on a slot that the codebase doesn't actually contend on. The class of bug is unbounded: the API
+surface keeps growing to handle interleavings that don't happen.
+</p>
+
+<h3>What this design does instead</h3>
+
+<ul class="tight">
+  <li>
+    <b>No <code>withProvisionalType</code>, no <code>appendUserType</code>, no <code>peekContribution</code>.</b>
+    <code>UserTypesService</code> exposes only the read-side surface (<code>getTypeBlockId</code>) needed by UI.
+    Block writes go through the kernel orchestration entry points (<code>addTypeInTx</code> etc.) which already
+    handle the strict/lenient distinction and reject on missing/tombstoned blocks
+    (<a href="https://github.com/Stvad/knowledge-medium/pull/49">PR #49</a>).
+  </li>
+  <li>
+    <b>Where in-tx dependents exist, use two txs.</b> The Roam-isa adoption flow commits the type-definition
+    block in tx A, lets the subscription rebuild register the type, then opens tx B for the bulk retag. Two undo
+    entries instead of one; trivial concurrency model; no rollback machinery.
+  </li>
+  <li>
+    <b>If a future caller needs single-tx atomicity, design the primitive against that caller's actual
+    interleavings.</b> Single-caller-per-name semantics make this trivial. Arbitrary concurrent overlap is a much
+    deeper invariant; defer until there's a real caller that needs it.
+  </li>
+</ul>
+
+<p>
+The deeper meta-lesson: <b>design-time spec rigor on concurrency edge cases isn't free</b>. Each "what if two
+callers&hellip;" question that can be sidestepped at the design level by ordering txs differently or narrowing
+the API surface is worth sidestepping. The places where it truly can't be sidestepped &mdash; same-tx processors
+on user-driven property edits, post-commit processors on sync-applied writes &mdash; have their concurrency model
+documented at the primitive level (commit pipeline order, row_events tail semantics) and consumers compose
+against that documented model rather than re-deriving invariants per-feature.
+</p>
 
 <h2>What's deferred</h2>
 <ul class="tight">
-  <li><b>Type templates as data.</b> A subtree to materialize on instance creation, declared on the type-definition block via a <code>block-type:template</code> refList. Once the same-tx processor pattern is established, a single generic <code>typeTemplateProcessor</code> can dispatch from data. Defer until at least one type wants this in practice.</li>
   <li><b>Type inheritance for user types.</b> A user type extending <i>another user type</i> rather than a kernel type. The override merge already handles "child extends parent" semantics; only the resolver loop guard (cycle detection) is missing.</li>
   <li><b>Required-field validation on add.</b> A type-definition block lists which of its <code>properties[]</code> are required; a same-tx processor rejects writes that leave them unset. Easy once Phase 3 lands.</li>
   <li><b>Property-schema authoring inline with the type.</b> Today the user creates schemas on the Properties page, then refs them from a type on the Types page. A combined "type editor" surface that creates schemas as side-effects of editing a type is ergonomic but not necessary for v1.</li>
   <li><b>Bulk reimport-time auto-promotion.</b> The import currently <i>suggests</i>; this design's promotion stays user-triggered. Heuristic-based auto-promotion at import time is plausible but a separate UX call.</li>
+  <li><b>Include-root template materialization.</b> &sect;Type templates fixes descendants-only as the default. A separate slot for include-root semantics (when the template root itself should be cloned) is plausible but no current consumer.</li>
 </ul>
 
 <h2>Decisions locked in</h2>
 <ul class="tight">
-  <li>User-defined types are blocks of kernel type <code>block-type</code>, hosted on a per-workspace Types page.</li>
+  <li>User-defined types are blocks of kernel type <code>block-type</code>, hosted on a per-workspace Types page. The Types page itself follows the type-flow pattern: tagged with both <code>PAGE_TYPE</code> and <code>TYPES_PAGE_TYPE</code> at bootstrap.</li>
   <li>Type id is the block id. Display label is <code>block-type:label</code>. The picker shows the label; <code>block:types</code> arrays carry ids.</li>
-  <li>Override existing types via <code>block-type:extends</code>; merge at the rebuild step, never destructive.</li>
-  <li>Behavioral fields (today: <code>setup</code>) cannot come from data. The merge rule is "kernel only" for those.</li>
+  <li>A type-definition block is the user's block, not a hidden shadow. One block, dual role &mdash; navigable as a page, its subtree (if any) acts as the type template.</li>
+  <li>Override existing types via <code>block-type:extends</code>; merge at the rebuild step, never destructive. <code>properties[]</code> union, label/description user-wins-if-set, behavioral fields kernel-only.</li>
   <li>Replace <code>setup</code> with same-tx processors for atomic per-add behavior. Type contributions become pure metadata. Do this before any current kernel use lands. Behaviors that must run on sync-applied type changes from other devices use a separate post-commit processor on the row_events tail (same path <code>parseReferences</code> uses).</li>
-  <li>Roam <code>isa</code> adoption rides one primitive (<code>promoteToType</code>) usable from import time or after-the-fact.</li>
+  <li>Roam <code>isa</code> adoption rides one primitive (<code>promoteToType</code>) usable from import time or after-the-fact. <b>Two-tx flow</b> bridged by the subscription rebuild &mdash; no <code>withProvisional</code>-style primitive (per &sect;Lessons).</li>
+  <li>Template materialization (Phase 5): refList on <code>block-type:template</code>; descendants-only clone (root not duplicated); cycle detection at tx-time via a <code>ProcessorRejection</code>.</li>
+  <li><b>Companion <code>design.ts</code> typechecks against real codebase types.</b> Drift between this prose and the codebase fails <code>yarn tsc --noEmit --project docs/tsconfig.json</code>.</li>
 </ul>
 
 </body>

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -779,13 +779,20 @@ trivial concurrency model and a cleaner failure surface. See &sect;Lessons from 
     quietly mis-scoping.
   </li>
   <li>
-    Open tx A. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {label, properties: propertySchemaIds})</code>
-    materializes <code>block-type:label</code> and <code>block-type:properties</code> from the action args, plus
-    appends <code>'block-type'</code> to the target's <code>typesProp</code>. Per merged
+    Open tx A. <code>repo.addTypeInTx(tx, targetBlockId, BLOCK_TYPE_TYPE, {})</code> appends
+    <code>'block-type'</code> to the target's <code>typesProp</code>. Per merged
     <a href="https://github.com/Stvad/knowledge-medium/pull/49">PR #49</a> <code>addTypeInTx</code> is strict by
     default &mdash; throws <code>BlockNotFoundForTypeError</code> if the target was deleted concurrently between the
     pre-tx <code>load()</code> and tx-open, no silent no-op possible. (Sync-apply / processor paths that legitimately
     want to no-op on tombstone use the new <code>addTypeInTxLenient</code>; promotion uses strict.)
+  </li>
+  <li>
+    Set <code>block-type:label</code> and <code>block-type:properties</code> via <code>tx.setProperty</code>,
+    <i>not</i> through <code>addTypeInTx</code>'s <code>initialValues</code>. Per
+    <span class="file">type-system.md</span> &sect;3a, <code>initialValues</code> is init-if-missing — fine on a
+    fresh promotion, but on a partial-promotion retry with corrected inputs the existing stale values would
+    silently persist. <code>setProperty</code> unconditionally overwrites, which is what every retry actually
+    wants.
   </li>
   <li>
     Also tag the target with <code>PAGE_TYPE</code> in the same tx if it isn't already &mdash; the "type flow" pattern

--- a/docs/user-defined-types/design.html
+++ b/docs/user-defined-types/design.html
@@ -430,6 +430,14 @@ through the same <code>'user-data'</code> source bucket but as a different shape
   <li><code>properties[]</code> &mdash; <b>union</b> with the kernel list, dedup by name via the existing object-identity rule in <code>mergeLiftedSchemas</code> (<span class="file">src/data/repo.ts:178</span>).</li>
   <li><code>label</code> / <code>description</code> &mdash; <b>user wins if set</b>, else kernel.</li>
   <li>Any behavioral field (today: <code>setup</code>) &mdash; <b>kernel only</b>. User-defined types ship no code, so this isn't a regression from the user's side; it's an architectural invariant.</li>
+  <li>
+    <code>block-type:template</code> &mdash; <b>NOT part of the contribution merge</b>. The template refList lives
+    on the source block (the type-definition block carrying the field), and the materializer (&sect;Type templates)
+    reads it directly at type-add time via <code>userTypes.getTypeBlockId(typeId)</code>. The v1 single-source-block
+    model means an override block's own template is currently ignored by the materializer; if a future caller
+    needs override-added templates, widen <code>UserTypesService</code> to track all source blocks per typeId
+    (base + overrides) and have the materializer iterate. Out of scope for Phase 5.
+  </li>
 </ul>
 
 <div class="callout">
@@ -858,7 +866,11 @@ await repo.tx(async tx =&gt; {
 }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${label}`})
 
 <span class="comment">// Subscription rebuild publishes targetBlockId into the user-data bucket</span>
-<span class="comment">// on typesFacet. Wait for it before opening Phase B.</span>
+<span class="comment">// on typesFacet, which re-runs the dependent rebuild step and fires</span>
+<span class="comment">// `repo.onTypesChange`. waitForTypeRegistration listens for that event</span>
+<span class="comment">// (no polling, no timer-based timeout). See design.ts for the helper</span>
+<span class="comment">// and the module augmentation declaring onTypesChange — Phase 1 adds</span>
+<span class="comment">// the kernel-side listener symmetric to onPropertySchemasChange.</span>
 await waitForTypeRegistration(repo, targetBlockId)
 
 <span class="comment">// Phase B: retag instances. queryBlocks must run OUTSIDE the tx — bare DB reads</span>
@@ -954,6 +966,13 @@ await repo.tx(async tx =&gt; {
 <ul class="tight">
   <li>Add <code>blockTypeLabelProp</code>, <code>blockTypeDescriptionProp</code>, <code>blockTypePropertiesProp</code> to <span class="file">src/data/properties.ts</span>.</li>
   <li>Add <code>BLOCK_TYPE_TYPE</code> and <code>TYPES_PAGE_TYPE</code> to <span class="file">src/data/blockTypes.ts</span>; lift the three props onto the contribution.</li>
+  <li>
+    Add <code>Repo.onTypesChange(listener)</code> in <span class="file">src/data/repo.ts</span>, symmetric to
+    the existing <code>onPropertySchemasChange</code> / <code>onValuePresetsChange</code>
+    (<span class="file">src/data/repo.ts:1402</span>). Fires when the rebuild step republishes the merged
+    <code>_types</code> map. Required by <code>promoteToType</code>'s Phase A&rarr;B handoff to avoid the
+    1s-polling shape the design-review caught.
+  </li>
   <li>
     <b>Extract a shared <code>getOrCreateKernelPage</code> helper</b> rather than cloning
     <span class="file">src/data/propertiesPage.ts</span> verbatim. Both pages have the same shape: uuid-v5 from

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -27,8 +27,8 @@ import {
   defineProperty,
   defineSameTxProcessor,
 } from '@/data/api'
-import {propertyNameProp} from '@/data/properties'
-import {PAGE_TYPE} from '@/data/blockTypes'
+import {hasBlockType, propertyNameProp} from '@/data/properties'
+import {PAGE_TYPE, PROPERTY_SCHEMA_TYPE} from '@/data/blockTypes'
 import {propertySchemasFacet, typesFacet} from '@/data/facets'
 
 // ──────────────────────────────────────────────────────────────────────
@@ -93,18 +93,6 @@ export const blockTypePropertiesProp = defineProperty<readonly string[]>('block-
   changeScope: ChangeScope.BlockDefault,
 })
 
-/** Optional. RefList of blocks whose subtree is materialized under a
- *  new instance when this type is first added to a block (the
- *  `setup`-replacement path; see §5). Descendants-only semantics:
- *  the referenced root is NOT cloned, only its children are attached
- *  as children of the new instance. Cycle detection on this field is
- *  enforced by a same-tx processor (§5b). */
-export const blockTypeTemplateProp = defineProperty<readonly string[]>('block-type:template', {
-  codec: codecs.refList({}),
-  defaultValue: [],
-  changeScope: ChangeScope.BlockDefault,
-})
-
 export const blockTypeKernelType = defineBlockType({
   id: BLOCK_TYPE_TYPE,
   label: 'Type',
@@ -112,8 +100,30 @@ export const blockTypeKernelType = defineBlockType({
     blockTypeLabelProp,
     blockTypeDescriptionProp,
     blockTypePropertiesProp,
-    blockTypeTemplateProp,
   ],
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Phase 4 (templates, deferred): block-type:template
+//
+// RefList of blocks whose subtree is materialized under a new instance
+// when this type is first added to a block (the `setup`-replacement
+// path; see §5). Descendants-only semantics: the referenced root is
+// NOT cloned, only its children are attached as children of the new
+// instance. Cycle detection on this field is enforced by a same-tx
+// processor (§5b).
+//
+// Defined here for the materializer / cycle-guard sketches below, but
+// NOT included in the Phase-1 blockTypeKernelType.properties list —
+// Phase 1 lifts only label / description / properties[]. Phase 4 adds
+// blockTypeTemplateProp to the kernel contribution at the same time as
+// the materializer and cycle guard land.
+// ──────────────────────────────────────────────────────────────────────
+
+export const blockTypeTemplateProp = defineProperty<readonly string[]>('block-type:template', {
+  codec: codecs.refList({}),
+  defaultValue: [],
+  changeScope: ChangeScope.BlockDefault,
 })
 
 // NOTE: `block-type:extends` and the TypeOverride / mergeTypeOverrides
@@ -438,16 +448,69 @@ export async function promoteToType(
       `so committing one would leave a half-promotion.`,
     )
   }
-  // propertySchemaIds: each id must resolve to a property-schema block,
-  // otherwise tryBuildType's refList resolution emits an empty
-  // properties[] which is a silent UX failure (instances tag fine but
-  // the panel surfaces no slots). Resolving here is a cheap read.
+  // Load the target first so workspaceId is available for cross-workspace
+  // checks below.
+  const target = await repo.load(args.targetBlockId)
+  if (!target) {
+    throw new Error(`promoteToType: target ${args.targetBlockId} not found`)
+  }
+  if (target.deleted) {
+    throw new Error(`promoteToType: target ${args.targetBlockId} is tombstoned`)
+  }
+  const workspaceId = target.workspaceId
+
+  // propertySchemaIds: every ref must survive the full set of invariants
+  // that UserTypesService.tryBuildType applies. tryBuildType silently
+  // drops a ref that fails any of these checks, which would leave the
+  // promoted type with missing panel slots — instances retag fine but
+  // the property panel surfaces nothing. The pre-tx validation enforces
+  // each invariant explicitly so the failure is loud and pre-commit:
+  //
+  //   - block exists and isn't tombstoned
+  //   - block carries the `property-schema` type tag (a plain block
+  //     wouldn't be a property-schema even if it had a propertyName)
+  //   - block is in the same workspace as the promotion target (refs
+  //     across workspaces would deference to nothing at materialization)
+  //   - the schema's name is non-empty (tryBuildType drops empty-name
+  //     blocks via UserSchemasService's same diagnostic path)
+  //   - the resolved name is registered in the merged propertySchemas
+  //     map (e.g. user-data schema hasn't been published yet because
+  //     its preset isn't loaded, or a typo'd kernel name)
+  const mergedSchemas = repo.propertySchemas
   for (const schemaId of args.propertySchemaIds) {
     const schemaBlock = await repo.load(schemaId)
     if (!schemaBlock || schemaBlock.deleted) {
       throw new Error(
         `promoteToType: property-schema ref ${schemaId} doesn't resolve to a live block. ` +
         `Drop it from propertySchemaIds before retrying.`,
+      )
+    }
+    if (schemaBlock.workspaceId !== workspaceId) {
+      throw new Error(
+        `promoteToType: property-schema ref ${schemaId} is in workspace ` +
+        `${schemaBlock.workspaceId} but the target is in ${workspaceId}. ` +
+        `Cross-workspace property-schema refs aren't supported.`,
+      )
+    }
+    if (!hasBlockType(schemaBlock, PROPERTY_SCHEMA_TYPE)) {
+      throw new Error(
+        `promoteToType: ref ${schemaId} is not a property-schema block ` +
+        `(missing the ${PROPERTY_SCHEMA_TYPE} type tag).`,
+      )
+    }
+    const name = schemaBlock.properties[propertyNameProp.name]
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new Error(
+        `promoteToType: property-schema block ${schemaId} has empty ` +
+        `${propertyNameProp.name}; tryBuildType would silently drop it.`,
+      )
+    }
+    if (!mergedSchemas.has(name)) {
+      throw new Error(
+        `promoteToType: property-schema "${name}" (block ${schemaId}) isn't in ` +
+        `the merged registry — e.g. UserSchemasService skipped it because its ` +
+        `preset isn't loaded or its config didn't validate. Fix the schema ` +
+        `block before retrying.`,
       )
     }
   }
@@ -458,16 +521,9 @@ export async function promoteToType(
   args.signal?.throwIfAborted()
 
   // Phase A (tx A): turn the target page into a block-type block.
-  //   - Read workspaceId from the target before opening the tx (avoids
-  //     queryActiveWorkspace silent fallback per the merged PR #48).
   //   - In-tx existence guard: addTypeInTx is strict-by-default per
   //     merged PR #49 — throws BlockNotFoundForTypeError if the target
   //     was deleted concurrently between the pre-tx load() and tx-open.
-  const target = await repo.load(args.targetBlockId)
-  if (!target) {
-    throw new Error(`promoteToType: target ${args.targetBlockId} not found`)
-  }
-  const workspaceId = target.workspaceId
 
   const typeSnapshot: TypeRegistrySnapshot = repo.snapshotTypeRegistries()
   await repo.tx(async (tx: Tx) => {

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -739,6 +739,15 @@ async function waitForTypeRegistrationBounded(
       timeoutMs,
     )
     signal?.addEventListener('abort', onAbort)
+    // Re-check abort AFTER attaching the listener — same race shape
+    // as the type-registration check above. If signal.aborted flipped
+    // true in the window between the top-of-function check and the
+    // addEventListener call, the 'abort' event already fired and our
+    // listener missed it. Without this re-check we'd wait until the
+    // 10s timeout (or resolve on a real registration) despite the
+    // caller having cancelled. Re-checking now closes the race; if
+    // already aborted, settle synchronously.
+    if (signal?.aborted) settle(() => reject(signal.reason))
   })
 }
 

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -415,6 +415,14 @@ export async function promoteToType(
   userTypes: UserTypesService,
   args: PromoteToTypeArgs,
 ): Promise<void> {
+  // Preflight: if the caller's signal is already aborted, return before
+  // touching the DB. waitForTypeRegistrationBounded handles abort during
+  // the Phase A→B wait, but doesn't help if abort happened before Phase
+  // A wrote anything — without this guard, an already-aborted call still
+  // commits the type-definition block and then throws, leaving an
+  // unexpected partial mutation despite cancellation.
+  args.signal?.throwIfAborted()
+
   // Pre-tx validation — fail fast on inputs that UserTypesService's
   // tryBuildType will silently reject, before Phase A writes anything.
   // Without this, a blank label (etc.) commits a block-type block,
@@ -443,6 +451,11 @@ export async function promoteToType(
       )
     }
   }
+
+  // Re-check abort after the async validation reads — if the caller
+  // cancelled during schema-resolution awaits we still want to bail
+  // before committing anything.
+  args.signal?.throwIfAborted()
 
   // Phase A (tx A): turn the target page into a block-type block.
   //   - Read workspaceId from the target before opening the tx (avoids
@@ -492,10 +505,12 @@ export async function promoteToType(
   // bare-DB-read-inside-tx deadlock documented in
   // tasks/processor-tx-deadlock.md), retag each in-tx with strict
   // existence guards on every row.
+  args.signal?.throwIfAborted()
   const candidates = await repo.queryBlocks({
     workspaceId,
     referencedBy: {id: args.targetBlockId, sourceField: 'roam:isa'},
   })
+  args.signal?.throwIfAborted()
 
   await repo.tx(async (tx: Tx) => {
     // Capture the registry snapshot INSIDE the tx body, not before.

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -460,6 +460,7 @@ export class PromotionTypeUnregistered extends Error {
 export async function promoteToType(
   repo: Repo,
   userTypes: UserTypesService,
+  userSchemas: UserSchemasService,
   args: PromoteToTypeArgs,
 ): Promise<void> {
   // Preflight: if the caller's signal is already aborted, return before
@@ -542,12 +543,23 @@ export async function promoteToType(
         `${propertyNameProp.name}; tryBuildType would silently drop it.`,
       )
     }
-    if (!mergedSchemas.has(name)) {
+    // Resolve by block id, not by name. tryBuildType uses
+    // userSchemas.getSchemaForBlockId(refId) — checking
+    // mergedSchemas.has(name) would let a name-match-only ref pass
+    // (e.g. a kernel schema with the same name as a user-defined
+    // one whose block is malformed/unpublished). The name-by-name
+    // check would say "registered" while the block-id lookup at
+    // runtime would silently drop the ref because UserSchemasService
+    // never published a contribution mapped to THIS block id.
+    // Validating via the same path tryBuildType uses keeps the
+    // preflight in lockstep with runtime resolution.
+    const resolved = userSchemas.getSchemaForBlockId(schemaId)
+    if (!resolved) {
       throw new Error(
-        `promoteToType: property-schema "${name}" (block ${schemaId}) isn't in ` +
-        `the merged registry — e.g. UserSchemasService skipped it because its ` +
-        `preset isn't loaded or its config didn't validate. Fix the schema ` +
-        `block before retrying.`,
+        `promoteToType: property-schema block ${schemaId} ("${name}") isn't ` +
+        `published by UserSchemasService — e.g. its preset isn't loaded, its ` +
+        `config didn't validate, or the block hasn't synced yet. Fix the ` +
+        `schema block before retrying.`,
       )
     }
   }
@@ -698,19 +710,31 @@ async function waitForTypeRegistrationBounded(
 
   await new Promise<void>((resolve, reject) => {
     let settled = false
-    const settle = (cb: () => void) => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      dispose()
-      signal?.removeEventListener('abort', onAbort)
-      cb()
-    }
+    let timer: ReturnType<typeof setTimeout> | undefined
     const dispose = repo.onTypesChange(() => {
       if (repo.types.has(typeId)) settle(resolve)
     })
     const onAbort = () => settle(() => reject(signal!.reason))
-    const timer = setTimeout(
+    const settle = (cb: () => void) => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) clearTimeout(timer)
+      dispose()
+      signal?.removeEventListener('abort', onAbort)
+      cb()
+    }
+    // Re-check AFTER attaching the listener. The registration can
+    // land in the gap between the early-return check at the top and
+    // the dispose-assignment above; if it does, no future
+    // onTypesChange event fires for it and we'd hang until timeout.
+    // Checking now closes the race — if the type is already there,
+    // settle immediately; if not, the listener catches the next
+    // event.
+    if (repo.types.has(typeId)) {
+      settle(resolve)
+      return
+    }
+    timer = setTimeout(
       () => settle(() => reject(new PromotionRegistrationTimeout(typeId, typeLabel, timeoutMs))),
       timeoutMs,
     )

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -576,6 +576,29 @@ export async function promoteToType(
 
   const typeSnapshot: TypeRegistrySnapshot = repo.snapshotTypeRegistries()
   await repo.tx(async (tx: Tx) => {
+    // In-tx re-check of every schema ref. Mirrors the target's
+    // strict-addTypeInTx existence guard but for the schema refs:
+    // sync-applied writes between the preflight loop and tx-open can
+    // delete a schema block, move it to another workspace, or strip
+    // its property-schema type tag. Without re-checking, Phase A
+    // would commit block-type:properties referencing a now-stale
+    // schema id; tryBuildType would silently drop it at runtime,
+    // leaving the promoted type with missing panel slots. tx.get is
+    // cheap and same-tick (no interleaving possible during this
+    // synchronous body).
+    for (const schemaId of args.propertySchemaIds) {
+      const row = await tx.get(schemaId)
+      if (!row || row.deleted) {
+        throw new Error(`promoteToType: schema block ${schemaId} no longer exists`)
+      }
+      if (row.workspaceId !== workspaceId) {
+        throw new Error(`promoteToType: schema block ${schemaId} moved to a different workspace`)
+      }
+      if (!hasBlockType(row, PROPERTY_SCHEMA_TYPE)) {
+        throw new Error(`promoteToType: schema block ${schemaId} no longer carries ${PROPERTY_SCHEMA_TYPE}`)
+      }
+    }
+
     // Tag with BLOCK_TYPE_TYPE (idempotent on retry; addTypeInTx
     // no-ops when the type is already present).
     await repo.addTypeInTx(tx, args.targetBlockId, BLOCK_TYPE_TYPE, {}, typeSnapshot)

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -1,0 +1,500 @@
+// Design sketch for the user-defined types system.
+//
+// Companion to design.html. The prose describes; this file specifies.
+// The typechecker — not a human reviewer — rejects drift between the
+// design pieces and the codebase.
+//
+// Not a build artifact. Function bodies are skeletons; types reference
+// real codebase paths so renames in src/ break this file too.
+//
+// Typecheck (along with every other docs/**/*.ts sketch) with:
+//   yarn tsc --noEmit --project docs/tsconfig.json
+
+import type {Block} from '@/data/block'
+import type {Repo} from '@/data/repo'
+import type {Tx} from '@/data/api/tx'
+import type {
+  AnyPropertySchema,
+  TypeContribution,
+  TypeRegistrySnapshot,
+} from '@/data/api'
+import type {SameTxEvent, SameTxCtx} from '@/data/api/sameTxProcessor'
+import type {ChangedRow} from '@/data/api/processor'
+import {
+  ChangeScope,
+  codecs,
+  defineBlockType,
+  defineProperty,
+  defineSameTxProcessor,
+} from '@/data/api'
+import {propertyNameProp} from '@/data/properties'
+import {PAGE_TYPE} from '@/data/blockTypes'
+import {propertySchemasFacet, typesFacet} from '@/data/facets'
+
+// ──────────────────────────────────────────────────────────────────────
+// 1. Kernel `block-type` type and its slots
+//
+// Symmetric to the `property-schema` kernel type already in
+// src/data/blockTypes.ts. User-defined types persist as blocks of this
+// type, hosted on a per-workspace Types page.
+//
+// The type-definition block is the user's block, not a hidden shadow.
+// When a user marks a block as a type (via the type-system UI or by
+// the future recurring-tasks template flow), that same block becomes
+// the type definition AND remains a navigable, editable page. One
+// block, dual role. The block's id is the persisted type id (see §3).
+// ──────────────────────────────────────────────────────────────────────
+
+export const BLOCK_TYPE_TYPE = 'block-type'
+export const TYPES_PAGE_TYPE = 'panel:types'
+
+export const blockTypeLabelProp = defineProperty<string>('block-type:label', {
+  codec: codecs.string,
+  defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
+export const blockTypeDescriptionProp = defineProperty<string>('block-type:description', {
+  codec: codecs.string,
+  defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
+export const blockTypePropertiesProp = defineProperty<readonly string[]>('block-type:properties', {
+  // RefList over `property-schema` blocks. The runtime dereferences each
+  // ref, reads `propertyName` from the schema block, and joins to the
+  // merged `repo.propertySchemas` map for the lifted schema entry.
+  codec: codecs.refList({targetTypes: ['property-schema']}),
+  defaultValue: [],
+  changeScope: ChangeScope.BlockDefault,
+})
+
+/** Optional. Present ⇒ this block-type is an override of an existing
+ *  type (kernel or user-defined) rather than a fresh definition. Value
+ *  is the target type id (kernel semantic id like `'daily-note'`, or a
+ *  block id for user-defined). See §4 merge rules. */
+export const blockTypeExtendsProp = defineProperty<string>('block-type:extends', {
+  codec: codecs.string,
+  defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
+/** Optional. RefList of blocks whose subtree is materialized under a
+ *  new instance when this type is first added to a block (the
+ *  `setup`-replacement path; see §5). Descendants-only semantics:
+ *  the referenced root is NOT cloned, only its children are attached
+ *  as children of the new instance. Cycle detection on this field is
+ *  enforced by a same-tx processor (§5b). */
+export const blockTypeTemplateProp = defineProperty<readonly string[]>('block-type:template', {
+  codec: codecs.refList({}),
+  defaultValue: [],
+  changeScope: ChangeScope.BlockDefault,
+})
+
+export const blockTypeKernelType = defineBlockType({
+  id: BLOCK_TYPE_TYPE,
+  label: 'Type',
+  properties: [
+    blockTypeLabelProp,
+    blockTypeDescriptionProp,
+    blockTypePropertiesProp,
+    blockTypeExtendsProp,
+    blockTypeTemplateProp,
+  ],
+})
+
+/** The Types page itself follows the "type flow" pattern landed in
+ *  the merged kernel: it carries both PAGE_TYPE (for normal page
+ *  affordances — open, alias, navigate) AND a marker type so
+ *  `block_types`-keyed lookups can find it. Mirrors how the
+ *  Properties page now carries both PAGE_TYPE and PROPERTIES_PAGE_TYPE
+ *  (src/data/propertiesPage.ts). */
+export const typesPageKernelType = defineBlockType({
+  id: TYPES_PAGE_TYPE,
+  label: 'Types page',
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// 2. UserTypesService — subscription + synchronous-append + rollback
+//
+// Mirrors UserSchemasService (src/data/userSchemasService.ts) in
+// shape: subscribe to `block-type` blocks via repo.subscribeBlocks,
+// build TypeContribution[], publish into the `'user-data'` source
+// bucket on typesFacet via setRuntimeContributions. Re-resolve when
+// the merged schema map changes (a newly-loaded property schema makes
+// a previously-unresolvable ref in block-type:properties suddenly
+// resolvable).
+//
+// Concurrency model deliberately narrowed (see §6, "Lessons from
+// withProvisionalSchema"): the service supports the single-caller-
+// per-name flow. The complex provisional/rollback semantics that
+// withProvisionalSchema chased through PR #50 are NOT mirrored here;
+// callers needing in-tx dependents commit the type-definition block
+// in its own tx and let the subscription rebuild register the type
+// before opening the dependent tx (see §7 Roam-isa adoption).
+// ──────────────────────────────────────────────────────────────────────
+
+export class UserTypesService {
+  private contributions: readonly TypeContribution[] = []
+  private nameToBlockId = new Map<string, string>()
+  private subscriptionDisposer: (() => void) | null = null
+
+  constructor(private readonly repo: Repo) {}
+
+  start(_workspaceId: string): () => void {
+    // Pin the workspace at start() time. The React provider restarts
+    // this service on workspace switch, so capturing here pairs the
+    // subscription's lifetime to one workspace explicitly (the same
+    // shape UserSchemasService landed on PR #48).
+    //
+    // ...subscription wiring follows UserSchemasService exactly...
+    return () => this.dispose()
+  }
+
+  dispose(): void {
+    this.subscriptionDisposer?.()
+    this.subscriptionDisposer = null
+  }
+
+  /** Build a TypeContribution from a user-authored block-type block.
+   *  Returns null + diagnostic when the label is empty (and it's NOT
+   *  an extends-override; overrides may legitimately omit label since
+   *  the kernel value wins). */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private tryBuildType(
+    block: Block,
+    _schemas: ReadonlyMap<string, AnyPropertySchema>,
+  ): TypeContribution | TypeOverride | null {
+    // ... read blockTypeLabelProp / blockTypeExtendsProp / etc.
+    // ... resolve blockTypePropertiesProp refList → schema name → merged schemas map ...
+    // ... return TypeContribution (full) or TypeOverride (extends-set, see §4)
+    return null
+  }
+
+  /** Look up the user-data type contribution for a block id. */
+  getTypeBlockId(typeId: string): string | undefined {
+    return this.nameToBlockId.get(typeId)
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 3. Type id = block id
+//
+// User-defined types persist their id IN the typesProp array of every
+// instance block. The id is the type-definition block's id (a uuid),
+// not a slug from the label. Two reasons:
+//
+//   - Renaming the label doesn't invalidate every instance's typesProp.
+//   - Roam-isa adoption is mechanical: `roam:isa = [[Person]]` already
+//     refs the Person block by id, so promotion just appends that id
+//     to typesProp on each instance (see §7).
+//
+// The picker / panel UI shows blockTypeLabelProp, never the id.
+// ──────────────────────────────────────────────────────────────────────
+
+// (No code shape needed here — the id space is just the string union
+// of kernel ids and block-uuid strings.)
+
+// ──────────────────────────────────────────────────────────────────────
+// 4. Override merge (extends)
+//
+// When a block-type block has blockTypeExtendsProp set, its
+// contribution is folded INTO the existing target rather than
+// replacing it. The merge happens in the rebuild step that already
+// populates the merged `_types` map on Repo (the same site §1a-public
+// in type-system.md describes for property schemas).
+// ──────────────────────────────────────────────────────────────────────
+
+export interface TypeOverride {
+  readonly kind: 'override'
+  /** The type id being extended — kernel semantic id or user block id. */
+  readonly target: string
+  /** undefined ⇒ inherit kernel/base value (`label || undefined`
+   *  in tryBuildType so an empty string doesn't clobber the kernel). */
+  readonly label?: string
+  readonly description?: string
+  /** Always-unioned with the target's properties[]; dedup by object identity. */
+  readonly properties?: ReadonlyArray<AnyPropertySchema>
+  /** Always-unioned with the target's template[]. */
+  readonly template?: ReadonlyArray<string>
+}
+
+/** Fold overrides into base contributions. Called inside the runtime
+ *  rebuild step that already populates `_types` on Repo, AFTER
+ *  typesFacet.combine has produced the base map. Overrides that
+ *  target an unknown id are dropped with a logged diagnostic. */
+export function mergeTypeOverrides(
+  base: ReadonlyMap<string, TypeContribution>,
+  overrides: readonly TypeOverride[],
+): Map<string, TypeContribution> {
+  const out = new Map(base)
+  for (const ov of overrides) {
+    const target = out.get(ov.target)
+    if (!target) {
+      console.warn(`[mergeTypeOverrides] override targets unknown type ${JSON.stringify(ov.target)}; dropping`)
+      continue
+    }
+    // Behavioral fields (setup) are kernel-only. The override merge
+    // is metadata-only: properties[] union, template[] union,
+    // label/description user-wins-if-set. setup stays whatever the
+    // base contribution declared.
+    out.set(ov.target, {
+      ...target,
+      label: ov.label ?? target.label,
+      description: ov.description ?? target.description,
+      properties: dedupBy(
+        [...(target.properties ?? []), ...(ov.properties ?? [])],
+        s => s.name,
+      ),
+      // template is user-data only (no kernel base today, but the
+      // union is still well-defined when both are present).
+    })
+  }
+  return out
+}
+
+function dedupBy<T, K>(xs: readonly T[], key: (x: T) => K): T[] {
+  const seen = new Set<K>()
+  const out: T[] = []
+  for (const x of xs) {
+    const k = key(x)
+    if (seen.has(k)) continue
+    seen.add(k)
+    out.push(x)
+  }
+  return out
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 5. Behavior replacement: same-tx processor, not setup
+//
+// Per `docs/type-system.md` §3a-setup the original design carried
+// behavior on `TypeContribution.setup`. Replacing that with a field-
+// watching same-tx processor (per `src/data/api/sameTxProcessor.ts`)
+// removes the bypass footgun across raw / plan / orchestrated write
+// paths — every property write goes through commit pipeline
+// regardless of who wrote it.
+//
+// Local-only constraint: sync-applied writes still bypass repo.tx
+// per src/data/internals/rowEventsTail.ts (the gap the design.html
+// "Sync-apply gap" subsection covers). Type-add behaviors that MUST
+// run on cross-device tagging use a separate post-commit processor
+// wired to the row_events tail.
+// ──────────────────────────────────────────────────────────────────────
+
+/** Delta helpers added to src/data/properties.ts (or equivalent).
+ *  Null-safe on both ends — hard-deletes have row.after=null,
+ *  inserts have row.before=null. */
+export const addedTypes = (_row: ChangedRow): readonly string[] => []
+export const removedTypes = (_row: ChangedRow): readonly string[] => []
+
+/** Example: a type-defined per-instance template materializer. Runs
+ *  inside the same tx as the type-add via the same-tx processor
+ *  pipeline. Idempotent per row (init-if-missing semantics so a
+ *  re-add doesn't duplicate template children). */
+export const typeTemplateMaterializer = defineSameTxProcessor({
+  name: 'userTypes.materializeTemplate',
+  watches: {kind: 'field', table: 'blocks', fields: ['properties']},
+  apply: async (event: SameTxEvent, _ctx: SameTxCtx) => {
+    for (const row of event.changedRows) {
+      const added = addedTypes(row)
+      if (added.length === 0) continue
+      // ... for each added typeId, look up its block-type:template
+      // refList in ctx.propertySchemas-resolved registry, clone the
+      // descendants under row.after.id ...
+    }
+  },
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// 5a. Template materialization: descendants only
+//
+// `block-type:template` is a refList of root blocks. When the type is
+// added to an instance, the children of each referenced root are
+// attached under the instance — the root itself is NOT cloned.
+//
+// Rationale: matches the shape of every other code path that adds
+// children today (createChild appending under a parent), and avoids
+// the surprise of an instance having a duplicate root block. If a
+// future use case needs root-included clone, add a separate slot
+// (e.g. `block-type:template-root-included`) with explicit naming.
+
+// ──────────────────────────────────────────────────────────────────────
+// 5b. Cycle detection on block-type:template
+//
+// A footgun: if a block-type block at id T1 lists a root R1 in its
+// template, and R1's subtree contains a block tagged with type T1,
+// materialization recurses indefinitely on instantiation. Easily
+// constructed accidentally (user drags an instance back into a
+// template).
+//
+// Reject at tx-time, not at materialization-time. A same-tx
+// processor watching `properties` (for typesProp changes) and
+// `parent_id` (for moves) checks the would-be-resulting state and
+// throws ProcessorRejection if it'd create a self-referential cycle.
+// Cleaner error surface (the user sees "this block can't be moved
+// into its own type's template") than a depth-guard surface ("hit
+// recursion limit during materialization").
+// ──────────────────────────────────────────────────────────────────────
+
+export const templateCycleGuard = defineSameTxProcessor({
+  name: 'userTypes.templateCycleGuard',
+  watches: {kind: 'field', table: 'blocks', fields: ['properties', 'parentId']},
+  apply: async (_event: SameTxEvent, _ctx: SameTxCtx) => {
+    // For each row whose typesProp gained types or whose parent_id
+    // changed: walk up the parent chain from row.after looking for
+    // an ancestor B such that any of row.after's types appears in
+    // B's blockTypeTemplateProp refList. If found, throw
+    // ProcessorRejection('userTypes.templateCycle').
+  },
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// 6. Lessons from withProvisionalSchema (PR #50)
+//
+// withProvisionalSchema started as "register synchronously, run tx,
+// rollback on failure." The shape compounded under review into per-
+// call CAS tokens, committed-only mirrors, etc. — each fix valid,
+// but the scope kept widening for a use case (concurrent overlapping
+// calls for the same name) that doesn't exist in the codebase today.
+//
+// The lesson: when in-tx dependents need a fresh registration, the
+// simpler shape is two txs — commit the type-definition block first,
+// let the subscription rebuild register the contribution, then open
+// the dependent tx. Two undo entries instead of one, but the
+// concurrency model stays trivial.
+//
+// UserTypesService deliberately does NOT mirror UserSchemasService's
+// withProvisionalSchema. The Roam-isa adoption flow uses two txs
+// (see §7). If a future caller genuinely needs single-tx atomicity
+// AND can prove single-caller-per-name semantics, a narrowly-scoped
+// withProvisionalType can be added then, with documented contract.
+// ──────────────────────────────────────────────────────────────────────
+
+// ──────────────────────────────────────────────────────────────────────
+// 7. Roam-isa adoption — two-tx flow
+//
+// Promote a Roam-isa target page (e.g. the [[Person]] page that's
+// referenced by N blocks via roam:isa) into a user-defined type AND
+// retag the referencing blocks.
+//
+// Two-tx flow (see §6 lesson): the subscription rebuild bridges the
+// txs by registering the new type into the runtime bucket between
+// them. No appendUserType / withProvisionalType primitive needed.
+// ──────────────────────────────────────────────────────────────────────
+
+export interface PromoteToTypeArgs {
+  /** The Roam-isa target page (e.g. the "Person" page). */
+  targetBlockId: string
+  /** Display label — pre-filled from the page's alias by the UI. */
+  label: string
+  /** Property-schema block ids picked from the candidate-prop list. */
+  propertySchemaIds: readonly string[]
+  /** Default false: leave roam:isa refs on each instance for review. */
+  rewriteIsaReferences?: boolean
+}
+
+export async function promoteToType(
+  repo: Repo,
+  userTypes: UserTypesService,
+  args: PromoteToTypeArgs,
+): Promise<void> {
+  // Phase 1 (tx A): turn the target page into a block-type block.
+  //   - Read workspaceId from the target before opening the tx (avoids
+  //     queryActiveWorkspace silent fallback per the merged PR #48).
+  //   - In-tx existence guard: addTypeInTx is strict-by-default per
+  //     merged PR #49 — throws BlockNotFoundForTypeError if the target
+  //     was deleted concurrently between the pre-tx load() and tx-open.
+  const target = await repo.load(args.targetBlockId)
+  if (!target) {
+    throw new Error(`promoteToType: target ${args.targetBlockId} not found`)
+  }
+  const workspaceId = target.workspaceId
+
+  const typeSnapshot: TypeRegistrySnapshot = repo.snapshotTypeRegistries()
+  await repo.tx(async (tx: Tx) => {
+    await repo.addTypeInTx(tx, args.targetBlockId, BLOCK_TYPE_TYPE, {
+      [blockTypeLabelProp.name]: args.label,
+      [blockTypePropertiesProp.name]: args.propertySchemaIds,
+    }, typeSnapshot)
+    // The page also gets PAGE_TYPE so it stays navigable as a page —
+    // matches the "type flow" pattern (properties page / readwise
+    // root / plugin state / alias user pages).
+    await repo.addTypeInTx(tx, args.targetBlockId, PAGE_TYPE, {}, typeSnapshot)
+  }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${args.label}`})
+
+  // The subscription on `block-type` blocks fires between txs and
+  // registers args.targetBlockId in the user-data bucket on typesFacet.
+  // The next snapshotTypeRegistries() sees it. No synchronous-append
+  // dance — that was the withProvisional approach, deliberately
+  // dropped (§6).
+  await waitForTypeRegistration(repo, args.targetBlockId)
+
+  // Phase 2 (tx B): query candidates outside the tx (avoids the
+  // bare-DB-read-inside-tx deadlock documented in
+  // tasks/processor-tx-deadlock.md), retag each in-tx with strict
+  // existence guards on every row.
+  const candidates = await repo.queryBlocks({
+    workspaceId,
+    referencedBy: {id: args.targetBlockId, sourceField: 'roam:isa'},
+  })
+
+  const snapshot2 = repo.snapshotTypeRegistries()
+  await repo.tx(async (tx: Tx) => {
+    for (const candidate of candidates) {
+      // tx.get re-check closes the TOCTOU window: the candidate may
+      // have been deleted or had its roam:isa rewritten between the
+      // pre-tx query and the tx open.
+      const row = await tx.get(candidate.id)
+      if (!row) continue
+      const isaRefs = row.properties['roam:isa']
+      if (!Array.isArray(isaRefs) || !isaRefs.includes(args.targetBlockId)) continue
+      await repo.addTypeInTx(tx, candidate.id, args.targetBlockId, {}, snapshot2)
+    }
+    if (args.rewriteIsaReferences) {
+      // ... rewrite roam:isa per instance, dropping the promoted alias
+    }
+  }, {scope: ChangeScope.BlockDefault, description: `promoteToType:retag ${args.label}`})
+}
+
+/** Wait for UserTypesService's subscription to publish args.targetBlockId
+ *  into the typesFacet runtime bucket. Polls repo.types until the id
+ *  appears or a small timeout expires. Polling because the subscription
+ *  tick is microtask-bounded and very fast in practice; if it doesn't
+ *  fire within the timeout the new type-definition block didn't write
+ *  successfully and the second tx would no-op anyway. */
+async function waitForTypeRegistration(
+  repo: Repo,
+  typeId: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (repo.types.has(typeId)) return
+    if (Date.now() > deadline) {
+      throw new Error(`promoteToType: type ${typeId} did not appear in registry within ${timeoutMs}ms`)
+    }
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 8. Phasing (see §Phases in design.html)
+//
+// Phase 1: BLOCK_TYPE_TYPE + TYPES_PAGE_TYPE + UserTypesService + Types page bootstrap
+// Phase 2: extends overrides (mergeTypeOverrides folded into _types rebuild step)
+// Phase 3: setup → same-tx processor migration + addedTypes/removedTypes helpers
+// Phase 4: Roam-isa promoteToType
+// Phase 5 (optional): block-type:template + materializer + cycle guard
+// ──────────────────────────────────────────────────────────────────────
+
+// Compile-only references to make this file fail if anything moves:
+const _refs = {
+  propertyNameProp,
+  propertySchemasFacet,
+  typesFacet,
+  blockTypeKernelType,
+  typesPageKernelType,
+} as const
+void _refs

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -420,8 +420,10 @@ export class PromotionRegistrationTimeout extends Error {
       `promoteToType: type-definition block for "${typeLabel}" was committed ` +
       `but did not appear in the runtime registry within ${timeoutMs}ms. ` +
       `Phase A committed; Phase B (instance retag) was not run. ` +
-      `Re-run promoteToType to finish retagging — the second call will ` +
-      `skip Phase A and proceed directly to retag.`,
+      `Re-run promoteToType to finish retagging — Phase A is idempotent ` +
+      `(addType no-ops on already-typed blocks; setProperty overwrites ` +
+      `label/properties to repair any stale values) so a second call ` +
+      `safely re-runs both phases.`,
     )
     this.name = 'PromotionRegistrationTimeout'
   }
@@ -688,7 +690,11 @@ async function waitForTypeRegistrationBounded(
   timeoutMs: number,
 ): Promise<void> {
   if (repo.types.has(typeId)) return
-  if (signal?.aborted) throw new Error('promoteToType: aborted')
+  // Use signal.reason (standard AbortSignal API) so callers that pass
+  // a typed reason (DOMException, custom error class) get their typed
+  // value back instead of an opaque "promoteToType: aborted" string.
+  // throwIfAborted at the call sites uses the same convention.
+  if (signal?.aborted) throw signal.reason
 
   await new Promise<void>((resolve, reject) => {
     let settled = false
@@ -703,7 +709,7 @@ async function waitForTypeRegistrationBounded(
     const dispose = repo.onTypesChange(() => {
       if (repo.types.has(typeId)) settle(resolve)
     })
-    const onAbort = () => settle(() => reject(new Error('promoteToType: aborted')))
+    const onAbort = () => settle(() => reject(signal!.reason))
     const timer = setTimeout(
       () => settle(() => reject(new PromotionRegistrationTimeout(typeId, typeLabel, timeoutMs))),
       timeoutMs,

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -93,16 +93,6 @@ export const blockTypePropertiesProp = defineProperty<readonly string[]>('block-
   changeScope: ChangeScope.BlockDefault,
 })
 
-/** Optional. Present ⇒ this block-type is an override of an existing
- *  type (kernel or user-defined) rather than a fresh definition. Value
- *  is the target type id (kernel semantic id like `'daily-note'`, or a
- *  block id for user-defined). See §4 merge rules. */
-export const blockTypeExtendsProp = defineProperty<string>('block-type:extends', {
-  codec: codecs.string,
-  defaultValue: '',
-  changeScope: ChangeScope.BlockDefault,
-})
-
 /** Optional. RefList of blocks whose subtree is materialized under a
  *  new instance when this type is first added to a block (the
  *  `setup`-replacement path; see §5). Descendants-only semantics:
@@ -122,10 +112,14 @@ export const blockTypeKernelType = defineBlockType({
     blockTypeLabelProp,
     blockTypeDescriptionProp,
     blockTypePropertiesProp,
-    blockTypeExtendsProp,
     blockTypeTemplateProp,
   ],
 })
+
+// NOTE: `block-type:extends` and the TypeOverride / mergeTypeOverrides
+// machinery are deferred (see design.html §What's deferred). The fields
+// are not declared here because v1 ships without them — adding them
+// later is mechanical and the design.html section preserves the spec.
 
 /** The Types page itself follows the "type flow" pattern landed in
  *  the merged kernel: it carries both PAGE_TYPE (for normal page
@@ -181,17 +175,15 @@ export class UserTypesService {
   }
 
   /** Build a TypeContribution from a user-authored block-type block.
-   *  Returns null + diagnostic when the label is empty (and it's NOT
-   *  an extends-override; overrides may legitimately omit label since
-   *  the kernel value wins). */
+   *  Returns null + diagnostic when the label is empty. */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private tryBuildType(
     block: Block,
     _schemas: ReadonlyMap<string, AnyPropertySchema>,
-  ): TypeContribution | TypeOverride | null {
-    // ... read blockTypeLabelProp / blockTypeExtendsProp / etc.
+  ): TypeContribution | null {
+    // ... read blockTypeLabelProp / blockTypePropertiesProp / etc.
     // ... resolve blockTypePropertiesProp refList → schema name → merged schemas map ...
-    // ... return TypeContribution (full) or TypeOverride (extends-set, see §4)
+    // ... return TypeContribution
     return null
   }
 
@@ -220,83 +212,15 @@ export class UserTypesService {
 // of kernel ids and block-uuid strings.)
 
 // ──────────────────────────────────────────────────────────────────────
-// 4. Override merge (extends)
+// 4. Override merge (extends) — DEFERRED
 //
-// When a block-type block has blockTypeExtendsProp set, its
-// contribution is folded INTO the existing target rather than
-// replacing it. The merge happens in the rebuild step that already
-// populates the merged `_types` map on Repo (the same site §1a-public
-// in type-system.md describes for property schemas).
+// `block-type:extends` and the merge step that folds overrides into
+// the base TypeContribution are deferred (see design.html §What's
+// deferred). No concrete consumer today. The cut keeps v1 simple;
+// adding the override mechanism later is mechanical and the
+// design.html section preserves the full spec (property name, merge
+// rules, renderer affordance).
 // ──────────────────────────────────────────────────────────────────────
-
-export interface TypeOverride {
-  readonly kind: 'override'
-  /** The type id being extended — kernel semantic id or user block id. */
-  readonly target: string
-  /** undefined ⇒ inherit kernel/base value (`label || undefined`
-   *  in tryBuildType so an empty string doesn't clobber the kernel). */
-  readonly label?: string
-  readonly description?: string
-  /** Always-unioned with the target's properties[]; dedup by object identity. */
-  readonly properties?: ReadonlyArray<AnyPropertySchema>
-  // Template membership is intentionally NOT part of the override
-  // merge. `block-type:template` lives on the source block; the
-  // materializer (§5) resolves at runtime by reading the type's
-  // source block(s) directly via UserTypesService. An earlier draft
-  // declared `template` on TypeOverride and noted "always-unioned"
-  // but didn't implement the union (because TypeContribution has no
-  // template field). Dropping the field avoids the silent-mismatch
-  // footgun the design-review caught: an override that declares a
-  // template now stores it on its own block-type:template property,
-  // and the materializer picks it up at type-add time when v1's
-  // single-source-block model is widened to multi-source.
-}
-
-/** Fold overrides into base contributions. Called inside the runtime
- *  rebuild step that already populates `_types` on Repo, AFTER
- *  typesFacet.combine has produced the base map. Overrides that
- *  target an unknown id are dropped with a logged diagnostic. */
-export function mergeTypeOverrides(
-  base: ReadonlyMap<string, TypeContribution>,
-  overrides: readonly TypeOverride[],
-): Map<string, TypeContribution> {
-  const out = new Map(base)
-  for (const ov of overrides) {
-    const target = out.get(ov.target)
-    if (!target) {
-      console.warn(`[mergeTypeOverrides] override targets unknown type ${JSON.stringify(ov.target)}; dropping`)
-      continue
-    }
-    // Behavioral fields (setup) are kernel-only. The override merge
-    // is metadata-only: properties[] union, label/description
-    // user-wins-if-set. setup stays whatever the base contribution
-    // declared. Template membership is NOT merged here — it lives on
-    // the source block and is resolved at materialization time
-    // (§5, see comment on TypeOverride).
-    out.set(ov.target, {
-      ...target,
-      label: ov.label ?? target.label,
-      description: ov.description ?? target.description,
-      properties: dedupBy(
-        [...(target.properties ?? []), ...(ov.properties ?? [])],
-        s => s.name,
-      ),
-    })
-  }
-  return out
-}
-
-function dedupBy<T, K>(xs: readonly T[], key: (x: T) => K): T[] {
-  const seen = new Set<K>()
-  const out: T[] = []
-  for (const x of xs) {
-    const k = key(x)
-    if (seen.has(k)) continue
-    seen.add(k)
-    out.push(x)
-  }
-  return out
-}
 
 // ──────────────────────────────────────────────────────────────────────
 // 5. Behavior replacement: same-tx processor, not setup
@@ -432,7 +356,7 @@ export async function promoteToType(
   userTypes: UserTypesService,
   args: PromoteToTypeArgs,
 ): Promise<void> {
-  // Phase 1 (tx A): turn the target page into a block-type block.
+  // Phase A (tx A): turn the target page into a block-type block.
   //   - Read workspaceId from the target before opening the tx (avoids
   //     queryActiveWorkspace silent fallback per the merged PR #48).
   //   - In-tx existence guard: addTypeInTx is strict-by-default per
@@ -463,7 +387,7 @@ export async function promoteToType(
   // dropped (§6).
   await waitForTypeRegistration(repo, args.targetBlockId)
 
-  // Phase 2 (tx B): query candidates outside the tx (avoids the
+  // Phase B (tx B): query candidates outside the tx (avoids the
   // bare-DB-read-inside-tx deadlock documented in
   // tasks/processor-tx-deadlock.md), retag each in-tx with strict
   // existence guards on every row.
@@ -543,10 +467,13 @@ async function waitForTypeRegistration(
 // 8. Phasing (see §Phases in design.html)
 //
 // Phase 1: BLOCK_TYPE_TYPE + TYPES_PAGE_TYPE + UserTypesService + Types page bootstrap
-// Phase 2: extends overrides (mergeTypeOverrides folded into _types rebuild step)
-// Phase 3: setup → same-tx processor migration + addedTypes/removedTypes helpers
-// Phase 4: Roam-isa promoteToType
-// Phase 5 (optional): block-type:template + materializer + cycle guard
+// Phase 2: setup → same-tx processor migration + addedTypes/removedTypes helpers
+// Phase 3: Roam-isa promoteToType
+// Phase 4 (optional): block-type:template + materializer + cycle guard
+//
+// Deferred: extends overrides (see design.html §What's deferred). The cut
+// keeps v1 simple; adding the override mechanism is mechanical when a
+// real consumer arrives.
 // ──────────────────────────────────────────────────────────────────────
 
 // Compile-only references to make this file fail if anything moves:

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -415,6 +415,35 @@ export async function promoteToType(
   userTypes: UserTypesService,
   args: PromoteToTypeArgs,
 ): Promise<void> {
+  // Pre-tx validation — fail fast on inputs that UserTypesService's
+  // tryBuildType will silently reject, before Phase A writes anything.
+  // Without this, a blank label (etc.) commits a block-type block,
+  // tryBuildType drops it, and Phase B's bounded wait surfaces
+  // PromotionRegistrationTimeout 10s later — a half-promotion the
+  // caller has to clean up manually. Validating upfront keeps the
+  // failure pre-commit so there's nothing to clean up.
+  const trimmedLabel = args.label.trim()
+  if (trimmedLabel === '') {
+    throw new Error(
+      `promoteToType: label must be a non-empty string (got ${JSON.stringify(args.label)}). ` +
+      `UserTypesService.tryBuildType would silently skip a block-type block with an empty label, ` +
+      `so committing one would leave a half-promotion.`,
+    )
+  }
+  // propertySchemaIds: each id must resolve to a property-schema block,
+  // otherwise tryBuildType's refList resolution emits an empty
+  // properties[] which is a silent UX failure (instances tag fine but
+  // the panel surfaces no slots). Resolving here is a cheap read.
+  for (const schemaId of args.propertySchemaIds) {
+    const schemaBlock = await repo.load(schemaId)
+    if (!schemaBlock || schemaBlock.deleted) {
+      throw new Error(
+        `promoteToType: property-schema ref ${schemaId} doesn't resolve to a live block. ` +
+        `Drop it from propertySchemaIds before retrying.`,
+      )
+    }
+  }
+
   // Phase A (tx A): turn the target page into a block-type block.
   //   - Read workspaceId from the target before opening the tx (avoids
   //     queryActiveWorkspace silent fallback per the merged PR #48).
@@ -430,14 +459,14 @@ export async function promoteToType(
   const typeSnapshot: TypeRegistrySnapshot = repo.snapshotTypeRegistries()
   await repo.tx(async (tx: Tx) => {
     await repo.addTypeInTx(tx, args.targetBlockId, BLOCK_TYPE_TYPE, {
-      [blockTypeLabelProp.name]: args.label,
+      [blockTypeLabelProp.name]: trimmedLabel,
       [blockTypePropertiesProp.name]: args.propertySchemaIds,
     }, typeSnapshot)
     // The page also gets PAGE_TYPE so it stays navigable as a page —
     // matches the "type flow" pattern (properties page / readwise
     // root / plugin state / alias user pages).
     await repo.addTypeInTx(tx, args.targetBlockId, PAGE_TYPE, {}, typeSnapshot)
-  }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${args.label}`})
+  }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${trimmedLabel}`})
 
   // The subscription on `block-type` blocks fires between txs and
   // registers args.targetBlockId in the user-data bucket on typesFacet.
@@ -454,7 +483,7 @@ export async function promoteToType(
   await waitForTypeRegistrationBounded(
     repo,
     args.targetBlockId,
-    args.label,
+    trimmedLabel,
     args.signal,
     args.registrationTimeoutMs ?? 10_000,
   )
@@ -488,7 +517,7 @@ export async function promoteToType(
     // tx body's first read settles whether the registry still has the
     // type; if not, abort the retag rather than write orphan ids.
     if (!snapshotInTx.types.has(args.targetBlockId)) {
-      throw new PromotionTypeUnregistered(args.targetBlockId, args.label)
+      throw new PromotionTypeUnregistered(args.targetBlockId, trimmedLabel)
     }
 
     for (const candidate of candidates) {
@@ -507,7 +536,7 @@ export async function promoteToType(
     if (args.rewriteIsaReferences) {
       // ... rewrite roam:isa per instance, dropping the promoted alias
     }
-  }, {scope: ChangeScope.BlockDefault, description: `promoteToType:retag ${args.label}`})
+  }, {scope: ChangeScope.BlockDefault, description: `promoteToType:retag ${trimmedLabel}`})
 }
 
 /** Wait for UserTypesService's subscription to publish `typeId` into

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -382,6 +382,34 @@ export class PromotionRegistrationTimeout extends Error {
   }
 }
 
+/** Thrown by Phase B's in-tx guard when the target type is no longer
+ *  in the live registry at the moment the retag tx opens. The
+ *  realistic trigger is a sync-applied delete of the type-definition
+ *  block between Phase A's commit and Phase B's tx-open that
+ *  UserTypesService reacted to by dropping the user-data contribution.
+ *  Distinct from PromotionRegistrationTimeout (which fires before
+ *  Phase B's tx opens) so callers can branch on the recovery path:
+ *  for this case the type was deleted from another device, so retry
+ *  with the same args would just re-trigger the same race; the
+ *  surface to the user is "the type was deleted while promotion was
+ *  in progress; verify with the other device." */
+export class PromotionTypeUnregistered extends Error {
+  constructor(
+    public readonly targetBlockId: string,
+    public readonly typeLabel: string,
+  ) {
+    super(
+      `promoteToType: type "${typeLabel}" (${targetBlockId}) is no longer ` +
+      `registered when Phase B opened the retag tx. Likely a sync-applied ` +
+      `delete of the type-definition block from another device between ` +
+      `Phase A and Phase B. Phase A committed; Phase B aborted before ` +
+      `writing any retag. Verify whether the type-definition block should ` +
+      `still exist before retrying.`,
+    )
+    this.name = 'PromotionTypeUnregistered'
+  }
+}
+
 export async function promoteToType(
   repo: Repo,
   userTypes: UserTypesService,
@@ -440,17 +468,41 @@ export async function promoteToType(
     referencedBy: {id: args.targetBlockId, sourceField: 'roam:isa'},
   })
 
-  const snapshot2 = repo.snapshotTypeRegistries()
   await repo.tx(async (tx: Tx) => {
+    // Capture the registry snapshot INSIDE the tx body, not before.
+    // Sync-applied writes between Phase A and Phase B could in
+    // principle delete the type-definition block on another device,
+    // which UserTypesService would react to by dropping the contribution
+    // from the user-data bucket. A pre-tx snapshot would still carry
+    // the type and pass addTypeInTx's existence check, then write
+    // orphan ids into instance block:types. Capturing inside the tx
+    // narrows the staleness window to a single event-loop tick (no
+    // other writer can interleave during the synchronous tx body).
+    const snapshotInTx = repo.snapshotTypeRegistries()
+
+    // Belt-and-suspenders: even with the in-tx snapshot, sanity-check
+    // the target is still registered before fanning out tags. The
+    // realistic cause for this firing is a sync-applied delete of the
+    // type-definition block between Phase A and Phase B that
+    // UserTypesService reacted to by dropping the contribution. The
+    // tx body's first read settles whether the registry still has the
+    // type; if not, abort the retag rather than write orphan ids.
+    if (!snapshotInTx.types.has(args.targetBlockId)) {
+      throw new PromotionTypeUnregistered(args.targetBlockId, args.label)
+    }
+
     for (const candidate of candidates) {
       // tx.get re-check closes the TOCTOU window: the candidate may
       // have been deleted or had its roam:isa rewritten between the
-      // pre-tx query and the tx open.
+      // pre-tx query and the tx open. (tx.get returns tombstoned
+      // rows as non-null, so check row.deleted too — a soft-deleted
+      // candidate that gets restored later shouldn't carry the
+      // promoted type id retroactively.)
       const row = await tx.get(candidate.id)
-      if (!row) continue
+      if (!row || row.deleted) continue
       const isaRefs = row.properties['roam:isa']
       if (!Array.isArray(isaRefs) || !isaRefs.includes(args.targetBlockId)) continue
-      await repo.addTypeInTx(tx, candidate.id, args.targetBlockId, {}, snapshot2)
+      await repo.addTypeInTx(tx, candidate.id, args.targetBlockId, {}, snapshotInTx)
     }
     if (args.rewriteIsaReferences) {
       // ... rewrite roam:isa per instance, dropping the promoted alias

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -349,6 +349,37 @@ export interface PromoteToTypeArgs {
   propertySchemaIds: readonly string[]
   /** Default false: leave roam:isa refs on each instance for review. */
   rewriteIsaReferences?: boolean
+  /** Caller cancellation signal. Aborting between Phase A and Phase B
+   *  leaves the type-definition block committed but instances un-retagged;
+   *  the caller can re-run `promoteToType` to finish retagging (the
+   *  subscription will have registered the type by then, so the second
+   *  run skips the wait and goes straight to Phase B). */
+  signal?: AbortSignal
+  /** Sanity bound on the Phase-A→Phase-B handoff. If the subscription
+   *  doesn't register the new type within this window, throw a clear
+   *  PromotionRegistrationTimeout so the caller can surface a recovery
+   *  prompt instead of hanging indefinitely. Default 10s — long enough
+   *  to absorb event-loop load / inactive-tab throttling spikes, short
+   *  enough that a genuine "the type-definition block didn't parse"
+   *  bug surfaces within an interactive UI window. */
+  registrationTimeoutMs?: number
+}
+
+export class PromotionRegistrationTimeout extends Error {
+  constructor(
+    public readonly targetBlockId: string,
+    public readonly typeLabel: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(
+      `promoteToType: type-definition block for "${typeLabel}" was committed ` +
+      `but did not appear in the runtime registry within ${timeoutMs}ms. ` +
+      `Phase A committed; Phase B (instance retag) was not run. ` +
+      `Re-run promoteToType to finish retagging — the second call will ` +
+      `skip Phase A and proceed directly to retag.`,
+    )
+    this.name = 'PromotionRegistrationTimeout'
+  }
 }
 
 export async function promoteToType(
@@ -385,7 +416,20 @@ export async function promoteToType(
   // The next snapshotTypeRegistries() sees it. No synchronous-append
   // dance — that was the withProvisional approach, deliberately
   // dropped (§6).
-  await waitForTypeRegistration(repo, args.targetBlockId)
+  //
+  // Bounded wait: if the subscription doesn't fire within the timeout
+  // (real cause: tryBuildType returned null, e.g. the block-type block
+  // failed to parse against current presets/schemas), surface
+  // PromotionRegistrationTimeout with a clear recovery message rather
+  // than hanging on the unbounded wait. The caller's AbortSignal
+  // composes with the internal timeout.
+  await waitForTypeRegistrationBounded(
+    repo,
+    args.targetBlockId,
+    args.label,
+    args.signal,
+    args.registrationTimeoutMs ?? 10_000,
+  )
 
   // Phase B (tx B): query candidates outside the tx (avoids the
   // bare-DB-read-inside-tx deadlock documented in
@@ -417,48 +461,58 @@ export async function promoteToType(
 /** Wait for UserTypesService's subscription to publish `typeId` into
  *  the typesFacet runtime bucket. Event-driven via `repo.onTypesChange`
  *  (added in Phase 1, symmetric to the existing
- *  `onPropertySchemasChange` / `onValuePresetsChange`). No polling, no
- *  hard-coded timeout: the listener fires when the rebuild step
- *  republishes after the subscription tick, which can be delayed by
- *  event-loop load or inactive-tab throttling without harming
- *  correctness.
+ *  `onPropertySchemasChange` / `onValuePresetsChange`). The listener
+ *  fires when the rebuild step republishes after the subscription
+ *  tick, which can be delayed by event-loop load or inactive-tab
+ *  throttling without harming correctness.
  *
- *  Note on the deferred follow-up: an event-loop deadline can still be
- *  added as a sanity bound (e.g. 30s, AbortSignal-aware) once a real
- *  caller surfaces a "user-cancelled the promotion" UI path. v1 ships
- *  without one — a stuck registration here means tx A wrote a
- *  block-type block that doesn't parse into a valid contribution,
- *  which is a separate bug to surface via diagnostic logs in
- *  UserTypesService.tryBuildType.
+ *  Three exit paths:
+ *  1. Registration appears → resolve.
+ *  2. Caller aborts via signal → reject with the abort reason.
+ *  3. Timeout elapses → reject with PromotionRegistrationTimeout
+ *     (the type-definition block committed but tryBuildType is rejecting
+ *     it, e.g. because a referenced property-schema id doesn't resolve).
+ *     The error message instructs the caller's recovery path (re-run
+ *     promoteToType once the underlying issue is fixed; the second run
+ *     skips Phase A and goes straight to Phase B).
+ *
+ *  Cleanup invariant: every exit path disposes the onTypesChange
+ *  listener and clears the timer so a leaked listener can't accumulate
+ *  across retries.
  *
  *  Declared on Repo as part of Phase 1 (alongside onPropertySchemasChange):
  *
  *    onTypesChange(listener: () => void): () => void
  *
  *  Fires when the rebuild step republishes the merged _types map. */
-async function waitForTypeRegistration(
+async function waitForTypeRegistrationBounded(
   repo: Repo,
   typeId: string,
-  signal?: AbortSignal,
+  typeLabel: string,
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
 ): Promise<void> {
   if (repo.types.has(typeId)) return
+  if (signal?.aborted) throw new Error('promoteToType: aborted')
+
   await new Promise<void>((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new Error('promoteToType: aborted'))
-      return
-    }
-    const dispose = repo.onTypesChange(() => {
-      if (repo.types.has(typeId)) {
-        dispose()
-        signal?.removeEventListener('abort', onAbort)
-        resolve()
-      }
-    })
-    const onAbort = () => {
+    let settled = false
+    const settle = (cb: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
       dispose()
       signal?.removeEventListener('abort', onAbort)
-      reject(new Error('promoteToType: aborted'))
+      cb()
     }
+    const dispose = repo.onTypesChange(() => {
+      if (repo.types.has(typeId)) settle(resolve)
+    })
+    const onAbort = () => settle(() => reject(new Error('promoteToType: aborted')))
+    const timer = setTimeout(
+      () => settle(() => reject(new PromotionRegistrationTimeout(typeId, typeLabel, timeoutMs))),
+      timeoutMs,
+    )
     signal?.addEventListener('abort', onAbort)
   })
 }

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -12,6 +12,7 @@
 
 import type {Block} from '@/data/block'
 import type {Repo} from '@/data/repo'
+import type {UserSchemasService} from '@/data/userSchemasService'
 import type {Tx} from '@/data/api/tx'
 import type {
   AnyPropertySchema,
@@ -52,6 +53,33 @@ import {propertySchemasFacet, typesFacet} from '@/data/facets'
 declare module '@/data/repo' {
   interface Repo {
     onTypesChange(listener: () => void): () => void
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Phase 1 API addition: UserSchemasService.getSchemaForBlockId
+//
+// Routes UserTypesService's `block-type:properties` ref resolution
+// through the existing schemas service rather than peeking the
+// referenced schema blocks directly. Avoids two cold-start footguns:
+//
+//   1. BlockCache hydration race — peek() on an unloaded row returns
+//      undefined, so valid refs would silently drop on first rebuild
+//      until something else triggered hydration.
+//   2. Cross-block invariant duplication — UserSchemasService already
+//      validates schemas pass workspace/type/name/preset checks
+//      before publishing; a successful getSchemaForBlockId proves
+//      those invariants hold, no re-derivation needed.
+//
+// Implementation: UserSchemasService grows a private blockIdToName
+// map populated alongside the existing nameToBlockId in rebuild and
+// appendUserSchema. getSchemaForBlockId(blockId) reads blockIdToName,
+// then this.contributions for the matching schema. O(1).
+// ──────────────────────────────────────────────────────────────────────
+
+declare module '@/data/userSchemasService' {
+  interface UserSchemasService {
+    getSchemaForBlockId(blockId: string): AnyPropertySchema | undefined
   }
 }
 
@@ -167,7 +195,14 @@ export class UserTypesService {
   private nameToBlockId = new Map<string, string>()
   private subscriptionDisposer: (() => void) | null = null
 
-  constructor(private readonly repo: Repo) {}
+  constructor(
+    private readonly repo: Repo,
+    // Phase 1 addition: UserSchemasService grows getSchemaForBlockId
+    // (with internal blockIdToName mirror) so UserTypesService can
+    // resolve block-type:properties refs without peek-based cache-
+    // hydration races. See design.html §Phase 1 checklist.
+    private readonly userSchemas: UserSchemasService,
+  ) {}
 
   start(_workspaceId: string): () => void {
     // Pin the workspace at start() time. The React provider restarts
@@ -527,14 +562,22 @@ export async function promoteToType(
 
   const typeSnapshot: TypeRegistrySnapshot = repo.snapshotTypeRegistries()
   await repo.tx(async (tx: Tx) => {
-    await repo.addTypeInTx(tx, args.targetBlockId, BLOCK_TYPE_TYPE, {
-      [blockTypeLabelProp.name]: trimmedLabel,
-      [blockTypePropertiesProp.name]: args.propertySchemaIds,
-    }, typeSnapshot)
+    // Tag with BLOCK_TYPE_TYPE (idempotent on retry; addTypeInTx
+    // no-ops when the type is already present).
+    await repo.addTypeInTx(tx, args.targetBlockId, BLOCK_TYPE_TYPE, {}, typeSnapshot)
     // The page also gets PAGE_TYPE so it stays navigable as a page —
     // matches the "type flow" pattern (properties page / readwise
     // root / plugin state / alias user pages).
     await repo.addTypeInTx(tx, args.targetBlockId, PAGE_TYPE, {}, typeSnapshot)
+    // Set the type's metadata explicitly with tx.setProperty rather
+    // than via addTypeInTx's initialValues. initialValues is
+    // init-if-missing (per type-system.md §3a) — on a retry with a
+    // corrected label or different property set, the existing
+    // values would silently persist and the retry would never
+    // repair the type. setProperty unconditionally overwrites, which
+    // is what every retry actually wants.
+    await tx.setProperty(args.targetBlockId, blockTypeLabelProp, trimmedLabel)
+    await tx.setProperty(args.targetBlockId, blockTypePropertiesProp, args.propertySchemaIds)
   }, {scope: ChangeScope.BlockDefault, description: `promoteToType:create ${trimmedLabel}`})
 
   // The subscription on `block-type` blocks fires between txs and

--- a/docs/user-defined-types/design.ts
+++ b/docs/user-defined-types/design.ts
@@ -32,6 +32,30 @@ import {PAGE_TYPE} from '@/data/blockTypes'
 import {propertySchemasFacet, typesFacet} from '@/data/facets'
 
 // ──────────────────────────────────────────────────────────────────────
+// Phase 1 API addition: Repo.onTypesChange
+//
+// Symmetric to the existing `onPropertySchemasChange` /
+// `onValuePresetsChange` listeners (src/data/repo.ts:1402, :1415).
+// Fires when the rebuild step republishes the merged `_types` map —
+// after a typesFacet contribution change (e.g. UserTypesService's
+// setRuntimeContributions publish lands and the step re-runs).
+//
+// Used by the Roam-isa promotion flow's `waitForTypeRegistration`
+// helper to bridge Phase A (commit type-definition block) and Phase B
+// (retag instances) without polling.
+//
+// Module augmentation here is intentional — the design file declares
+// the API addition concretely so consumers can compile against the
+// shape now; the kernel implementation lands in Phase 1.
+// ──────────────────────────────────────────────────────────────────────
+
+declare module '@/data/repo' {
+  interface Repo {
+    onTypesChange(listener: () => void): () => void
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
 // 1. Kernel `block-type` type and its slots
 //
 // Symmetric to the `property-schema` kernel type already in
@@ -215,8 +239,17 @@ export interface TypeOverride {
   readonly description?: string
   /** Always-unioned with the target's properties[]; dedup by object identity. */
   readonly properties?: ReadonlyArray<AnyPropertySchema>
-  /** Always-unioned with the target's template[]. */
-  readonly template?: ReadonlyArray<string>
+  // Template membership is intentionally NOT part of the override
+  // merge. `block-type:template` lives on the source block; the
+  // materializer (§5) resolves at runtime by reading the type's
+  // source block(s) directly via UserTypesService. An earlier draft
+  // declared `template` on TypeOverride and noted "always-unioned"
+  // but didn't implement the union (because TypeContribution has no
+  // template field). Dropping the field avoids the silent-mismatch
+  // footgun the design-review caught: an override that declares a
+  // template now stores it on its own block-type:template property,
+  // and the materializer picks it up at type-add time when v1's
+  // single-source-block model is widened to multi-source.
 }
 
 /** Fold overrides into base contributions. Called inside the runtime
@@ -235,9 +268,11 @@ export function mergeTypeOverrides(
       continue
     }
     // Behavioral fields (setup) are kernel-only. The override merge
-    // is metadata-only: properties[] union, template[] union,
-    // label/description user-wins-if-set. setup stays whatever the
-    // base contribution declared.
+    // is metadata-only: properties[] union, label/description
+    // user-wins-if-set. setup stays whatever the base contribution
+    // declared. Template membership is NOT merged here — it lives on
+    // the source block and is resolved at materialization time
+    // (§5, see comment on TypeOverride).
     out.set(ov.target, {
       ...target,
       label: ov.label ?? target.label,
@@ -246,8 +281,6 @@ export function mergeTypeOverrides(
         [...(target.properties ?? []), ...(ov.properties ?? [])],
         s => s.name,
       ),
-      // template is user-data only (no kernel base today, but the
-      // union is still well-defined when both are present).
     })
   }
   return out
@@ -457,26 +490,53 @@ export async function promoteToType(
   }, {scope: ChangeScope.BlockDefault, description: `promoteToType:retag ${args.label}`})
 }
 
-/** Wait for UserTypesService's subscription to publish args.targetBlockId
- *  into the typesFacet runtime bucket. Polls repo.types until the id
- *  appears or a small timeout expires. Polling because the subscription
- *  tick is microtask-bounded and very fast in practice; if it doesn't
- *  fire within the timeout the new type-definition block didn't write
- *  successfully and the second tx would no-op anyway. */
+/** Wait for UserTypesService's subscription to publish `typeId` into
+ *  the typesFacet runtime bucket. Event-driven via `repo.onTypesChange`
+ *  (added in Phase 1, symmetric to the existing
+ *  `onPropertySchemasChange` / `onValuePresetsChange`). No polling, no
+ *  hard-coded timeout: the listener fires when the rebuild step
+ *  republishes after the subscription tick, which can be delayed by
+ *  event-loop load or inactive-tab throttling without harming
+ *  correctness.
+ *
+ *  Note on the deferred follow-up: an event-loop deadline can still be
+ *  added as a sanity bound (e.g. 30s, AbortSignal-aware) once a real
+ *  caller surfaces a "user-cancelled the promotion" UI path. v1 ships
+ *  without one — a stuck registration here means tx A wrote a
+ *  block-type block that doesn't parse into a valid contribution,
+ *  which is a separate bug to surface via diagnostic logs in
+ *  UserTypesService.tryBuildType.
+ *
+ *  Declared on Repo as part of Phase 1 (alongside onPropertySchemasChange):
+ *
+ *    onTypesChange(listener: () => void): () => void
+ *
+ *  Fires when the rebuild step republishes the merged _types map. */
 async function waitForTypeRegistration(
   repo: Repo,
   typeId: string,
-  timeoutMs = 1000,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    if (repo.types.has(typeId)) return
-    if (Date.now() > deadline) {
-      throw new Error(`promoteToType: type ${typeId} did not appear in registry within ${timeoutMs}ms`)
+  if (repo.types.has(typeId)) return
+  await new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('promoteToType: aborted'))
+      return
     }
-    await new Promise(resolve => setTimeout(resolve, 0))
-  }
+    const dispose = repo.onTypesChange(() => {
+      if (repo.types.has(typeId)) {
+        dispose()
+        signal?.removeEventListener('abort', onAbort)
+        resolve()
+      }
+    })
+    const onAbort = () => {
+      dispose()
+      signal?.removeEventListener('abort', onAbort)
+      reject(new Error('promoteToType: aborted'))
+    }
+    signal?.addEventListener('abort', onAbort)
+  })
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

New design doc at `docs/user-defined-types.html` covering how end users author types as blocks, parallel to the existing user-defined property schemas path.

Key points:

- **Storage**: a new kernel `block-type` type with `label`, `description`, `properties` (refList → property-schema blocks), and optional `extends`. Hosted on a per-workspace `Types` page (deterministic uuid v5 from `workspaceId`, parallel to `src/data/propertiesPage.ts`).
- **Service**: `UserTypesService` near-clone of `UserSchemasService` — subscribes to `block-type` blocks, builds `TypeContribution[]`, publishes via `repo.setRuntimeContributions(typesFacet, 'user-data', ...)`. Re-resolves on schema-map changes.
- **Type id = block id.** Block ids end up in `block:types` arrays alongside semantic kernel ids. Picker UI shows the label. Survives renames; makes Roam `isa` adoption mechanical because `roam:isa = [[Person]]` already resolves to a block id.
- **Override kernel types** via `block-type:extends`. Merge at the rebuild step: union `properties[]`, user-wins on `label`/`description`, kernel-only for behavioral fields. Not destructive.
- **Replace `setup` on `TypeContribution` with same-tx processors.** Bypass-proof across raw / sync / orchestrated write paths, removal becomes symmetric, multiple plugins can compose, user-defined types stop being second-class on this axis. Do this before any kernel `setup` use lands (today: zero use, only proposed).
- **Roam `isa` adoption**: one `promoteToType(targetBlockId, propertySchemaIds)` primitive used both at import time (button in the existing type-candidate report) and after-the-fact (action on any `isa`-targeted page).

The doc supersedes the §9 deferral in `docs/type-system.md` and the follow-up at `docs/follow-ups.md:147`. That deferral's reasoning ("no mutable FacetRuntime sink") was invalidated by the user-defined-properties work shipping exactly that mechanism.

Four phases, each independently shippable: kernel type + service + page; overrides; setup→processor migration; Roam adoption.

## Test plan

- [ ] Skim the doc for arguments that feel off, especially the same-tx-processor replacement for `setup` and the "type id = block id" call.
- [ ] Confirm phase ordering matches your priorities (Roam adoption could land earlier if that's the bigger win).
- [ ] Sanity-check the override merge rules against any in-flight kernel-type-with-setup work I might have missed.

https://claude.ai/code/session_01BMwEwkqo1tKGcBHu9aD5bd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMwEwkqo1tKGcBHu9aD5bd)_