### PR TITLE
Add withProvisionalSchema primitive to UserSchemasService

### DIFF
--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -326,4 +326,44 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     expect(env.repo.propertySchemas.get('topic')).toBe(newer)
     expect(env.service.getSchemaBlockId('topic')).toBe('block-newer')
   })
+
+  it('concurrent overlap: A fails after B succeeds → A does NOT clobber B', async () => {
+    // Two concurrent withProvisionalSchema calls for the same name:
+    //   - A peeks prior=undefined, appends A.
+    //   - B (simulated as a synchronous append from another caller)
+    //     overwrites the live entry with schemaB / block-B.
+    //   - A's tx body then throws.
+    // Without the CAS guard, A's catch arm would call
+    // `removeUserSchema('topic')` (because A's snapshot of prior was
+    // undefined) and wipe B's legitimately-live entry. The CAS guard
+    // checks `peekContribution(name).blockId === blockId` and skips
+    // rollback when the current live entry isn't A's any more.
+    //
+    // We don't go through two concurrent repo.tx calls here — PowerSync
+    // serializes writes, so the inner tx would deadlock waiting for the
+    // outer's body to release. Simulating B's append synchronously from
+    // inside A's body exercises the same CAS logic (the field-level
+    // race that the guard exists to handle).
+    env = await setup()
+    await drainInitialSubscriptionTick()
+
+    const schemaA = buildSchema('topic', 'A')
+    const schemaB = buildSchema('topic', 'B')
+    const boom = new Error('A tx failed')
+
+    const aResult = await env.service.withProvisionalSchema(schemaA, 'block-A', async () => {
+      // A's provisional is live at this point. Simulate a concurrent
+      // caller B that appends-and-overwrites.
+      env.service.appendUserSchema(schemaB, 'block-B')
+      expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
+      expect(env.service.getSchemaBlockId('topic')).toBe('block-B')
+      throw boom
+    }).catch(err => err)
+
+    expect(aResult).toBe(boom)
+    // Key invariant: A's catch arm DID NOT call removeUserSchema('topic').
+    // B's entry is still live, paired with block-B.
+    expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
+    expect(env.service.getSchemaBlockId('topic')).toBe('block-B')
+  })
 })

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { createElement, type JSX } from 'react'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
-import { ChangeScope, codecs, definePreset, defineProperty, type AnyValuePreset } from '@/data/api'
+import { ChangeScope, codecs, definePreset, defineProperty, type AnyPropertySchema, type AnyValuePreset } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { createTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
@@ -218,5 +218,76 @@ describe('Repo.setFacetRuntime — runtime contribution survival', () => {
     ]))
     const schema = await addPromise
     expect(env.repo.propertySchemas.get('siteUrl')).toBe(schema)
+  })
+})
+
+describe('UserSchemasService.withProvisionalSchema', () => {
+  const buildSchema = (name: string, defaultValue: string): AnyPropertySchema =>
+    defineProperty<string | undefined>(name, {
+      codec: codecs.optionalString,
+      defaultValue,
+      changeScope: ChangeScope.BlockDefault,
+    })
+
+  // The subscription started in `setup()` queues an initial microtask
+  // that rebuilds contributions from `[]` blocks. Wait for it to fire
+  // before the test seeds any provisional registrations, otherwise the
+  // late tick wipes them and the assertion is checking a stale state.
+  const drainInitialSubscriptionTick = async () => {
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  it('no prior registration + body succeeds → schema registered after; body result returned', async () => {
+    env = await setup()
+    await drainInitialSubscriptionTick()
+    const schema = buildSchema('topic', 'first')
+    const result = await env.service.withProvisionalSchema(schema, 'block-1', async () => 'ok')
+    expect(result).toBe('ok')
+    expect(env.repo.propertySchemas.get('topic')).toBe(schema)
+    expect(env.service.getSchemaBlockId('topic')).toBe('block-1')
+  })
+
+  it('no prior registration + body throws → schema NOT registered after; error rethrown', async () => {
+    env = await setup()
+    await drainInitialSubscriptionTick()
+    const schema = buildSchema('topic', 'first')
+    const boom = new Error('tx failed')
+    await expect(env.service.withProvisionalSchema(schema, 'block-1', async () => {
+      throw boom
+    })).rejects.toBe(boom)
+    expect(env.repo.propertySchemas.get('topic')).toBeUndefined()
+    expect(env.service.getSchemaBlockId('topic')).toBeUndefined()
+  })
+
+  it('prior registration exists + body succeeds → new schema is the live one after', async () => {
+    env = await setup()
+    await drainInitialSubscriptionTick()
+    const prior = buildSchema('topic', 'prior')
+    env.service.appendUserSchema(prior, 'block-prior')
+    expect(env.repo.propertySchemas.get('topic')).toBe(prior)
+
+    const next = buildSchema('topic', 'next')
+    const result = await env.service.withProvisionalSchema(next, 'block-next', async () => 42)
+    expect(result).toBe(42)
+    expect(env.repo.propertySchemas.get('topic')).toBe(next)
+    expect(env.service.getSchemaBlockId('topic')).toBe('block-next')
+  })
+
+  it('prior registration exists + body throws → prior schema is restored, not removed', async () => {
+    env = await setup()
+    await drainInitialSubscriptionTick()
+    const prior = buildSchema('topic', 'prior')
+    env.service.appendUserSchema(prior, 'block-prior')
+    expect(env.repo.propertySchemas.get('topic')).toBe(prior)
+
+    const next = buildSchema('topic', 'next')
+    const boom = new Error('tx failed')
+    await expect(env.service.withProvisionalSchema(next, 'block-next', async () => {
+      throw boom
+    })).rejects.toBe(boom)
+    // Key invariant: rollback restores the prior contribution rather
+    // than calling removeUserSchema unconditionally.
+    expect(env.repo.propertySchemas.get('topic')).toBe(prior)
+    expect(env.service.getSchemaBlockId('topic')).toBe('block-prior')
   })
 })

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -327,23 +327,18 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     expect(env.service.getSchemaBlockId('topic')).toBe('block-newer')
   })
 
-  it('concurrent overlap: A fails after B succeeds → A does NOT clobber B', async () => {
+  it('concurrent overlap (different blockId): A fails after B succeeds → A does NOT clobber B', async () => {
     // Two concurrent withProvisionalSchema calls for the same name:
     //   - A peeks prior=undefined, appends A.
     //   - B (simulated as a synchronous append from another caller)
     //     overwrites the live entry with schemaB / block-B.
     //   - A's tx body then throws.
     // Without the CAS guard, A's catch arm would call
-    // `removeUserSchema('topic')` (because A's snapshot of prior was
-    // undefined) and wipe B's legitimately-live entry. The CAS guard
-    // checks `peekContribution(name).blockId === blockId` and skips
-    // rollback when the current live entry isn't A's any more.
+    // `removeUserSchema('topic')` and wipe B's legitimately-live entry.
     //
-    // We don't go through two concurrent repo.tx calls here — PowerSync
-    // serializes writes, so the inner tx would deadlock waiting for the
-    // outer's body to release. Simulating B's append synchronously from
-    // inside A's body exercises the same CAS logic (the field-level
-    // race that the guard exists to handle).
+    // Simulated synchronously (not via two concurrent repo.tx calls)
+    // because PowerSync serializes writes — a real second tx inside A's
+    // body would deadlock waiting on the outer's writer slot.
     env = await setup()
     await drainInitialSubscriptionTick()
 
@@ -352,8 +347,6 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     const boom = new Error('A tx failed')
 
     const aResult = await env.service.withProvisionalSchema(schemaA, 'block-A', async () => {
-      // A's provisional is live at this point. Simulate a concurrent
-      // caller B that appends-and-overwrites.
       env.service.appendUserSchema(schemaB, 'block-B')
       expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
       expect(env.service.getSchemaBlockId('topic')).toBe('block-B')
@@ -361,9 +354,36 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     }).catch(err => err)
 
     expect(aResult).toBe(boom)
-    // Key invariant: A's catch arm DID NOT call removeUserSchema('topic').
-    // B's entry is still live, paired with block-B.
     expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
     expect(env.service.getSchemaBlockId('topic')).toBe('block-B')
+  })
+
+  it('concurrent overlap (SAME blockId, different schema): A fails after B succeeds → A does NOT clobber B', async () => {
+    // The blockId-only guard would falsely pass here because B reuses
+    // A's blockId (retries / duplicate submits / re-registration of the
+    // same property-schema block with a different codec). The token-
+    // based CAS distinguishes A's appendUserSchema from B's even when
+    // (name, blockId) coincide.
+    env = await setup()
+    await drainInitialSubscriptionTick()
+
+    const sharedBlockId = 'block-shared'
+    const schemaA = buildSchema('topic', 'A')
+    const schemaB = buildSchema('topic', 'B')
+    const boom = new Error('A tx failed')
+
+    const aResult = await env.service.withProvisionalSchema(schemaA, sharedBlockId, async () => {
+      env.service.appendUserSchema(schemaB, sharedBlockId)
+      expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
+      throw boom
+    }).catch(err => err)
+
+    expect(aResult).toBe(boom)
+    // Key invariant: even though A and B share blockId, A's catch arm
+    // must not roll back over B's registration. The token-based CAS
+    // distinguishes them; a blockId-only check would falsely pass and
+    // wipe B.
+    expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
+    expect(env.service.getSchemaBlockId('topic')).toBe(sharedBlockId)
   })
 })

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -304,11 +304,15 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     const newer = buildSchema('topic', 'newer')
     // Simulate the duplicate-name state the subscription rebuild can
     // produce: two contributions with the same name in registration
-    // order, `nameToBlockId` pinned to the latter block.
+    // order, `nameToBlockId` and the committed mirror pinned to the
+    // latter block. Mirrors what rebuildFromBlocks would produce, so
+    // both live and committed views agree.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(env.service as any).contributions = [older, newer]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(env.service as any).nameToBlockId = new Map([['topic', 'block-newer']])
+    const svc = env.service as any
+    svc.contributions = [older, newer]
+    svc.nameToBlockId = new Map([['topic', 'block-newer']])
+    svc.committedContributions = [older, newer]
+    svc.committedNameToBlockId = new Map([['topic', 'block-newer']])
     env.repo.setRuntimeContributions(
       propertySchemasFacet, 'user-data', [older, newer],
     )
@@ -356,6 +360,57 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     expect(aResult).toBe(boom)
     expect(env.repo.propertySchemas.get('topic')).toBe(schemaB)
     expect(env.service.getSchemaBlockId('topic')).toBe('block-B')
+  })
+
+  it('overlapping provisionals + both fail: name ends UNREGISTERED (no failed provisional restored)', async () => {
+    // Two overlapping withProvisionalSchema calls for the same name,
+    // both fail. If `prior` captured the live view, A's failed
+    // provisional would become B's restore target — leaving a failed
+    // provisional registered with no successful tx behind it. The
+    // committed-only baseline (_peekCommitted) avoids this.
+    //
+    // We can't actually run nested repo.tx (PowerSync serializes
+    // writes — the inner tx would deadlock). Instead, simulate B
+    // entirely via the synchronous primitives the public method
+    // uses internally.
+    env = await setup()
+    await drainInitialSubscriptionTick()
+
+    const schemaA = buildSchema('topic', 'A')
+    const schemaB = buildSchema('topic', 'B')
+    const boomA = new Error('A tx failed')
+
+    const aResult = await env.service.withProvisionalSchema(schemaA, 'block-A', async () => {
+      // Inside A's body: A is the live provisional, committed mirror
+      // is still empty. Simulate B's flow synchronously:
+      //   1. B captures _peekCommitted (returns undefined because A
+      //      is provisional, not committed).
+      //   2. B appends its own provisional.
+      //   3. B's tx body throws → B's catch arm runs removeUserSchema
+      //      (since B's captured prior was undefined).
+      // Net of B's simulated overlap: name is fully unregistered.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const serviceAny = env.service as any
+      const bCommittedPrior = serviceAny._peekCommitted('topic')
+      expect(bCommittedPrior).toBeUndefined()       // committed view, not A's live provisional
+      serviceAny._appendProvisional(schemaB, 'block-B')
+      // B's hypothetical tx fails — its catch arm would call
+      // removeUserSchema (since bCommittedPrior was undefined).
+      env.service.removeUserSchema('topic')
+      expect(env.repo.propertySchemas.get('topic')).toBeUndefined()
+
+      // Now A's body throws.
+      throw boomA
+    }).catch(err => err)
+
+    expect(aResult).toBe(boomA)
+    // A's catch ran. Its token was cleared by removeUserSchema (B's
+    // rollback simulation), so the CAS check skipped rollback. Final
+    // state: name is fully unregistered. The bug we're guarding
+    // against: a live-peek prior would have made B "restore" schemaA,
+    // leaving a failed provisional registered.
+    expect(env.repo.propertySchemas.get('topic')).toBeUndefined()
+    expect(env.service.getSchemaBlockId('topic')).toBeUndefined()
   })
 
   it('concurrent overlap (SAME blockId, different schema): A fails after B succeeds → A does NOT clobber B', async () => {

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -290,4 +290,40 @@ describe('UserSchemasService.withProvisionalSchema', () => {
     expect(env.repo.propertySchemas.get('topic')).toBe(prior)
     expect(env.service.getSchemaBlockId('topic')).toBe('block-prior')
   })
+
+  it('duplicate-name contributions + body throws → restores LIVE (last) schema, not the first', async () => {
+    // rebuildFromBlocks can produce duplicate-name entries (one per
+    // matching `property-schema` block); `propertySchemasFacet.combine`
+    // is last-wins on duplicates and `nameToBlockId` is last-wins on
+    // the block id. `peekContribution` must snapshot the LAST match so
+    // a rollback can't pair an older schema with a newer block id.
+    env = await setup()
+    await drainInitialSubscriptionTick()
+
+    const older = buildSchema('topic', 'older')
+    const newer = buildSchema('topic', 'newer')
+    // Simulate the duplicate-name state the subscription rebuild can
+    // produce: two contributions with the same name in registration
+    // order, `nameToBlockId` pinned to the latter block.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(env.service as any).contributions = [older, newer]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(env.service as any).nameToBlockId = new Map([['topic', 'block-newer']])
+    env.repo.setRuntimeContributions(
+      propertySchemasFacet, 'user-data', [older, newer],
+    )
+    expect(env.repo.propertySchemas.get('topic')).toBe(newer)
+    expect(env.service.getSchemaBlockId('topic')).toBe('block-newer')
+
+    const provisional = buildSchema('topic', 'provisional')
+    const boom = new Error('tx failed')
+    await expect(env.service.withProvisionalSchema(provisional, 'block-provisional', async () => {
+      throw boom
+    })).rejects.toBe(boom)
+    // After rollback the live schema must be `newer` (paired with
+    // `block-newer`) — restoring `older` paired with `block-newer`
+    // would be the bug.
+    expect(env.repo.propertySchemas.get('topic')).toBe(newer)
+    expect(env.service.getSchemaBlockId('topic')).toBe('block-newer')
+  })
 })

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -179,9 +179,17 @@ export class UserSchemasService {
    *  schema or its block id is missing (kernel/plugin schemas don't
    *  live in `contributions` / `nameToBlockId`). Used by
    *  `withProvisionalSchema` to snapshot prior registrations so a
-   *  rollback can restore them rather than wiping them. */
+   *  rollback can restore them rather than wiping them.
+   *
+   *  `rebuildFromBlocks` pushes duplicate-name entries unconditionally
+   *  (one per matching block), and `nameToBlockId` is last-wins.
+   *  `propertySchemasFacet.combine` is also last-wins on duplicate
+   *  names, so the LIVE schema is the last occurrence in
+   *  `contributions`. `findLast` snapshots that one — pairing it with
+   *  the (also last-wins) `nameToBlockId.get(name)` so restore can't
+   *  end up with an older schema mapped to a newer block's id. */
   peekContribution(name: string): {contribution: AnyPropertySchema; blockId: string} | undefined {
-    const contribution = this.contributions.find(s => s.name === name)
+    const contribution = this.contributions.findLast(s => s.name === name)
     if (!contribution) return undefined
     const blockId = this.nameToBlockId.get(name)
     if (!blockId) return undefined

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -230,10 +230,21 @@ export class UserSchemasService {
         description: opts.description ?? 'withProvisionalSchema',
       })
     } catch (err) {
-      if (prior) {
-        this.appendUserSchema(prior.contribution, prior.blockId)
-      } else {
-        this.removeUserSchema(schema.name)
+      // Compare-and-swap on the live entry's blockId. Two concurrent
+      // withProvisionalSchema calls for the same name can interleave:
+      // call A peeks prior=undefined, appends, awaits its tx; call B
+      // peeks prior=A's-provisional, appends-and-overwrites with B's
+      // schema, and its tx succeeds; A's tx then fails. Without this
+      // check, A's catch would call `removeUserSchema(name)` and wipe
+      // B's legitimately-live entry. Only roll back if the current
+      // live entry is still the one this call appended.
+      const current = this.peekContribution(schema.name)
+      if (current && current.blockId === blockId) {
+        if (prior) {
+          this.appendUserSchema(prior.contribution, prior.blockId)
+        } else {
+          this.removeUserSchema(schema.name)
+        }
       }
       throw err
     }

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -44,6 +44,18 @@ export class UserSchemasService {
    *  `contributions`, so it's always in sync. */
   private nameToBlockId = new Map<string, string>()
 
+  /** Per-name CAS token. Every mutation (`appendUserSchema`,
+   *  `removeUserSchema`, subscription rebuild) generates a fresh symbol
+   *  for the affected name. `withProvisionalSchema` captures the token
+   *  right after its append and compares in the catch arm: if the
+   *  current token matches, no one has touched this slot since our
+   *  append, so rollback is safe. If it differs, someone else has
+   *  mutated the slot — skip rollback to avoid clobbering their entry.
+   *  blockId alone isn't a sufficient sentinel because two overlapping
+   *  calls (retries / duplicate submits) can legitimately share the
+   *  same (name, blockId) pair. */
+  private contributionTokens = new Map<string, symbol>()
+
   /** Active block-subscription disposer, set by `start()`. */
   private subscriptionDisposer: Unsubscribe | null = null
 
@@ -75,15 +87,18 @@ export class UserSchemasService {
       const presets = this.repo.valuePresets
       const next: AnyPropertySchema[] = []
       const nextNameToBlockId = new Map<string, string>()
+      const nextTokens = new Map<string, symbol>()
       for (const block of blocks) {
         const built = this.tryBuildSchema(block, presets)
         if (built) {
           next.push(built)
           nextNameToBlockId.set(built.name, block.id)
+          nextTokens.set(built.name, Symbol('rebuild'))
         }
       }
       this.contributions = next
       this.nameToBlockId = nextNameToBlockId
+      this.contributionTokens = nextTokens
       this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
     }
 
@@ -171,6 +186,7 @@ export class UserSchemasService {
       schema,
     ]
     this.nameToBlockId.set(schema.name, blockId)
+    this.contributionTokens.set(schema.name, Symbol('appendUserSchema'))
     this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
   }
 
@@ -203,6 +219,7 @@ export class UserSchemasService {
   removeUserSchema(name: string): void {
     this.contributions = this.contributions.filter(s => s.name !== name)
     this.nameToBlockId.delete(name)
+    this.contributionTokens.delete(name)
     this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
   }
 
@@ -224,22 +241,23 @@ export class UserSchemasService {
   ): Promise<T> {
     const prior = this.peekContribution(schema.name)
     this.appendUserSchema(schema, blockId)
+    // Snapshot our token IMMEDIATELY after appendUserSchema — this is
+    // the per-call sentinel for the CAS check below. blockId isn't
+    // unique enough: two overlapping calls (retries / duplicate
+    // submits) can legitimately share the same (name, blockId) pair.
+    // A fresh symbol per appendUserSchema makes ownership identifiable.
+    const ourToken = this.contributionTokens.get(schema.name)
     try {
       return await this.repo.tx(body, {
         scope: opts.scope ?? ChangeScope.BlockDefault,
         description: opts.description ?? 'withProvisionalSchema',
       })
     } catch (err) {
-      // Compare-and-swap on the live entry's blockId. Two concurrent
-      // withProvisionalSchema calls for the same name can interleave:
-      // call A peeks prior=undefined, appends, awaits its tx; call B
-      // peeks prior=A's-provisional, appends-and-overwrites with B's
-      // schema, and its tx succeeds; A's tx then fails. Without this
-      // check, A's catch would call `removeUserSchema(name)` and wipe
-      // B's legitimately-live entry. Only roll back if the current
-      // live entry is still the one this call appended.
-      const current = this.peekContribution(schema.name)
-      if (current && current.blockId === blockId) {
+      // CAS: only roll back if our token is still the live one. Any
+      // intervening appendUserSchema / removeUserSchema / subscription
+      // rebuild generates a fresh token, so a token mismatch means
+      // someone else has taken ownership of this slot — skip rollback.
+      if (this.contributionTokens.get(schema.name) === ourToken) {
         if (prior) {
           this.appendUserSchema(prior.contribution, prior.blockId)
         } else {

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -56,6 +56,18 @@ export class UserSchemasService {
    *  same (name, blockId) pair. */
   private contributionTokens = new Map<string, symbol>()
 
+  /** Committed-only mirror of `contributions` / `nameToBlockId`. Tracks
+   *  the rollback baseline for `withProvisionalSchema`: what the live
+   *  state would be if every in-flight provisional unwound. Updated by
+   *  successful operations (subscription rebuild, `appendUserSchema`
+   *  from outside withProvisionalSchema, `removeUserSchema`, and the
+   *  success arm of `withProvisionalSchema`); NOT touched by an
+   *  in-flight provisional append. Without this, two overlapping
+   *  provisional calls for the same name capture each other as "prior"
+   *  and a double-failure rollback restores a failed provisional. */
+  private committedContributions: readonly AnyPropertySchema[] = []
+  private committedNameToBlockId = new Map<string, string>()
+
   /** Active block-subscription disposer, set by `start()`. */
   private subscriptionDisposer: Unsubscribe | null = null
 
@@ -96,9 +108,13 @@ export class UserSchemasService {
           nextTokens.set(built.name, Symbol('rebuild'))
         }
       }
+      // Subscription rebuild reflects on-disk truth — write to both
+      // committed and live (and reset any stale provisional tokens).
       this.contributions = next
       this.nameToBlockId = nextNameToBlockId
       this.contributionTokens = nextTokens
+      this.committedContributions = next
+      this.committedNameToBlockId = new Map(nextNameToBlockId)
       this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
     }
 
@@ -187,6 +203,14 @@ export class UserSchemasService {
     ]
     this.nameToBlockId.set(schema.name, blockId)
     this.contributionTokens.set(schema.name, Symbol('appendUserSchema'))
+    // Public appendUserSchema asserts a committed registration — addSchema
+    // calls it after its tx succeeds. Update the committed mirror too so a
+    // subsequent withProvisionalSchema sees this as the rollback baseline.
+    this.committedContributions = [
+      ...this.committedContributions.filter(s => s.name !== schema.name),
+      schema,
+    ]
+    this.committedNameToBlockId.set(schema.name, blockId)
     this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
   }
 
@@ -220,6 +244,35 @@ export class UserSchemasService {
     this.contributions = this.contributions.filter(s => s.name !== name)
     this.nameToBlockId.delete(name)
     this.contributionTokens.delete(name)
+    this.committedContributions = this.committedContributions.filter(s => s.name !== name)
+    this.committedNameToBlockId.delete(name)
+    this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
+  }
+
+  /** Look up the COMMITTED entry for `name` (ignoring any in-flight
+   *  provisional appended by a still-running `withProvisionalSchema`).
+   *  Used by `withProvisionalSchema` as the rollback baseline so two
+   *  overlapping provisional calls for the same name don't capture
+   *  each other as "prior." */
+  private _peekCommitted(name: string): {contribution: AnyPropertySchema; blockId: string} | undefined {
+    const blockId = this.committedNameToBlockId.get(name)
+    if (!blockId) return undefined
+    const contribution = this.committedContributions.findLast(s => s.name === name)
+    if (!contribution) return undefined
+    return {contribution, blockId}
+  }
+
+  /** Append `schema` to the LIVE view only. The committed mirror is
+   *  not touched — this is for in-flight provisional registrations
+   *  that may or may not commit. Mirrors `appendUserSchema` shape but
+   *  without the committed-mirror update. */
+  private _appendProvisional(schema: AnyPropertySchema, blockId: string): void {
+    this.contributions = [
+      ...this.contributions.filter(s => s.name !== schema.name),
+      schema,
+    ]
+    this.nameToBlockId.set(schema.name, blockId)
+    this.contributionTokens.set(schema.name, Symbol('provisional'))
     this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
   }
 
@@ -239,19 +292,37 @@ export class UserSchemasService {
     body: (tx: Tx) => Promise<T>,
     opts: {scope?: ChangeScope; description?: string} = {},
   ): Promise<T> {
-    const prior = this.peekContribution(schema.name)
-    this.appendUserSchema(schema, blockId)
-    // Snapshot our token IMMEDIATELY after appendUserSchema — this is
-    // the per-call sentinel for the CAS check below. blockId isn't
-    // unique enough: two overlapping calls (retries / duplicate
-    // submits) can legitimately share the same (name, blockId) pair.
-    // A fresh symbol per appendUserSchema makes ownership identifiable.
+    // Capture the COMMITTED prior, not the live peek. If another
+    // in-flight withProvisionalSchema for the same name overlapped
+    // (call A appended, call B starts), live peek would return A's
+    // provisional. Restoring it on B's failure would leave a failed
+    // provisional registered. The committed mirror only reflects
+    // successful operations, so it's the right rollback baseline.
+    const prior = this._peekCommitted(schema.name)
+    // Provisional append: updates LIVE only, leaves committed mirror
+    // untouched so a later overlapping caller doesn't see this entry
+    // as a committed baseline.
+    this._appendProvisional(schema, blockId)
     const ourToken = this.contributionTokens.get(schema.name)
     try {
-      return await this.repo.tx(body, {
+      const result = await this.repo.tx(body, {
         scope: opts.scope ?? ChangeScope.BlockDefault,
         description: opts.description ?? 'withProvisionalSchema',
       })
+      // Success: promote our provisional to committed. The caller's
+      // body asserted the registration is good (presumably wrote a
+      // backing property-schema block; the next subscription rebuild
+      // will reconcile from disk regardless). Only promote if we
+      // still own the token — an intervening rebuild / external
+      // append / removeUserSchema may have already taken over.
+      if (this.contributionTokens.get(schema.name) === ourToken) {
+        this.committedContributions = [
+          ...this.committedContributions.filter(s => s.name !== schema.name),
+          schema,
+        ]
+        this.committedNameToBlockId.set(schema.name, blockId)
+      }
+      return result
     } catch (err) {
       // CAS: only roll back if our token is still the live one. Any
       // intervening appendUserSchema / removeUserSchema / subscription

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -6,6 +6,7 @@ import {
   ChangeScope,
   type AnyPropertySchema,
   type AnyValuePreset,
+  type Tx,
   type Unsubscribe,
 } from '@/data/api'
 import type { Block } from '@/data/block'
@@ -171,6 +172,63 @@ export class UserSchemasService {
     ]
     this.nameToBlockId.set(schema.name, blockId)
     this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
+  }
+
+  /** Capture the currently-registered user-data schema for `name`,
+   *  along with its source block id. Returns undefined when either the
+   *  schema or its block id is missing (kernel/plugin schemas don't
+   *  live in `contributions` / `nameToBlockId`). Used by
+   *  `withProvisionalSchema` to snapshot prior registrations so a
+   *  rollback can restore them rather than wiping them. */
+  peekContribution(name: string): {contribution: AnyPropertySchema; blockId: string} | undefined {
+    const contribution = this.contributions.find(s => s.name === name)
+    if (!contribution) return undefined
+    const blockId = this.nameToBlockId.get(name)
+    if (!blockId) return undefined
+    return {contribution, blockId}
+  }
+
+  /** Symmetric to `appendUserSchema`: drop a user-data schema from the
+   *  runtime bucket and republish. Used by `withProvisionalSchema` to
+   *  unregister a provisional schema when its tx aborts and no prior
+   *  registration existed for the name. */
+  removeUserSchema(name: string): void {
+    this.contributions = this.contributions.filter(s => s.name !== name)
+    this.nameToBlockId.delete(name)
+    this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, this.contributions)
+  }
+
+  /** Register `schema` provisionally, run `body` inside a repo tx, and
+   *  on tx failure either restore the previously-registered schema for
+   *  `schema.name` (if one existed) or drop the provisional registration
+   *  (if none did). The capture-and-restore shape lets callers register
+   *  a user-data schema *before* an in-tx write that depends on it
+   *  (e.g. retagging blocks against a new isa) without permanently
+   *  wiping a legitimate prior registration on retry.
+   *
+   *  Mirrors `addSchema`'s tx convention by default (BlockDefault scope,
+   *  a descriptive label). Callers can override either via `opts`. */
+  async withProvisionalSchema<T>(
+    schema: AnyPropertySchema,
+    blockId: string,
+    body: (tx: Tx) => Promise<T>,
+    opts: {scope?: ChangeScope; description?: string} = {},
+  ): Promise<T> {
+    const prior = this.peekContribution(schema.name)
+    this.appendUserSchema(schema, blockId)
+    try {
+      return await this.repo.tx(body, {
+        scope: opts.scope ?? ChangeScope.BlockDefault,
+        description: opts.description ?? 'withProvisionalSchema',
+      })
+    } catch (err) {
+      if (prior) {
+        this.appendUserSchema(prior.contribution, prior.blockId)
+      } else {
+        this.removeUserSchema(schema.name)
+      }
+      throw err
+    }
   }
 
   /** Create a property-schema block in the workspace's Properties


### PR DESCRIPTION
## Summary

Adds a capture-and-restore primitive to `UserSchemasService` so callers that need to register a user-data schema synchronously, before an in-tx write that depends on it, and roll the registration back if the tx fails, have a primitive that does not wipe a legitimate prior registration on retry.

Three new methods on `UserSchemasService`:

- `peekContribution(name)` — snapshot the currently-registered schema plus its source block id, or undefined if either is missing.
- `removeUserSchema(name)` — symmetric to `appendUserSchema`; drops a name from the user-data bucket and republishes.
- `withProvisionalSchema(schema, blockId, body, opts?)` — register, open a tx around `body`, restore the captured prior on failure (or drop the provisional if none existed), re-throw the original error.

## Why capture-and-restore beats unconditional `remove`

The naive rollback path — `appendUserSchema` then `remove` on failure — is wrong when an earlier `appendUserSchema(name, ...)` already lived in the bucket. Unconditional `remove` would erase that legitimate prior registration during a tx retry, leaving the runtime in a worse state than before the attempt. Capturing the prior contribution + block id up front and restoring it on failure keeps the bucket exactly where it started for any retry path.

## Design context

See PR #47 / `docs/user-defined-types.html` — the upcoming `UserTypesService` for the Roam-isa adoption flow will mirror this primitive (register before tx, retag many blocks inside tx, rollback registration if tx aborts).

## Test plan

- [x] No prior registration, body succeeds → schema is registered after, body result returned
- [x] No prior registration, body throws → schema is NOT registered after, error rethrown
- [x] Prior registration exists, body succeeds → new schema is the live one after
- [x] Prior registration exists, body throws → prior schema is restored, not removed
- [x] `yarn run check` passes

https://claude.ai/code/session_01BMwEwkqo1tKGcBHu9aD5bd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMwEwkqo1tKGcBHu9aD5bd)_