### PR TITLE
Add strict variant for addTypeInTx

### DIFF
--- a/src/data/api/errors.ts
+++ b/src/data/api/errors.ts
@@ -23,6 +23,25 @@ export class BlockNotFoundError extends DataLayerError {
   }
 }
 
+/** Thrown by `repo.addType` / `repo.addTypeInTx` when the target block is
+ *  missing or tombstoned at write time. Orchestration code that's about
+ *  to fan out work based on the assumption the tag was applied wants this
+ *  to throw rather than silently no-op. Callers that legitimately race
+ *  against a concurrent delete (sync-apply / processor paths) can opt
+ *  into the lenient `addTypeInTxLenient` entry point. */
+export class BlockNotFoundForTypeError extends DataLayerError {
+  constructor(
+    public readonly blockId: string,
+    public readonly typeId: string,
+    public readonly reason: 'missing' | 'tombstoned',
+  ) {
+    super(
+      `cannot add type ${JSON.stringify(typeId)} to block ${blockId}: ` +
+      `block is ${reason}`,
+    )
+  }
+}
+
 // ──── Tx primitives ────
 
 export class DuplicateIdError extends DataLayerError {

--- a/src/data/internals/typeSystem.test.ts
+++ b/src/data/internals/typeSystem.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
+  BlockNotFoundForTypeError,
   ChangeScope,
   codecs,
   defineBlockType,
@@ -148,6 +149,114 @@ describe('Repo type membership orchestration', () => {
 
     await block.removeType('b')
     expect(block.types).toEqual(['a'])
+  })
+
+  it('addType throws BlockNotFoundForTypeError when the target block is missing', async () => {
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      typesFacet.of(defineBlockType({id: 'todo'}), {source: 'test'}),
+    ]))
+
+    await expect(repo.addType('does-not-exist', 'todo')).rejects.toBeInstanceOf(BlockNotFoundForTypeError)
+    try {
+      await repo.addType('does-not-exist', 'todo')
+    } catch (err) {
+      const e = err as BlockNotFoundForTypeError
+      expect(e.blockId).toBe('does-not-exist')
+      expect(e.typeId).toBe('todo')
+      expect(e.reason).toBe('missing')
+    }
+  })
+
+  it('addTypeInTx (strict default) throws BlockNotFoundForTypeError on a missing block', async () => {
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      typesFacet.of(defineBlockType({id: 'todo'}), {source: 'test'}),
+    ]))
+    const snapshot = repo.snapshotTypeRegistries()
+
+    let caught: unknown = null
+    await repo.tx(async tx => {
+      try {
+        await repo.addTypeInTx(tx, 'ghost', 'todo', {}, snapshot)
+      } catch (err) {
+        caught = err
+        throw err
+      }
+    }, {scope: ChangeScope.BlockDefault, description: 'strict missing'}).catch(() => {})
+
+    expect(caught).toBeInstanceOf(BlockNotFoundForTypeError)
+    const e = caught as BlockNotFoundForTypeError
+    expect(e.blockId).toBe('ghost')
+    expect(e.typeId).toBe('todo')
+    expect(e.reason).toBe('missing')
+  })
+
+  it('addTypeInTx (strict default) throws BlockNotFoundForTypeError on a tombstoned block', async () => {
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      typesFacet.of(defineBlockType({id: 'todo'}), {source: 'test'}),
+    ]))
+    await createBlock('b1')
+    // Soft-delete the row so tx.get returns it with deleted=true.
+    await repo.tx(async tx => {
+      await tx.delete('b1')
+    }, {scope: ChangeScope.BlockDefault, description: 'tombstone'})
+
+    const snapshot = repo.snapshotTypeRegistries()
+    let caught: unknown = null
+    await repo.tx(async tx => {
+      try {
+        await repo.addTypeInTx(tx, 'b1', 'todo', {}, snapshot)
+      } catch (err) {
+        caught = err
+        throw err
+      }
+    }, {scope: ChangeScope.BlockDefault, description: 'strict tombstone'}).catch(() => {})
+
+    expect(caught).toBeInstanceOf(BlockNotFoundForTypeError)
+    const e = caught as BlockNotFoundForTypeError
+    expect(e.blockId).toBe('b1')
+    expect(e.typeId).toBe('todo')
+    expect(e.reason).toBe('tombstoned')
+  })
+
+  it('addTypeInTxLenient silently no-ops on a missing block (preserves legacy semantics)', async () => {
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      typesFacet.of(defineBlockType({id: 'todo'}), {source: 'test'}),
+    ]))
+    const snapshot = repo.snapshotTypeRegistries()
+
+    // Should not throw; should not write anything.
+    await repo.tx(async tx => {
+      await repo.addTypeInTxLenient(tx, 'ghost', 'todo', {}, snapshot)
+    }, {scope: ChangeScope.BlockDefault, description: 'lenient missing'})
+  })
+
+  it('addTypeInTxLenient silently no-ops on a tombstoned block', async () => {
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      typesFacet.of(defineBlockType({id: 'todo'}), {source: 'test'}),
+    ]))
+    await createBlock('b1')
+    await repo.tx(async tx => {
+      await tx.delete('b1')
+    }, {scope: ChangeScope.BlockDefault, description: 'tombstone'})
+
+    const snapshot = repo.snapshotTypeRegistries()
+    await repo.tx(async tx => {
+      await repo.addTypeInTxLenient(tx, 'b1', 'todo', {}, snapshot)
+    }, {scope: ChangeScope.BlockDefault, description: 'lenient tombstone'})
+  })
+
+  it('addTypeInTx (strict default) tags a valid block normally', async () => {
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      typesFacet.of(defineBlockType({id: 'todo'}), {source: 'test'}),
+    ]))
+    await createBlock('b1')
+    const snapshot = repo.snapshotTypeRegistries()
+
+    await repo.tx(async tx => {
+      await repo.addTypeInTx(tx, 'b1', 'todo', {}, snapshot)
+    }, {scope: ChangeScope.BlockDefault, description: 'strict happy'})
+
+    expect(repo.block('b1').types).toEqual(['todo'])
   })
 
   it('addTypeInTx uses a caller-supplied registry snapshot', async () => {

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -40,6 +40,7 @@ import type {
   User,
 } from '@/data/api'
 import {
+  BlockNotFoundForTypeError,
   ChangeScope,
   MutatorNotRegisteredError,
   ParentDeletedError,
@@ -1616,6 +1617,12 @@ export class Repo {
     blockId: string,
     typeId: string,
     initialValues: Readonly<Record<string, unknown>>,
+    /** When true (the default, used by `addType` / `addTypeInTx`), throw
+     *  `BlockNotFoundForTypeError` if the target block is missing or
+     *  tombstoned. Lenient callers (`addTypeInTxLenient`) pass `false`
+     *  to preserve the legacy silent-no-op behavior for sync-apply /
+     *  processor paths that may legitimately race a concurrent delete. */
+    strict: boolean,
   ): Promise<void> {
     const contribution = types.get(typeId)
     if (contribution === undefined) {
@@ -1625,7 +1632,14 @@ export class Repo {
       )
     }
     const block = await tx.get(blockId)
-    if (!block) return
+    if (!block) {
+      if (strict) throw new BlockNotFoundForTypeError(blockId, typeId, 'missing')
+      return
+    }
+    if (block.deleted) {
+      if (strict) throw new BlockNotFoundForTypeError(blockId, typeId, 'tombstoned')
+      return
+    }
 
     const current = getBlockTypes(block)
     const wasNew = !current.includes(typeId)
@@ -1670,6 +1684,12 @@ export class Repo {
     await tx.update(blockId, {properties: next})
   }
 
+  /** Strict: throws `BlockNotFoundForTypeError` if `blockId` is missing
+   *  or tombstoned at write time. Use when the caller's correctness
+   *  depends on the tag actually landing (orchestration / fan-out
+   *  paths). For the lenient variant that silently no-ops on a missing
+   *  block, see `addTypeInTxLenient` and (in-tx) the dedicated lenient
+   *  entry points. */
   async addType(
     blockId: string,
     typeId: string,
@@ -1677,10 +1697,14 @@ export class Repo {
   ): Promise<void> {
     const {types, propertySchemas} = this.snapshotTypeRegistries()
     await this.tx(async tx => {
-      await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, initialValues)
+      await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, initialValues, true)
     }, {scope: ChangeScope.BlockDefault, description: `addType ${typeId}`})
   }
 
+  /** Strict in-tx variant. Throws `BlockNotFoundForTypeError` if the
+   *  target block is missing or tombstoned. The default for orchestration
+   *  code; pair with the lenient variant only when racing a concurrent
+   *  delete is legitimate (sync-apply / processor paths). */
   async addTypeInTx(
     tx: Tx,
     blockId: string,
@@ -1690,7 +1714,25 @@ export class Repo {
   ): Promise<void> {
     const types = snapshot?.types ?? this._types
     const propertySchemas = snapshot?.propertySchemas ?? this._propertySchemas
-    await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, initialValues)
+    await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, initialValues, true)
+  }
+
+  /** Lenient in-tx variant — silently no-ops if the target block is
+   *  missing or tombstoned. Reserved for sync-apply / processor paths
+   *  that may legitimately observe a concurrent delete between
+   *  pre-tx state and tx-start. New orchestration code should prefer
+   *  `addTypeInTx` (strict) so a footgun like the Roam-isa adoption
+   *  bug (PR #47) can't be expressed. */
+  async addTypeInTxLenient(
+    tx: Tx,
+    blockId: string,
+    typeId: string,
+    initialValues: Readonly<Record<string, unknown>> = {},
+    snapshot?: TypeRegistrySnapshot,
+  ): Promise<void> {
+    const types = snapshot?.types ?? this._types
+    const propertySchemas = snapshot?.propertySchemas ?? this._propertySchemas
+    await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, initialValues, false)
   }
 
   async removeType(blockId: string, typeId: string): Promise<void> {
@@ -1707,11 +1749,16 @@ export class Repo {
     const {types, propertySchemas} = this.snapshotTypeRegistries()
     await this.tx(async tx => {
       const block = await tx.get(blockId)
-      if (!block) return
+      // toggleType pre-checks the block existence itself; if it's
+      // missing or tombstoned here, the no-op is intentional (this is a
+      // UI/UX entry point, not orchestration). Pass strict=false to
+      // `_addTypeInTx` so the pre-check stays the single source of
+      // truth for the missing-block branch.
+      if (!block || block.deleted) return
       if (getBlockTypes(block).includes(typeId)) {
         await this._removeTypeInTx(tx, blockId, typeId)
       } else {
-        await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, {})
+        await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, {}, false)
       }
     }, {scope: ChangeScope.BlockDefault, description: `toggleType ${typeId}`})
   }
@@ -1721,7 +1768,10 @@ export class Repo {
     const {types, propertySchemas} = this.snapshotTypeRegistries()
     await this.tx(async tx => {
       const block = await tx.get(blockId)
-      if (!block) return
+      // Pre-check matches toggleType's contract — silently no-op on a
+      // missing/tombstoned target (UI-driven path); pass strict=false
+      // to the inner add so the pre-check remains authoritative.
+      if (!block || block.deleted) return
 
       const current = getBlockTypes(block)
       const want = new Set(desiredOrder)
@@ -1732,7 +1782,7 @@ export class Repo {
       const currentSet = new Set(current)
       for (const typeId of desiredOrder) {
         if (currentSet.has(typeId)) continue
-        await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, {})
+        await this._addTypeInTx(tx, types, propertySchemas, blockId, typeId, {}, false)
       }
 
       const after = await tx.get(blockId)


### PR DESCRIPTION
## Summary

`repo.addTypeInTx` (and its sibling `repo.addType`) silently no-ops when the target block is missing or tombstoned at tx-start. That's defensible for sync-apply paths where another device deleted the row concurrently, but it's a footgun for orchestration code that's about to fan out work based on the assumption the tag was applied.

This PR flips the default: `addType` / `addTypeInTx` now **throw** `BlockNotFoundForTypeError` (typed, with `blockId` / `typeId` / `reason: 'missing' | 'tombstoned'` fields). The legacy silent-no-op behavior is preserved under a new `addTypeInTxLenient` entry point for sync-apply / processor paths.

Also closes a latent bug: the old `if (!block) return` only handled missing rows; tombstoned blocks (which `tx.get` returns with `deleted: true`) flowed straight through and got tagged. Strict throws on both; lenient short-circuits on both.

### Motivation (from PR #47 design review)

In the Roam-isa adoption flow at `docs/user-defined-types.html`, a concurrent delete of the promotion target between pre-tx `load()` and tx-start would silently no-op the target's `addTypeInTx(target, BLOCK_TYPE_TYPE, ...)` while the outer loop kept tagging N instances with the now-orphan target id. Pushing strict semantics into the API surface makes the bug impossible to express in code that uses the strict variant.

## Option picked: A (flip the default)

The plan offered Option A (rename current to lenient, new strict-default at the canonical name) or Option B (add `addTypeInTxStrict` alongside the existing lenient default). I picked **Option A**.

The deciding factor was the call-site audit: **every** in-tree call site of `addTypeInTx` / `addType` either creates the block in the same tx or pre-checks it via `tx.get` and bails out before calling. There were no sync-apply / processor uses where the silent no-op is the desired semantics. Flipping the default removes the footgun without surprising any existing caller.

### Call-site audit (strict-suitable everywhere)

| Site | Reason strict is correct |
|---|---|
| `src/data/propertiesPage.ts:53,65,75` | Block was just created / restored / verified in same tx. |
| `src/data/userSchemasService.ts:235` | Block id returned by `repo.mutate.createChild` immediately above. |
| `src/data/targets.ts:274` | Inside `onInsertedOrRestored` callback — block was just inserted/restored. |
| `src/initData.ts:47,78,91` | Block just `tx.create`d in same tx. |
| `src/extensions/exampleExtensions.ts:435` | Block just `tx.create`d in same tx. |
| `src/utils/panelLayoutProjection.ts:220,240` | Block just `tx.create`d in same tx. |
| `src/plugins/agent-runtime/commands.ts:295,339` | One path throws explicitly if the block disappears; the other just created it. |
| `src/plugins/roam-import/import.ts:699,706,1263,1271,1435` | All in upsert paths where the block was just inserted / restored / verified via `tx.get`. |
| `src/plugins/srs-rescheduling/moveSrsState.ts:55` | `target` was just verified via `tx.get` with an early return. |
| `src/plugins/srs-rescheduling/index.ts:170` | `row` was just verified via `tx.get` with an early return. |
| `src/plugins/daily-notes/dailyNotes.ts:120,134,144,203,204,225,226,244,245,319,320` | All in tx where the block was just verified or created. |
| `src/plugins/quick-find/QuickFind.tsx:193` | Block id just returned by `tx.create`. |
| `src/plugins/todo/actions.ts:50` | Toggle action on a Block facade; strict catches concurrent delete (UI-driven, but the previous no-op would silently fail to apply the type). |

No call site required a flip back to lenient. None received an inline "assumption" comment because no site was ambiguous.

### Compound methods (toggleType, setBlockTypes)

These already pre-check the block with `tx.get` and bail on missing. They now also bail on tombstoned (previously they would have happily added the type to a deleted row), and pass `strict=false` into the private `_addTypeInTx` so the outer pre-check stays the single source of truth — no double check, no spurious throw on a UI-driven race.

## API shape

- `repo.addType(blockId, typeId, initialValues?)` — strict (throws).
- `repo.addTypeInTx(tx, blockId, typeId, initialValues?, snapshot?)` — strict (throws).
- `repo.addTypeInTxLenient(tx, blockId, typeId, initialValues?, snapshot?)` — **new**, opt-in lenient (silent no-op on missing/tombstoned).
- `_addTypeInTx` private primitive grows a `strict: boolean` arg; not exposed publicly.

## Error class

New `BlockNotFoundForTypeError` in `src/data/api/errors.ts`, following the existing `DataLayerError` subclass convention (`BlockNotFoundError`, `DeletedConflictError`, etc.). Fields: `blockId`, `typeId`, `reason: 'missing' | 'tombstoned'`.

## Test plan

- [x] `yarn run compile` passes
- [x] `yarn run lint` passes (0 errors)
- [x] Full vitest suite passes (1885 / 1885)
- [x] New tests in `src/data/internals/typeSystem.test.ts`:
  - strict on missing block throws `BlockNotFoundForTypeError`
  - strict on tombstoned block throws `BlockNotFoundForTypeError`
  - lenient on missing block silently no-ops
  - lenient on tombstoned block silently no-ops
  - strict happy-path tags the block normally
  - `repo.addType` (top-level) throws on missing block

https://claude.ai/code/session_01BMwEwkqo1tKGcBHu9aD5bd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMwEwkqo1tKGcBHu9aD5bd)_