### PR TITLE
Doc: shortcut context precedence — options &amp; decision aid

### DIFF
--- a/docs/action-system-critique.html
+++ b/docs/action-system-critique.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Action system — architectural critique</title>
+<style>
+  body { font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         max-width: 980px; margin: 2rem auto; padding: 0 1.25rem; color: #1f2328; }
+  h1 { font-size: 1.6rem; margin-bottom: .25rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #d0d7de; padding-bottom: .25rem; }
+  h3 { font-size: 1rem; margin-top: 1.25rem; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; }
+  pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+        padding: .75rem .9rem; overflow-x: auto; }
+  code { background: #f6f8fa; padding: .1em .3em; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .65rem; vertical-align: top; text-align: left; }
+  th { background: #f6f8fa; }
+  .keep { color: #1a7f37; }
+  .keep::before { content: "✓ "; font-weight: 700; }
+  .weak { color: #cf222e; }
+  .weak::before { content: "✗ "; font-weight: 700; }
+  ul.tight { margin: .4rem 0; }
+  .note { background: #fff8c5; border-left: 4px solid #d4a72c; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .axes { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .verdict { background: #dafbe1; border-left: 4px solid #1a7f37; padding: .75rem 1rem;
+             border-radius: 4px; margin: 1.5rem 0; }
+  .prio td:first-child { font-weight: 600; white-space: nowrap; }
+  .p1 { background: #fff1f0; } .p2 { background: #fffbe6; } .p3 { background: #f0fdf4; }
+  small { color: #57606a; }
+  .filepath { color: #57606a; font-size: 11.5px; }
+</style>
+</head>
+<body>
+
+<h1>Action system — architectural critique</h1>
+<small>Fresh-eyes review of <code>src/shortcuts/</code> + the action facets — 2026-05-30</small>
+
+<p>Written alongside <code>docs/shortcut-context-precedence.html</code>. That doc fixes one bug
+(double-fire) and adds one knob (precedence). This doc steps back and asks the broader question the
+precedence work surfaced: <strong>is the action system's shape right, or are we patching a model that
+wants restructuring?</strong> It is a critique + target shape, not an implementation plan. No code
+changes proposed here.</p>
+
+<div class="note">
+<strong>Bias check up front.</strong> This system is <em>not</em> in bad shape. The facet contribution
+model is genuinely good and most of the friction is concentrated in two places (resolution and the
+transform pipeline). The honest recommendation (bottom) is "two surgical refactors, leave the rest
+alone" — not a rewrite. Flagging this so the list of weaknesses below isn't read as a teardown.
+</div>
+
+<h2>The model in one screen</h2>
+<ul class="tight">
+  <li><strong>Actions</strong> (<code>ActionConfig</code>) are contributed via <code>actionsFacet</code>
+      (<span class="filepath">core.ts:158</span>). Each carries <code>id</code>, <code>context</code>,
+      <code>handler</code>, optional <code>defaultBinding</code>, <code>canRun</code>, <code>icon</code>.
+      ~23 files contribute.</li>
+  <li><strong>Contexts</strong> (<code>ActionContextConfig</code>) via <code>actionContextsFacet</code>
+      (<span class="filepath">core.ts:225</span>); 6 call sites. A context is both an
+      <em>activation scope</em> and a <em>typed dependency bundle</em> (via
+      <code>validateDependencies</code>).</li>
+  <li><strong>Activation</strong> is React-lifecycle-driven: blocks call
+      <code>useActionContextActivations</code> (<span class="filepath">useActionContext.ts:17</span>),
+      which <code>activate()</code>s on mount/effect and <code>deactivate()</code>s on cleanup. The active
+      set is an insertion-ordered <code>Map</code> (<span class="filepath">ActiveContexts.tsx</span>).
+      27 surface-activation references.</li>
+  <li><strong>Transform pipeline:</strong> <code>actionOverridesFacet</code> → <code>actionDecoratorsFacet</code>
+      → <code>keybindingOverridesFacet</code>, composed in <code>getEffectiveActions</code>
+      (<span class="filepath">effectiveActions.ts:66</span>).</li>
+  <li><strong>Dispatch</strong> happens three ways: keyboard (per-action <code>window</code> listeners in
+      <code>HotkeyReconciler</code>), <code>runActionById</code> (module singleton), and
+      <code>useRunAction</code> (React hook). The latter two share <code>getActiveActionById</code>; the
+      keyboard path does not.</li>
+</ul>
+
+<h2>What's good — keep it</h2>
+<ul class="tight">
+  <li class="keep"><strong>Facet-based contribution.</strong> Actions, contexts, overrides, decorators all
+      flow through facets — plugins compose without editing core, no circular deps. This is the load-bearing
+      strength; nothing below proposes touching it.</li>
+  <li class="keep"><strong>Decorators that wrap rather than fork.</strong> Extending an action's
+      <code>canRun</code>/handler without owning the definition (e.g.
+      <span class="filepath">srs-rescheduling/rescheduleDecorator.ts</span>) is the right shape for
+      cross-plugin extension.</li>
+  <li class="keep"><strong>Per-action install/uninstall.</strong> Each action owning its subscription makes
+      activation changes cheap (no global teardown). Worth preserving even if the listener model changes.</li>
+  <li class="keep"><strong>Typed dependency map.</strong> <code>ShortcutDependenciesMap</code> keyed by
+      context type is a clean way to give handlers the right inputs.</li>
+</ul>
+
+<h2>Weaknesses — grouped by theme</h2>
+
+<h3>1. Resolution is implemented three times and the keyboard one disagrees</h3>
+<p>"Given an active set, which action handles X?" is answered in three places:</p>
+<ul class="tight">
+  <li><code>runActionById</code> → the module dispatcher installed by HotkeyReconciler
+      (<span class="filepath">HotkeyReconciler.tsx:174</span>) → <code>getActiveActionById</code>
+      (last-activated-context wins).</li>
+  <li><code>useRunAction</code> (<span class="filepath">runAction.ts:54</span>) → also
+      <code>getActiveActionById</code>, but re-implements the deps-lookup/throw around it.</li>
+  <li>The keyboard path → <strong>no resolution at all</strong>; every active action installs its own
+      listener, so collisions double-fire (the bug the precedence doc fixes).</li>
+</ul>
+<p class="weak">There is no single "resolve event → action" function. The keyboard path and the dispatch
+path have <em>different</em> semantics (double-fire vs single-winner) for what is conceptually one question.
+Precedence (priority/modal) then has to be taught to each path separately. <strong>This is the deepest
+structural issue and the one the precedence work half-forces us to confront.</strong></p>
+
+<h3>2. Three overlapping transform mechanisms</h3>
+<p><code>ActionOverride</code>, <code>ActionDecorator</code>, and <code>keybindingOverridesFacet</code> all
+rewrite the action list, with subtle, undocumented differences:</p>
+<table>
+<tr><th>Mechanism</th><th>Can drop an action?</th><th>Cross-action visibility?</th><th>Ordering</th></tr>
+<tr><td><code>ActionOverride.apply</code></td><td>yes (<code>→ null</code>)</td><td>no</td><td>1st</td></tr>
+<tr><td><code>ActionDecorator.decorate</code></td><td><strong>no</strong> (<code>→ ActionConfig</code>)</td><td>no</td><td>2nd</td></tr>
+<tr><td><code>keybindingOverridesFacet</code></td><td>strips chord, not action</td><td>yes (collision rule)</td><td>3rd (final)</td></tr>
+</table>
+<ul class="tight">
+  <li class="weak"><strong>Override vs decorator asymmetry is arbitrary.</strong> Both are
+      "(action) → action" transforms; only one may return <code>null</code>
+      (<span class="filepath">types.ts:164 vs 170</span>). A plugin that wants to <em>conditionally remove</em>
+      an action must use override; one that wants to <em>extend</em> it uses decorator — but nothing names
+      that distinction, so the choice is folklore.</li>
+  <li class="weak"><strong>Two ways to suppress, neither obvious.</strong> The user's "skip decorators"
+      (no-op the handler) and a hypothetical <code>override → null</code> (drop the action) both "disable"
+      an action, with totally different consequences (handler-still-listed-but-inert vs gone-from-palette).
+      No guidance on which to reach for.</li>
+  <li class="weak"><strong>The <code>'*'</code> wildcard</strong> (<span class="filepath">effectiveActions.ts:27</span>)
+      is a back-door for set-wise transforms bolted onto a per-action API — used once, for the keybinding
+      bridge, and easy to misuse.</li>
+</ul>
+
+<h3>3. <code>canRun</code> looks authoritative but is presentational</h3>
+<p><code>canRun</code> reads like a guard, but it gates only UI surfaces (palette, swipe menu); the keyboard
+and <code>runActionById</code> paths never call it (<span class="filepath">types.ts:148–156</span> spells this
+out, but the name fights the doc).</p>
+<ul class="tight">
+  <li class="weak">The user's skip-decorators exist <em>because</em> there's no dispatch-level "should this
+      run?" — they fake one by mutating the handler. A real predicate-at-dispatch (the precedence doc's
+      Option D) is the missing concept <code>canRun</code> appears to promise but doesn't deliver.</li>
+  <li class="weak">Name implies authority it doesn't have. <code>isApplicableForDisplay</code> would be honest;
+      or make it actually gate dispatch and the skip-decorator pattern evaporates.</li>
+</ul>
+
+<h3>4. Precedence is incidental because activation order is React-lifecycle order</h3>
+<p>The active set's order is whatever sequence <code>useEffect</code> activations fired in
+(<span class="filepath">ActiveContexts.tsx:86–97</span>). "Latest-activated wins" therefore inherits
+mount/effect ordering as its precedence signal — which is why the new-surface case resolves backwards
+(surface mounts early, normal-mode activates on click). The precedence doc adds an explicit
+<code>priority</code> to escape this, which is the right patch — but the underlying smell is
+<strong>using a lifecycle artifact as a semantic ordering</strong>.</p>
+
+<h3>5. The <code>runActionById</code> module singleton</h3>
+<p><code>runAction.ts</code> holds a module-level <code>dispatcher</code> var set by HotkeyReconciler on
+mount and nulled on unmount. It works, but: it's global mutable state, it throws if called before mount,
+and it couples "can I dispatch an action" to "is this one React component mounted." For a system whose whole
+point is decoupled contribution, the dispatch entry point being a singleton side-channel is a wart.</p>
+
+<h3>6. Context conflates scope and dependency-bundle</h3>
+<p>An <code>ActionContextConfig</code> is simultaneously (a) an activation scope that gates install, (b) a
+modal/precedence tier, and (c) a typed dependency carrier (<code>validateDependencies</code> +
+<code>ShortcutDependenciesMap</code>). These mostly co-vary, but the conflation shows up as type friction:
+<code>as never</code> / <code>as ActionConfig</code> casts in the override/decorator pipeline
+(<span class="filepath">effectiveActions.ts:52,57</span>) and the <code>bivarianceHack</code> in
+<code>ActionHandler</code> (<span class="filepath">types.ts:126</span>). The generics are being fought rather
+than expressing the model.</p>
+
+<h2>The unifying idea: one resolution core</h2>
+<div class="axes">
+Most of the weaknesses above (1, 3, 4, partly 5) are the same shape: <strong>there is no single place that
+owns "active set + event → which action runs."</strong> Resolution is smeared across per-action listeners,
+two dispatch helpers, a presentational predicate, and an implicit lifecycle ordering. The high-leverage
+refactor is to introduce <em>one</em> resolver and route every path through it:
+<pre><code>resolve(activeSet, event | actionId): ActionConfig | null
+  // single comparator: (priority desc, activation-recency desc)
+  // single canonicalization of chords
+  // single place to add modal / declinable / future tiers</code></pre>
+Keyboard dispatch, <code>runActionById</code>, and <code>useRunAction</code> all call it. Precedence,
+canonicalization, modal, and (if chosen) declinable fall-through become properties of the resolver, defined
+once, instead of being re-taught to each path. This is also exactly what the precedence doc's "shared
+comparator, used by both paths" bullet is reaching for — generalized.
+</div>
+
+<h2>What's worth doing — prioritized</h2>
+<table class="prio">
+<tr><th>Priority</th><th>Change</th><th>Why / payoff</th></tr>
+<tr><td class="p1">P1</td>
+  <td>Single resolution core; route keyboard + both dispatch helpers through it
+      (subsumes the precedence doc's comparator + the double-fire fix)</td>
+  <td>Kills the keyboard/dispatch divergence (weakness 1), gives precedence/canonicalization/modal one home,
+      makes Option D a localized change later instead of a rewrite. Highest leverage.</td></tr>
+<tr><td class="p1">P1</td>
+  <td>Decide <code>canRun</code>'s identity: either rename to a display-only name, or split into
+      <code>isVisible</code> (UI) + <code>canDispatch</code> (gate)</td>
+  <td>Removes the reason skip-decorators exist (weakness 3). Cheap, clarifies a contract people already misuse.</td></tr>
+<tr><td class="p2">P2</td>
+  <td>Unify the transform pipeline: one <code>(action) → action | null</code> transform type with a
+      documented phase, fold decorator/override into it; keep keybinding-override as the one cross-action pass</td>
+  <td>Ends the override/decorator asymmetry and the "which do I use?" folklore (weakness 2). Medium risk —
+      touches every contributor, so worth a codemod.</td></tr>
+<tr><td class="p3">P3</td>
+  <td>Replace the <code>runActionById</code> singleton with a runtime-scoped service obtained from context</td>
+  <td>Removes global mutable state + mount-coupling (weakness 5). Mostly mechanical; low urgency.</td></tr>
+<tr><td class="p3">P3</td>
+  <td>Tidy context generics (drop the <code>as never</code>/<code>bivarianceHack</code> by modeling
+      scope vs deps separately, or accept and document them)</td>
+  <td>Cosmetic/type-hygiene (weakness 6). Only worth it if touching the area anyway.</td></tr>
+</table>
+
+<h2>Explicitly NOT worth doing</h2>
+<ul class="tight">
+  <li><strong>Don't replace facets</strong> with a registry/event-bus. The contribution model is the part
+      that works; churning it buys nothing.</li>
+  <li><strong>Don't collapse contexts into a flat keymap.</strong> The scope concept earns its keep
+      (modal, dependency typing, per-surface activation). The problem is resolution <em>across</em> contexts,
+      not contexts themselves.</li>
+  <li><strong>Don't chase the type-generics cleanup on its own.</strong> Real but low-value; bundle it into
+      P1/P2 or skip.</li>
+</ul>
+
+<div class="verdict">
+<strong>Bottom line.</strong> The action system is fundamentally sound; the friction is concentrated in
+<em>resolution</em> (smeared across three paths with inconsistent semantics) and the <em>transform pipeline</em>
+(three overlapping mechanisms with arbitrary differences). The single highest-value move is <strong>P1: a
+single resolution core</strong> — and the precedence work in PR #57 is the natural first slice of it, if we
+build that change as "introduce the resolver" rather than "add a dedup to the loop." If we only ever do one
+thing here, do that. The rest (canRun identity, pipeline unification) are worthwhile follow-ups, not
+prerequisites. No rewrite warranted.
+</div>
+
+<h2>Relationship to PR #57 (precedence)</h2>
+<p>PR #57 stays docs-only and ships the narrow precedence model. This critique argues its "shared comparator
+used by both paths" recommendation is the <em>seed</em> of P1 above — so when precedence is implemented, it's
+worth spending the marginal effort to land it <em>as</em> the resolution core (one <code>resolve()</code> the
+keyboard and dispatch paths share) rather than as a dedup bolted onto the install loop. Same user-visible
+outcome; pays down weakness 1 instead of deepening it. That's an implementation-time decision, recorded here
+so it isn't lost.</p>
+
+</body>
+</html>

--- a/docs/action-system-critique.html
+++ b/docs/action-system-critique.html
@@ -93,8 +93,8 @@ alone" — not a rewrite. Flagging this so the list of weaknesses below isn't re
 
 <h2>Weaknesses — grouped by theme</h2>
 
-<h3>1. Resolution is implemented three times and the keyboard one disagrees</h3>
-<p>"Given an active set, which action handles X?" is answered in three places:</p>
+<h3>1. Resolution is implemented three four times and the keyboard one disagrees</h3>
+<p>"Given an active set, which action handles X?" is answered in <strong>four</strong> places:</p>
 <ul class="tight">
   <li><code>runActionById</code> → the module dispatcher installed by HotkeyReconciler
       (<span class="filepath">HotkeyReconciler.tsx:174</span>) → <code>getActiveActionById</code>
@@ -103,9 +103,19 @@ alone" — not a rewrite. Flagging this so the list of weaknesses below isn't re
       <code>getActiveActionById</code>, but re-implements the deps-lookup/throw around it.</li>
   <li>The keyboard path → <strong>no resolution at all</strong>; every active action installs its own
       listener, so collisions double-fire (the bug the precedence doc fixes).</li>
+  <li><strong>A plugin-level fork:</strong> swipe-quick-actions' <code>runBlockAction</code>
+      (<span class="filepath">SwipeActionMenu.tsx:340</span>) bypasses <em>all</em> of the above. It reaches
+      into <code>getEffectiveActions(runtime)</code>, <strong>hand-assembles deps</strong>
+      (<code>{block, uiStateBlock, …renderScopeId}</code>), gates on <code>canRun</code>, and calls
+      <code>action.handler(deps, trigger)</code> directly — because the dispatcher requires the action's
+      context (e.g. <code>NORMAL_MODE</code>) to be active, and a swipe gesture is its own activation with no
+      such context up. This is the worst of the four: a <em>plugin</em> re-implementing core dispatch by
+      reaching into registry internals, and it's a preview of the input-unification problem (a non-keyboard
+      trigger dispatching a block action with caller-held deps). See weakness 6 — the push-only supply model
+      is <em>why</em> it had to fork.</li>
 </ul>
-<p class="weak">There is no single "resolve event → action" function. The keyboard path and the dispatch
-path have <em>different</em> semantics (double-fire vs single-winner) for what is conceptually one question.
+<p class="weak">There is no single "resolve event → action" function. The four paths have <em>different</em>
+semantics (double-fire vs single-winner vs hand-rolled) for what is conceptually one question.
 Precedence (priority/modal) then has to be taught to each path separately. <strong>This is the deepest
 structural issue and the one the precedence work half-forces us to confront.</strong></p>
 
@@ -134,15 +144,23 @@ rewrite the action list, with subtle, undocumented differences:</p>
 </ul>
 
 <h3>3. <code>canRun</code> looks authoritative but is presentational</h3>
-<p><code>canRun</code> reads like a guard, but it gates only UI surfaces (palette, swipe menu); the keyboard
-and <code>runActionById</code> paths never call it (<span class="filepath">types.ts:148–156</span> spells this
-out, but the name fights the doc).</p>
+<p><code>canRun</code> reads like a guard, and <span class="filepath">types.ts:148–156</span> documents it as
+presentational-only — the keyboard and <code>runActionById</code> paths never call it. But the name fights
+the doc, and the contract is <strong>already violated in practice</strong>.</p>
 <ul class="tight">
-  <li class="weak">The user's skip-decorators exist <em>because</em> there's no dispatch-level "should this
-      run?" — they fake one by mutating the handler. A real predicate-at-dispatch (the precedence doc's
-      Option D) is the missing concept <code>canRun</code> appears to promise but doesn't deliver.</li>
-  <li class="weak">Name implies authority it doesn't have. <code>isApplicableForDisplay</code> would be honest;
-      or make it actually gate dispatch and the skip-decorator pattern evaporates.</li>
+  <li class="weak"><strong>The "presentational-only" invariant is already false.</strong> swipe's
+      <code>runBlockAction</code> (<span class="filepath">SwipeActionMenu.tsx:351</span>) does
+      <code>if (action.canRun &amp;&amp; !action.canRun(deps)) return false</code> — using <code>canRun</code> as
+      a real dispatch gate, not a display filter. So a plugin already needed a dispatch-level "should this run?"
+      and the only thing on hand was the presentational predicate. The precedence doc leans on
+      "<code>canRun</code> never gates dispatch"; that's a documented contract a shipping plugin breaks. Direct
+      evidence the <code>canDispatch</code> concept is missing and being faked.</li>
+  <li class="weak">The user's skip-decorators exist for the same reason — no dispatch-level gate, so they fake
+      one by mutating the handler. A real predicate-at-dispatch (the precedence doc's Option D /
+      <code>canDispatch</code>) is the missing concept <code>canRun</code> appears to promise but doesn't deliver.</li>
+  <li class="weak">Fix: split into <code>isVisible</code> (UI, presentational) + <code>canDispatch</code>
+      (real dispatch gate, declinable). Then swipe's <code>canRun</code>-as-gate, the skip-decorators, and the
+      scattered guards all collapse onto the one honest mechanism.</li>
 </ul>
 
 <h3>4. Precedence is incidental because activation order is React-lifecycle order</h3>
@@ -159,14 +177,85 @@ mount and nulled on unmount. It works, but: it's global mutable state, it throws
 and it couples "can I dispatch an action" to "is this one React component mounted." For a system whose whole
 point is decoupled contribution, the dispatch entry point being a singleton side-channel is a wart.</p>
 
-<h3>6. Context conflates scope and dependency-bundle</h3>
-<p>An <code>ActionContextConfig</code> is simultaneously (a) an activation scope that gates install, (b) a
-modal/precedence tier, and (c) a typed dependency carrier (<code>validateDependencies</code> +
-<code>ShortcutDependenciesMap</code>). These mostly co-vary, but the conflation shows up as type friction:
-<code>as never</code> / <code>as ActionConfig</code> casts in the override/decorator pipeline
-(<span class="filepath">effectiveActions.ts:52,57</span>) and the <code>bivarianceHack</code> in
-<code>ActionHandler</code> (<span class="filepath">types.ts:126</span>). The generics are being fought rather
-than expressing the model.</p>
+<h3>6. Context conflates scope and dependency-bundle — and dependency <em>supply</em> is the deeper issue</h3>
+<p>An <code>ActionContextConfig</code> (and the context identifier like <code>'normal-mode'</code>) does three
+jobs with different lifecycles: (a) an activation <strong>scope</strong> that gates install, (b) a
+<strong>precedence</strong> tier (<code>modal</code>, future <code>priority</code>), and (c) a typed
+<strong>dependency bundle</strong> (<code>validateDependencies</code> + <code>ShortcutDependenciesMap</code>).
+(a) and (b) legitimately co-vary. The smell is fusing <strong>(c) — per-activation runtime instance data —
+onto the same identifier as the static config</strong>.</p>
+
+<p>This surfaces as type friction (the symptom) and a supply limitation (the real issue).</p>
+
+<h4 style="font-size:.95rem;margin:.8rem 0 .3rem">Symptom: the variance casts</h4>
+<ul class="tight">
+  <li><code>ActiveContextsMap</code> stores the <em>widened base</em> (<code>BaseShortcutDependencies</code>),
+      because a heterogeneous "each key a different value type" map isn't expressible. <code>active.get('normal-mode')</code>
+      returns the base; the narrow type is recovered only by trusting <code>validateDependencies</code> ran.</li>
+  <li><code>override.apply(action as never)</code> (<span class="filepath">effectiveActions.ts:52,57</span>) —
+      a per-<code>T</code> transform applied over a flattened heterogeneous <code>ActionConfig[]</code>; casts
+      to <code>never</code> to silence variance.</li>
+  <li><code>bivarianceHack</code> on <code>ActionHandler</code> (<span class="filepath">types.ts:126</span>) —
+      exists purely to store <code>ActionHandler&lt;NormalMode&gt;</code> in a collection typed for the union.</li>
+  <li>Latent ceiling: deps in a type-keyed slot ⇒ you can't have two simultaneously-active instances of the
+      same context with different deps (two panels both in normal-mode, different focused blocks). Re-activation
+      overwrites. Harmless today; a real wall later.</li>
+</ul>
+
+<h4 style="font-size:.95rem;margin:.8rem 0 .3rem">The real issue: two axes — typing vs supply</h4>
+<p>"Handler-declared deps" (deps type rides with the handler, context goes back to pure scope+precedence)
+fixes <em>typing</em>. But supply is a separate axis, and it's where coherence lives:</p>
+<ul class="tight">
+  <li><strong>Typing</strong> — who owns the dep type? Context (today) vs handler.</li>
+  <li><strong>Supply</strong> — who produces the value, and when? <em>Pushed</em> at activation (today: closure
+      into the active map) vs <em>pulled/provided</em> at dispatch.</li>
+</ul>
+<p>Today is context-keyed + pushed. Because deps live in the active map, <strong>to dispatch an action you must
+be its active context</strong> — even if you already hold every dep it needs. That single constraint is what
+forces swipe's fork (weakness 1): the swipe handler has <code>block</code> and <code>uiStateBlock</code> in
+hand but no way to hand them to the dispatcher, so it bypasses dispatch entirely and calls the handler raw.
+<strong>swipe is hand-rolling the supply model the system doesn't offer.</strong></p>
+
+<h4 style="font-size:.95rem;margin:.8rem 0 .3rem">The coherent target: scopes provide typed capabilities</h4>
+<p>Active scopes become <em>providers</em> of typed tokens; actions declare what they <em>consume</em>; at
+dispatch the resolver walks active scopes in precedence order to fill each needed token:</p>
+<pre><code>activate({ scope: NORMAL_MODE, provides: { [BlockToken]: () =&gt; block } })
+{ needs: [BlockToken], handler: (deps /* {block} */, trigger) =&gt; … }
+// resolve(): pick winner → fill needs from {active scopes} ∪ {caller/trigger-supplied}
+//            a token with no provider ⇒ not dispatchable  ⇒ this IS canDispatch</code></pre>
+<p>This is, structurally, <strong>React-context-for-actions</strong>: a scoped DI container where the active
+scope stack is the provider chain and the comparator picks the winning provider. Payoffs beyond the casts:</p>
+<ul class="tight">
+  <li><strong>Staleness + ref machinery go away.</strong> Getters read fresh at dispatch, so a scope activates
+      <em>once</em> instead of re-activating on every dep-identity change — retiring much of HotkeyReconciler's
+      <code>activeRef</code>/<code>useLayoutEffect</code> dance and the staleness window.</li>
+  <li><strong><code>canDispatch</code> unifies with availability</strong> — "can it run?" = "do its needed
+      tokens resolve right now?". One mechanism replaces <code>canRun</code>-as-gate + skip-decorators + guards.</li>
+  <li><strong>Caller/trigger-supplied tokens dissolve the swipe fork</strong> — swipe supplies
+      <code>BlockToken</code> and dispatches through the one path; same seam input-unification needs for
+      mouse/touch.</li>
+  <li><strong>On the path to focus-tree, not a divergence.</strong> Providers-as-getters → providers-as-React-context;
+      "walk active scopes for a token" → "read up the tree". The focus-tree model is this model where the
+      provider chain <em>is</em> the component tree.</li>
+</ul>
+
+<h4 style="font-size:.95rem;margin:.8rem 0 .3rem">What helps vs. what's overkill</h4>
+<ul class="tight">
+  <li class="keep"><strong>Cheap, do now (Phase 1):</strong> make <code>resolve()</code>'s deps-narrowing
+      <em>one explicit validated seam</em>, and source deps from <strong>{active scopes} ∪ {caller-supplied}</strong>
+      — not active-map-only. This alone lets swipe's fork collapse back into <code>resolve()</code> and gives
+      input-unification its shape, without the full token registry.</li>
+  <li class="keep"><strong>Cheap, do at P2:</strong> design the unified transform type <em>erased</em>
+      (<code>(action) → action | null</code>, no <code>T</code>) so the cast moves from the pipeline to the
+      contributor's definition site (where <code>T</code> is known). Removes the <code>as never</code>.</li>
+  <li class="meh"><strong>Full provider/capability DI (the token registry + getters everywhere):</strong> the
+      real fix for typing <em>and</em> supply, but a rework of all ~27 activation sites. Justified only once
+      <strong>dep shapes grow faster than contexts</strong> — swipe + input are the first two data points;
+      adopt when there's a third, or when the focus-tree prototype lands (they're the same model).</li>
+</ul>
+<p>So #6 is mis-rated as pure cosmetics: the <em>casts</em> are cosmetic, but the <em>supply</em> model is the
+coherence question, and it already costs us one forked dispatch path. The P3 "model scope vs deps separately"
+is the endgame; the Phase-1 seam is the down payment that prevents building it twice.</p>
 
 <h2>The unifying idea: one resolution core</h2>
 <div class="axes">

--- a/docs/action-system-critique.html
+++ b/docs/action-system-critique.html
@@ -174,9 +174,12 @@ Most of the weaknesses above (1, 3, 4, partly 5) are the same shape: <strong>the
 owns "active set + event → which action runs."</strong> Resolution is smeared across per-action listeners,
 two dispatch helpers, a presentational predicate, and an implicit lifecycle ordering. The high-leverage
 refactor is to introduce <em>one</em> resolver and route every path through it:
-<pre><code>resolve(activeSet, event | actionId): ActionConfig | null
+<pre><code>resolve(activeSet, trigger): ActionConfig | null
+  // trigger = actionId | normalized input descriptor
+  //   descriptor: {kind:'key'|'mouse'|'touch'|…, modifiers, phase, role, …}
+  //   NOT a raw KeyboardEvent — canonicalization (chord/descriptor) sits
+  //   behind the shared canonicalizer so non-key triggers reuse the matcher
   // single comparator: (priority desc, activation-recency desc)
-  // single canonicalization of chords
   // single place to add modal / declinable / future tiers</code></pre>
 Keyboard dispatch, <code>runActionById</code>, and <code>useRunAction</code> all call it. Precedence,
 canonicalization, modal, and (if chosen) declinable fall-through become properties of the resolver, defined
@@ -184,23 +187,49 @@ once, instead of being re-taught to each path. This is also exactly what the pre
 comparator, used by both paths" bullet is reaching for — generalized.
 </div>
 
+<div class="note">
+<strong>Downstream consumer (2026-05-30): input unification.</strong> Spatial-navigation/selection work on
+another branch is hitting the input-side mirror of weakness 1 — mouse/click/gesture handling is smeared across
+~5 bespoke facets (<code>blockClickHandlersFacet</code>, <code>blockContentSurfacePropsFacet</code>,
+<code>blockGestureConflictsFacet</code>, <code>blockContentDecoratorsFacet</code>, and a new
+<code>blockSelectionClickDecoratorsFacet</code>). The intent downstream is to route <em>all</em> input through
+this same <code>resolve()</code> — which is why the <code>trigger</code> arg is a normalized descriptor, not a
+<code>KeyboardEvent</code>, and why <code>phase</code>/<code>role</code> must be first-class binding fields
+(a double-click gesture binds at <code>mousedown</code> on the content node to beat native text selection).
+This turns two of the prioritized items below from "nice cleanup" into "unblocks active work": the resolver
+itself (a click handler needs declinable "not mine — fall through" dispatch, which is the same mechanism as a
+shortcut yielding a key), and the <code>canDispatch</code> split (the declarative gate that replaces both the
+imperative skip-decorators and the scattered <code>if (isSelectionClick(event)) return</code> guards).
+<strong>This composes with — does not compete with — the focus-derived activation-model exploration:</strong>
+<code>resolve()</code> consumes an active set; the activation model produces one. Either source of
+<code>activeSet</code> feeds the same resolver, so pursuing the resolver now doesn't foreclose that rework.
+</div>
+
 <h2>What's worth doing — prioritized</h2>
 <table class="prio">
 <tr><th>Priority</th><th>Change</th><th>Why / payoff</th></tr>
 <tr><td class="p1">P1</td>
   <td>Single resolution core; route keyboard + both dispatch helpers through it
-      (subsumes the precedence doc's comparator + the double-fire fix)</td>
-  <td>Kills the keyboard/dispatch divergence (weakness 1), gives precedence/canonicalization/modal one home,
-      makes Option D a localized change later instead of a rewrite. Highest leverage.</td></tr>
+      (subsumes the precedence doc's comparator + the double-fire fix). Build it as the
+      <strong>fire-time, declinable</strong> coordinator (precedence-doc Option D), with the
+      <code>trigger</code> as a normalized descriptor — not a dedup bolted onto the install loop.</td>
+  <td>Kills the keyboard/dispatch divergence (weakness 1), gives precedence/canonicalization/modal one home.
+      The dedup-in-loop variant would leave the keyboard path as N independent <code>window</code> listeners that
+      input-unification must then tear out and rebuild — so building it that way is negative work. Highest leverage.</td></tr>
 <tr><td class="p1">P1</td>
   <td>Decide <code>canRun</code>'s identity: either rename to a display-only name, or split into
       <code>isVisible</code> (UI) + <code>canDispatch</code> (gate)</td>
-  <td>Removes the reason skip-decorators exist (weakness 3). Cheap, clarifies a contract people already misuse.</td></tr>
+  <td>Removes the reason skip-decorators exist (weakness 3). <code>canDispatch</code> is the declarative
+      "not me — fall through" gate the input-unification work needs to replace its click guards; land it
+      <em>with</em> the resolver. Cheap, clarifies a contract people already misuse.</td></tr>
 <tr><td class="p2">P2</td>
   <td>Unify the transform pipeline: one <code>(action) → action | null</code> transform type with a
-      documented phase, fold decorator/override into it; keep keybinding-override as the one cross-action pass</td>
-  <td>Ends the override/decorator asymmetry and the "which do I use?" folklore (weakness 2). Medium risk —
-      touches every contributor, so worth a codemod.</td></tr>
+      documented phase, fold decorator/override into it; keep keybinding-override as the one cross-action pass.
+      <em>Sequence close behind the resolver, not stacked into one PR.</em></td>
+  <td>Ends the override/decorator asymmetry and the "which do I use?" folklore (weakness 2). Also the type that
+      vim's skip-decorators <em>and</em> the downstream <code>blockSelectionClickDecoratorsFacet</code> both
+      collapse into — so it directly retires input-side duplication too. Medium risk — touches every contributor,
+      so worth a codemod.</td></tr>
 <tr><td class="p3">P3</td>
   <td>Replace the <code>runActionById</code> singleton with a runtime-scoped service obtained from context</td>
   <td>Removes global mutable state + mount-coupling (weakness 5). Mostly mechanical; low urgency.</td></tr>

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -123,8 +123,9 @@ Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds var
   <li>Comparator <code>(priority desc, then activation-recency desc)</code>, <code>global</code> as reserved
       top tier, <code>modal</code> preserved. Shared with <code>getActiveActionById</code> so the dispatch and
       keyboard paths can't diverge.</li>
-  <li><code>priority?: number</code> (named tiers) on <code>ActionContextConfig</code> → fixes the surface
-      early/late inversion.</li>
+  <li><code>priority</code> as <strong>named tiers</strong> <code>'low' | 'default' | 'high'</code> (see
+      "Precedence tiers" below — <em>not</em> a raw <code>number</code>) on <code>ActionContextConfig</code> →
+      fixes the surface early/late inversion.</li>
   <li><code>canRun</code> → <code>isVisible</code> (UI) + <code>canDispatch</code> (dispatch gate).
       <code>canDispatch</code> ships <em>with</em> the coordinator — it's the skip predicate the single-winner
       loop iterates on (PR&nbsp;1); the handler-return sentinel joins it as a second skip-condition in PR&nbsp;2.</li>
@@ -142,14 +143,22 @@ That loop already exists, so it closes the double-fire and fixes the early/late 
 downstream. <strong>PR&nbsp;2</strong> adds <em>only</em> the declinable fall-through: widen the handler return
 to a not-handled sentinel and add "handler returned <code>false</code>" as one more skip-condition to the loop
 PR&nbsp;1 already wrote (Option&nbsp;D). That is <strong>pure addition — no listener wiring is rewritten or
-discarded.</strong> So the split boundary is "everything the bug fix needs" (PR&nbsp;1, incl. the coordinator)
+discarded.</strong> <strong>Scope that claim precisely:</strong> "no rework" is about the <em>listener wiring</em>
+specifically. PR&nbsp;2 still <em>widens the shared <code>ActionHandler</code> return type</em> (add the
+not-handled sentinel). That is back-compat — <code>void</code> = handled, so no handler is <em>forced</em> to
+change — but it touches a signature that <strong>~176 <code>handler:</code> definitions across ~49 files</strong>
+structurally depend on, so budget PR&nbsp;2 as a wide-blast-radius type review even though nothing breaks. So the
+split boundary is "everything the bug fix needs" (PR&nbsp;1, incl. the coordinator)
 vs. "the dispatch-contract change the downstream input work needs" (PR&nbsp;2): PR&nbsp;1 can merge immediately;
 PR&nbsp;2 lands with / just ahead of the spatial-selection branch that is its only fall-through consumer.
-<strong>Option&nbsp;D remains the committed target.</strong> Note the trade: building the coordinator in
-PR&nbsp;1 (rather than keeping per-action listeners and deferring the rewrite) front-loads the one mechanically
-risky change — the reconciler rewrite, which carries the documented <code>useEffectEvent</code> regression
-history — into the bug-fix PR. It is not speculative there: single-winner dispatch needs a single dispatcher
-anyway. The earlier "negative work" warning applies only to the <em>other</em> way to fix the bug
+<strong>Option&nbsp;D remains the committed target.</strong> Note the trade — and don't mis-scope PR&nbsp;1 as
+"small": building the coordinator in PR&nbsp;1 (rather than keeping per-action listeners and deferring the
+rewrite) front-loads the one mechanically risky change — the reconciler rewrite, which carries the documented
+<code>useEffectEvent</code> regression history — into the bug-fix PR. It is not speculative there: the coordinator
+is the single-winner decision point that PR&nbsp;2 builds on, so it isn't discarded. (Strictly, a per-listener
+self-check against the shared comparator could fix <em>only</em> the double-fire at lower mechanical risk — but
+it gets thrown out once Option&nbsp;D lands, so it's only the lower-risk choice if Option&nbsp;D were ever
+dropped.) The earlier "negative work" warning applies to that <em>other</em> way to fix the bug
 (activation-time install-filtering / per-listener self-check), which this plan explicitly does not do precisely
 because it would be thrown out at PR&nbsp;2.</p>
 <p><strong>Retires:</strong> the double-fire (bug); critique weakness 1 (keyboard/dispatch divergence) and the
@@ -188,7 +197,25 @@ candidates that have <em>already</em> completed a match this event. Read the <co
 keyboard <code>Trigger</code> as "the chord that just completed" (used for ordering / dedup / logging), not as
 the matcher input. Do <em>not</em> reduce a keydown to one descriptor and hand it to <code>resolve</code> to
 match — that path is exactly how <code>g g</code> went dead historically
-(<span class="filepath">vim-normal-mode/actions.ts:204–208</span>).</p>
+(<span class="filepath">vim-normal-mode/actions.ts:204–208</span>). And keep <code>resolve</code>'s internal
+<code>Trigger</code> distinct from what the <em>handler</em> receives: handlers keep their existing second arg
+<code>ActionTrigger = KeyboardEvent | CustomEvent</code> (<span class="filepath">types.ts:108</span>) — the raw
+event still flows through to the handler; the <code>ChordDescriptor</code> is internal to resolution/ordering and
+is never handed to handlers.</p>
+<p><strong>Coordinator control flow (the highest-regression-risk seam in PR&nbsp;1 — spell it out, don't just
+say "keep a matcher"):</strong> keep <em>one tinykeys matcher per candidate binding</em> (today's
+<code>createKeybindingsHandler</code>, <span class="filepath">HotkeyReconciler.tsx:257</span>). On each keydown
+/ keyup the coordinator feeds the event to <em>every</em> candidate's matcher; tinykeys fires a binding's
+callback <em>synchronously</em> when <em>that</em> binding's sequence completes on this event. Rewire each
+callback to <strong>push its candidate into a "completed-this-event" set</strong> instead of running the handler
+directly. After feeding all candidates, the coordinator <strong>orders the completed set via
+<code>compareContexts</code> and runs the loop</strong> (<code>canDispatch</code> → <code>resolveDeps</code> →
+handler; run-until in PR&nbsp;2). Because tinykeys completion is synchronous within the event dispatch,
+collect-then-order happens in the same tick — no async-ordering hazard. Multiple candidates can complete on one
+keypress (two contexts both bind <code>g g</code>) — that is precisely the collision the comparator resolves;
+single chords are the degenerate length-1 case. This per-candidate-matcher → collect → order → run-loop is the
+substantive new design in PR&nbsp;1, not "addition," and it is where <code>g g</code>/<code>d d</code> will
+regress if guessed wrong — give it dedicated sequence tests.</p>
 <p><strong>Precedence tiers (named, not raw ints — CodeMirror <code>Prec</code> precedent):</strong>
 <code>type Priority = 'low' | 'default' | 'high'</code> on <code>ActionContextConfig</code> (default
 <code>'default'</code>). <code>global</code> = reserved top; <code>modal</code> orthogonal (own-all-chords).
@@ -212,7 +239,8 @@ while still letting a mode own its cancel key, and is closest to today's behavio
 <p><strong>File map:</strong></p>
 <ul class="tight">
   <li><code>src/shortcuts/resolve.ts</code> — new; <code>resolve</code> + <code>compareContexts</code> (pure).</li>
-  <li><code>src/shortcuts/types.ts</code> — add <code>priority</code> to <code>ActionContextConfig</code>;
+  <li><code>src/shortcuts/types.ts</code> — add <code>priority: 'low' | 'default' | 'high'</code> (named tier,
+      default <code>'default'</code>) to <code>ActionContextConfig</code>;
       split <code>canRun</code> → <code>isVisible</code> + <code>canDispatch</code>; widen
       <code>ActionHandler</code> return to allow a "not handled" sentinel (<code>boolean</code>;
       <code>void</code> = handled, for back-compat). <strong>Async rule:</strong> the not-handled signal must be
@@ -231,13 +259,17 @@ while still letting a mode own its cancel key, and is closest to today's behavio
       per-action <code>window.addEventListener</code> install loop with <em>one</em> keydown + one keyup
       coordinator that: normalize event → <code>ChordDescriptor</code> (Phase 0) → gather candidates whose
       <code>(chord, phase)</code> match and whose context is installable → order via <code>compareContexts</code>
-      → run until one's <code>canDispatch</code> passes and its handler returns "handled". Preserve
+      → run down the ordered candidates and dispatch the first whose <code>canDispatch</code> passes (PR&nbsp;1);
+      in PR&nbsp;2 a handler returning the not-handled sentinel also falls through. Preserve
       <code>withRecoveredLetterKey</code>, the existing <code>shouldHandleEvent</code> filter cascade, the
       separate hold-binding observer, <code>eventOptions</code> (preventDefault/stopPropagation) precedence,
       and <strong>tinykeys sequence state</strong> (<code>d d</code>, <code>g g</code>) — keep a per-candidate
       sequence matcher; don't reduce each event to a single chord.</li>
   <li><code>src/shortcuts/runAction.ts</code> — <code>runActionById</code>/<code>useRunAction</code> go through
-      <code>resolve(..., {kind:'action', actionId})</code> + the shared deps seam.</li>
+      <code>resolve(..., {kind:'action', actionId})</code> + the shared deps seam. <strong>Migrate both copies:</strong>
+      the module dispatcher (<span class="filepath">runAction.ts:15</span>) and <code>useRunAction</code> each have
+      their <em>own</em> lookup + "not found / context not active" throw (<span class="filepath">runAction.ts:51–56</span>) —
+      easy to migrate one and miss the other.</li>
   <li>Call sites that pass deps: keep working via the seam (see below).</li>
 </ul>
 
@@ -246,8 +278,13 @@ action installs its own <code>window</code> listener, so a binding's <code>stopP
 <em>sibling</em> action-listeners (that sibling-listener model is the root of the double-fire). With one
 coordinator, losing candidates are loop entries, not separate listeners — there's nothing left among them for
 <code>stopPropagation</code> to stop. It still matters versus the separate <em>hold</em> observer and any
-app-level listeners. Audit every binding that sets <code>stopPropagation</code>, decide what it should now mean,
-and add a regression test — this is a behavior change hiding inside "preserve <code>eventOptions</code>."</p>
+app-level listeners. <strong>Heads-up for the audit:</strong> no in-repo binding actually sets
+<code>stopPropagation: true</code> today — every <code>eventOptions</code>/<code>defaultEventOptions</code> only
+sets <code>preventDefault</code> (the binding default is <code>stopPropagation: false</code> at
+<span class="filepath">HotkeyReconciler.tsx:443/470</span>), so the in-repo audit comes back empty. The real
+consumers are the hold observer, app-level listeners, and <em>plugins</em>. Write the regression test against the
+<em>mechanism</em> (a binding declaring <code>stopPropagation: true</code>), not against a pre-existing in-tree
+case — there isn't one. This is a behavior change hiding inside "preserve <code>eventOptions</code>."</p>
 
 <p><strong>Deps seam (the Phase-1 slice of the dependency model):</strong> one function
 <code>resolveDeps(action, active, supplied?) → deps | null</code> that merges the action's active-context deps

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -85,6 +85,23 @@ one (not chord-only). Retrofit <code>keybindingConflicts.ts</code> off it.</p>
 everything. <span class="filepath">Addresses: precedence-doc "canonicalization is not free" review finding.</span></p>
 <p><strong>Done when:</strong> alias-equivalent chords (<code>Meta+K</code> / <code>$mod+k</code>) and
 reordered modifiers compare equal; one shared helper, used by dedup + conflict detection.</p>
+<p><strong>Files &amp; shape:</strong></p>
+<pre><code>// new: src/shortcuts/canonicalizeChord.ts
+export type ChordDescriptor = {
+  kind: 'key'                       // Phase 3 adds 'mouse' | 'touch'
+  key: string                       // canonical, e.g. 'k'
+  mods: readonly Modifier[]         // SORTED + alias-folded: cmd|meta|os → $mod
+  phase: 'keydown' | 'keyup' | 'hold'
+}
+export const canonicalizeChord = (raw: string, phase?: Phase): string  // stable string key
+export const parseChord = (raw: string): ChordDescriptor                // for matching
+</code></pre>
+<p><strong>Steps:</strong> (1) move <code>normalizeChord</code> body out of
+<span class="filepath">keybindings-settings/keyCapture.ts</span> into the new module; (2) add modifier
+<em>sorting</em> (today it folds aliases + lowercases but doesn't sort — that's the gap the review flagged);
+(3) re-export from <code>keyCapture.ts</code> so the settings UI is unchanged; (4) point
+<code>keybindingConflicts.ts</code>' <code>toChordArray</code> bucketing at the canonical key.
+Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds variants, not a rewrite.</p>
 </div>
 
 <div class="phase">
@@ -119,6 +136,72 @@ the next candidate; sequence chords (<code>d d</code>) still fire under the coor
 <p><strong>Carries the load-bearing invariant comment:</strong> resolution is correct because
 <code>eventFilter</code> only expands, never declines-and-defers — declinable handling is the supported
 fall-through, not filter scoping.</p>
+
+<p><strong>Core signature &amp; types:</strong></p>
+<pre><code>// new: src/shortcuts/resolve.ts
+type Trigger =
+  | { kind: 'action'; actionId: string }          // runActionById / useRunAction
+  | ChordDescriptor                                // keyboard now; mouse/touch in Phase 3
+
+// pure, unit-testable, no React/DOM:
+resolve(
+  actions: readonly ActionConfig[],   // effective actions (post-transform)
+  active: ActiveContextsMap,
+  trigger: Trigger,
+): readonly ActionConfig[]            // ORDERED candidates, best-first
+
+// comparator (the single source of precedence, shared with getActiveActionById):
+compareContexts(a, b): number  // 1) modal-over-global rule  2) priority desc  3) recency desc
+</code></pre>
+<p><strong>Precedence tiers (named, not raw ints — CodeMirror <code>Prec</code> precedent):</strong>
+<code>type Priority = 'low' | 'default' | 'high'</code> on <code>ActionContextConfig</code> (default
+<code>'default'</code>). <code>global</code> = reserved top; <code>modal</code> orthogonal (own-all-chords).
+The reporting surface declares <code>'high'</code> to beat <code>normal-mode</code>. Keep the set tiny; add a
+tier only when a real case needs one.</p>
+
+<p><strong>The <code>global</code>-vs-<code>modal</code> sub-question (the "Escape case") — DECIDE before coding:</strong>
+<code>global</code> owns <code>Escape</code> (clear focus) as reserved top tier, but a modal mode (e.g. scrub)
+wants <code>Escape</code> to cancel <em>itself</em>. <strong>Recommended &amp; assumed by this plan: an active
+<code>modal</code> context may override <code>global</code> on a shared chord</strong> (consistent with modal
+already being the tier that suppresses everything else). Encode as: comparator ranks active-<code>modal</code>
+above <code>global</code>, <code>global</code> above all other tiers. If you instead want <code>global</code>
+absolutely inviolable, modals must bind a non-<code>Escape</code> cancel key — flag back before building.</p>
+
+<p><strong>File map:</strong></p>
+<ul class="tight">
+  <li><code>src/shortcuts/resolve.ts</code> — new; <code>resolve</code> + <code>compareContexts</code> (pure).</li>
+  <li><code>src/shortcuts/types.ts</code> — add <code>priority</code> to <code>ActionContextConfig</code>;
+      split <code>canRun</code> → <code>isVisible</code> + <code>canDispatch</code>; widen
+      <code>ActionHandler</code> return to allow a "not handled" sentinel (<code>boolean</code>;
+      <code>void</code> = handled, for back-compat). Decide async: declination is a synchronous decision.</li>
+  <li><code>src/shortcuts/effectiveActions.ts</code> — <code>getActiveActionById</code> calls
+      <code>compareContexts</code> (kills the divergence).</li>
+  <li><code>src/shortcuts/HotkeyReconciler.tsx</code> — <strong>the big change.</strong> Replace the
+      per-action <code>window.addEventListener</code> install loop with <em>one</em> keydown + one keyup
+      coordinator that: normalize event → <code>ChordDescriptor</code> (Phase 0) → gather candidates whose
+      <code>(chord, phase)</code> match and whose context is installable → order via <code>compareContexts</code>
+      → run until one's <code>canDispatch</code> passes and its handler returns "handled". Preserve
+      <code>withRecoveredLetterKey</code>, the existing <code>shouldHandleEvent</code> filter cascade, the
+      separate hold-binding observer, <code>eventOptions</code> (preventDefault/stopPropagation) precedence,
+      and <strong>tinykeys sequence state</strong> (<code>d d</code>, <code>g g</code>) — keep a per-candidate
+      sequence matcher; don't reduce each event to a single chord.</li>
+  <li><code>src/shortcuts/runAction.ts</code> — <code>runActionById</code>/<code>useRunAction</code> go through
+      <code>resolve(..., {kind:'action', actionId})</code> + the shared deps seam.</li>
+  <li>Call sites that pass deps: keep working via the seam (see below).</li>
+</ul>
+
+<p><strong>Deps seam (the Phase-1 slice of the dependency model):</strong> one function
+<code>resolveDeps(action, active, supplied?) → deps | null</code> that merges the action's active-context deps
+with optional <em>caller-supplied</em> deps, runs the context's <code>validateDependencies</code>, and is the
+<em>only</em> place the widened→narrow cast happens. <code>null</code> ⇒ not dispatchable (this is what
+<code>canDispatch</code>'s dep-availability check returns). Build it caller-suppliable now so swipe's
+<code>runBlockAction</code> fork can later pass <code>{block, uiStateBlock}</code> through <code>resolve()</code>
+instead of bypassing it — even though the swipe migration itself is Phase 3.</p>
+
+<p><strong>Suggested internal order within the PR:</strong> (1) <code>resolve</code> + <code>compareContexts</code>
+pure, with unit tests — no wiring; (2) <code>priority</code> type + <code>getActiveActionById</code> swap;
+(3) the <code>canRun</code> split; (4) rewrite the reconciler install loop onto the coordinator; (5)
+deps seam; (6) integration tests. Steps 1–3 are independently reviewable even within the one PR.</p>
 </div>
 
 <div class="phase">
@@ -133,6 +216,23 @@ reviewable change + codemod. Stacking into Phase 1 makes it unreviewable.</p>
 <p><strong>Retires:</strong> weakness 2 (override/decorator asymmetry, the "which do I use?" folklore); the
 <code>as never</code> casts (weakness 6 symptom); collapses vim's skip-decorators <em>and</em> the downstream
 <code>blockSelectionClickDecoratorsFacet</code> into one mechanism.</p>
+<p><strong>Shape &amp; files:</strong></p>
+<pre><code>// one type replaces ActionOverride + ActionDecorator:
+type ActionTransform = {
+  actionId: string | '*'
+  context?: ActionContextType
+  apply: (action: ActionConfig) => ActionConfig | null   // ERASED: no T → cast at def site, not pipeline
+}</code></pre>
+<ul class="tight">
+  <li><code>types.ts</code> — define <code>ActionTransform</code>; deprecate the two old types (keep aliases
+      one release for plugins).</li>
+  <li><code>extensions/core.ts</code> — collapse <code>actionOverridesFacet</code> + <code>actionDecoratorsFacet</code>
+      into one transform facet (or keep two facet ids but one type + one apply pass).</li>
+  <li><code>effectiveActions.ts</code> — single ordered transform pass; <code>null</code> drops the action
+      (the genuine unbind primitive). Document phase ordering vs the cross-action keybinding-override pass.</li>
+  <li><strong>Codemod</strong> the ~handful of existing decorators/overrides (srs-rescheduling, vim skip-decorators
+      once they exist post-Phase-1, etc.) to the new type.</li>
+</ul>
 </div>
 
 <div class="phase">
@@ -142,9 +242,21 @@ reviewable change + codemod. Stacking into Phase 1 makes it unreviewable.</p>
 <code>blockGestureConflictsFacet</code>, <code>blockContentDecoratorsFacet</code>,
 <code>blockSelectionClickDecoratorsFacet</code>) onto <code>resolve()</code>; collapse swipe's
 <code>runBlockAction</code> fork back into the one path.</p>
-<p><strong>Owner:</strong> the spatial-selection branch, not this track. This plan's job through Phase 2 is to
-<em>not foreclose</em> it — which the trigger-descriptor, <code>canDispatch</code>, and caller-supplied deps
-seam decisions all ensure.</p>
+<p><strong>Owner:</strong> the spatial-selection branch (<code>claude/shift-click-spatial-selection-SvXGG</code>),
+not this track. This plan's job through Phase 2 is to <em>not foreclose</em> it — which the trigger-descriptor,
+<code>canDispatch</code>, and caller-supplied deps seam decisions all ensure.</p>
+<p><strong>What Phase 1/0 must have left in place for this to be additive (not a rewrite):</strong></p>
+<ul class="tight">
+  <li><code>ChordDescriptor.kind</code> extensible → add <code>{kind:'mouse', button, detail, role, phase}</code>,
+      <code>{kind:'touch', …}</code>; <code>parseChord</code>/matcher branch on <code>kind</code>.</li>
+  <li><code>phase</code>/<code>role</code> already first-class on bindings → a double-click binds at
+      <code>mousedown</code> on the content node to beat native text selection (can't be keyboard-only).</li>
+  <li>The coordinator already owns dispatch → extend it to register pointer/touch listeners alongside
+      keydown/keyup, same candidate-ordering + run-until-handled path.</li>
+  <li><code>canDispatch</code> + caller-supplied deps seam → a click handler declares "this is a selection
+      gesture, not mine" by declining; swipe's <code>runBlockAction</code> collapses into <code>resolve()</code>
+      with <code>{block,…}</code> supplied.</li>
+</ul>
 </div>
 
 <h3>Opportunistic — fold in where already touching the code (not their own phases)</h3>
@@ -171,11 +283,12 @@ model at different levels of "derive from tree." See critique weakness 6 for the
 
 <h2>The separate bet — do NOT gate anything on it</h2>
 <div class="sep">
-<strong>Focus-tree activation model.</strong> Replace the flat, runtime-maintained <code>ActiveContextsMap</code>
-with an active set <em>derived from the focus/DOM tree</em>, and split the one <code>activate</code> verb into
-"establish scope" (containment, structural) vs "override" (precedence, declared). This is the genuine
-best-in-class move — it retires the timing-as-precedence <em>bug class</em> at the root (weakness 4) by killing
-the registry that can desync.
+<strong>Focus-tree activation model</strong> — tracked in
+<a href="https://github.com/Stvad/knowledge-medium/issues/101">issue #101</a>. Replace the flat,
+runtime-maintained <code>ActiveContextsMap</code> with an active set <em>derived from the focus/DOM tree</em>,
+and split the one <code>activate</code> verb into "establish scope" (containment, structural) vs "override"
+(precedence, declared). This is the genuine best-in-class move — it retires the timing-as-precedence
+<em>bug class</em> at the root (weakness 4) by killing the registry that can desync.
 <ul class="tight" style="margin-top:.5rem">
   <li><strong>It does NOT fix the surface bug</strong> — the surface wants to override <em>against</em>
       containment depth (it's the ancestor; the block is deeper), which needs the explicit priority/override

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -79,26 +79,34 @@ input-unification consumer, it's work that gets torn out.
 <div class="phase">
 <h3>Phase 0 — Shared canonicalizer <span class="pill arch">enabling</span></h3>
 <p><strong>What:</strong> lift <code>normalizeChord</code> (<span class="filepath">keybindings-settings/keyCapture.ts:205</span>)
-into <code>src/shortcuts/</code>, add modifier sorting, shape it as <strong>chord↔descriptor</strong> from day
-one (not chord-only). Retrofit <code>keybindingConflicts.ts</code> off it.</p>
+into <code>src/shortcuts/</code>, add <em>sequence-chord parsing</em>, shape it as <strong>chord↔descriptor</strong>
+from day one (not chord-only). Retrofit <code>keybindingConflicts.ts</code> off it.</p>
 <p><strong>Why first:</strong> Phases 1–3 all assume canonical comparison. Cheap, no behavior change, unblocks
 everything. <span class="filepath">Addresses: precedence-doc "canonicalization is not free" review finding.</span></p>
-<p><strong>Done when:</strong> alias-equivalent chords (<code>Meta+K</code> / <code>$mod+k</code>) and
-reordered modifiers compare equal; one shared helper, used by dedup + conflict detection.</p>
+<p><strong>Done when:</strong> alias-equivalent chords (<code>Meta+K</code> / <code>$mod+k</code>) compare equal
+(already true today, including modifier order — see Steps); <em>sequence</em> chords (<code>d d</code>,
+<code>g g</code>) parse into an ordered list of presses instead of one atomic key; one shared helper, used by
+dedup + conflict detection.</p>
 <p><strong>Files &amp; shape:</strong></p>
 <pre><code>// new: src/shortcuts/canonicalizeChord.ts
 export type ChordDescriptor = {
   kind: 'key'                       // Phase 3 adds 'mouse' | 'touch'
   key: string                       // canonical, e.g. 'k'
-  mods: readonly Modifier[]         // SORTED + alias-folded: cmd|meta|os → $mod
+  mods: readonly Modifier[]         // SORTED + alias-folded (ALREADY done today): cmd|meta|os → $mod
   phase: 'keydown' | 'keyup' | 'hold'
 }
-export const canonicalizeChord = (raw: string, phase?: Phase): string  // stable string key
-export const parseChord = (raw: string): ChordDescriptor                // for matching
+// a chord is a SEQUENCE of presses: 'd d' / 'g g' → two descriptors; ordinary chords are length 1.
+export type ChordSequence = readonly ChordDescriptor[]
+export const canonicalizeChord = (raw: string, phase?: Phase): string   // stable key; sequence-aware
+export const parseChord = (raw: string): ChordSequence                  // for matching; splits on SPACE first
 </code></pre>
 <p><strong>Steps:</strong> (1) move <code>normalizeChord</code> body out of
-<span class="filepath">keybindings-settings/keyCapture.ts</span> into the new module; (2) add modifier
-<em>sorting</em> (today it folds aliases + lowercases but doesn't sort — that's the gap the review flagged);
+<span class="filepath">keybindings-settings/keyCapture.ts</span> into the new module — it <em>already</em>
+alias-folds, lowercases, AND sorts modifiers (<span class="filepath">keyCapture.ts:236</span>, tested at
+<span class="filepath">test/keyCapture.test.ts:147</span>), so this is a relocation, not a fix;
+(2) add the <em>real</em> gap — <strong>sequence-chord parsing</strong>: today it splits on <code>+</code>
+only and treats a space-bearing token like <code>d d</code> / <code>g g</code> as a single atomic key, so the
+canonicalizer must split on space first into an ordered list of presses, then canonicalize each press;
 (3) re-export from <code>keyCapture.ts</code> so the settings UI is unchanged; (4) point
 <code>keybindingConflicts.ts</code>' <code>toChordArray</code> bucketing at the canonical key.
 Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds variants, not a rewrite.</p>
@@ -106,7 +114,7 @@ Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds var
 
 <div class="phase">
 <h3>Phase 1 — Resolver core + precedence + canDispatch <span class="pill bug">closes the bug</span> <span class="pill arch">lays the spine</span></h3>
-<p><strong>What (one PR, these are genuinely coupled):</strong></p>
+<p><strong>What (one or two PRs — see "what's coupled vs. what can split" below):</strong></p>
 <ul class="tight">
   <li><code>resolve(activeSet, trigger) → action</code> as a <strong>fire-time, declinable coordinator</strong>
       (precedence-doc Option D): one keydown/keyup listener, <code>trigger → ordered candidates →
@@ -122,9 +130,20 @@ Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds var
   <li><strong>Deps seam:</strong> resolve deps from <strong>{active scopes} ∪ {caller/trigger-supplied}</strong>,
       narrowed at <em>one</em> explicit validated boundary — not active-map-only, not scattered casts.</li>
 </ul>
-<p><strong>Why coupled:</strong> the coordinator with nothing to gate is half a feature; <code>canDispatch</code>
-without the coordinator has no caller; precedence without single-winner doesn't fix the bug. Splitting them
-ships dead code in either direction.</p>
+<p><strong>What's genuinely coupled vs. what can split:</strong> <code>resolve</code> + <code>compareContexts</code>
++ <code>priority</code> + single-winner dedup are coupled — precedence without single-winner doesn't fix the
+bug. But the <em>fire-time coordinator rewrite</em> (one listener, run-until-handled, the declinable
+handler-return sentinel = Option D) is separable from the bug fix. <strong>Recommended sequencing (two PRs):</strong>
+<em>PR&nbsp;1</em> ships the comparator + <code>priority</code> + <code>canDispatch</code> as a synchronous
+<em>pre-gate</em> + single-winner dedup, <strong>keeping the per-action listener model</strong> — this alone
+closes the double-fire and fixes the early/late inversion, and stays small enough to bisect if shortcuts break.
+<em>PR&nbsp;2</em> swaps to the fire-time coordinator and widens the handler return for declinable fall-through
+(Option&nbsp;D), landing with / just ahead of the spatial-selection branch that is its only fall-through
+consumer. <strong>Option&nbsp;D remains the committed target</strong> (per the downstream input-unification
+need) — this is sequencing, not a retreat to activation-time-only. The risk it manages: the coordinator
+rewrite is the single riskiest mechanical change and its sole fall-through consumer is a branch not present in
+this checkout, so if that branch slips, PR&nbsp;1 has still shipped the user-visible fix. (The earlier
+"splitting ships dead code" framing only holds once both consumers are real — true at PR&nbsp;2 time, not before.)</p>
 <p><strong>Retires:</strong> the double-fire (bug); critique weakness 1 (keyboard/dispatch divergence) and the
 swipe fork's reason-to-exist; weakness 3 (canRun-as-gate); weakness 4 symptom (priority escapes lifecycle
 ordering).</p>
@@ -153,6 +172,15 @@ resolve(
 // comparator (the single source of precedence, shared with getActiveActionById):
 compareContexts(a, b): number  // 1) modal-over-global rule  2) priority desc  3) recency desc
 </code></pre>
+<p><strong>Sequence chords vs. this signature — reconcile explicitly:</strong> a single
+<code>ChordDescriptor</code> cannot represent a <em>mid-sequence</em> keypress (the first <code>d</code> of
+<code>d d</code> completes no chord). So <em>matching</em> — including tinykeys-style sequence state — lives in
+the <strong>coordinator</strong>, per-candidate; <code>resolve()</code> only <strong>orders</strong> the
+candidates that have <em>already</em> completed a match this event. Read the <code>ChordDescriptor</code> in the
+keyboard <code>Trigger</code> as "the chord that just completed" (used for ordering / dedup / logging), not as
+the matcher input. Do <em>not</em> reduce a keydown to one descriptor and hand it to <code>resolve</code> to
+match — that path is exactly how <code>g g</code> went dead historically
+(<span class="filepath">vim-normal-mode/actions.ts:204–208</span>).</p>
 <p><strong>Precedence tiers (named, not raw ints — CodeMirror <code>Prec</code> precedent):</strong>
 <code>type Priority = 'low' | 'default' | 'high'</code> on <code>ActionContextConfig</code> (default
 <code>'default'</code>). <code>global</code> = reserved top; <code>modal</code> orthogonal (own-all-chords).
@@ -164,8 +192,14 @@ tier only when a real case needs one.</p>
 wants <code>Escape</code> to cancel <em>itself</em>. <strong>Recommended &amp; assumed by this plan: an active
 <code>modal</code> context may override <code>global</code> on a shared chord</strong> (consistent with modal
 already being the tier that suppresses everything else). Encode as: comparator ranks active-<code>modal</code>
-above <code>global</code>, <code>global</code> above all other tiers. If you instead want <code>global</code>
-absolutely inviolable, modals must bind a non-<code>Escape</code> cancel key — flag back before building.</p>
+above <code>global</code>, <code>global</code> above all other tiers. Two alternatives, if you'd rather not bake
+a permanent modal-over-global inversion into the one comparator everything routes through: (a) keep
+<code>global</code> absolutely inviolable and make modals bind a non-<code>Escape</code> cancel key; or
+(b) <strong>conditional global</strong> — <code>global</code>'s reserved chords carry an implicit "no modal
+active" filter, so scrub's <code>Escape</code> wins simply because <code>global</code>'s <code>Escape</code>
+isn't contending while a modal is up. Option (b) preserves "<code>global</code> is top tier" <em>as a rule</em>
+while still letting a mode own its cancel key, and is closest to today's behavior (modal shadows non-global;
+<code>global</code> stays installed). Flag the choice before building.</p>
 
 <p><strong>File map:</strong></p>
 <ul class="tight">
@@ -173,9 +207,18 @@ absolutely inviolable, modals must bind a non-<code>Escape</code> cancel key —
   <li><code>src/shortcuts/types.ts</code> — add <code>priority</code> to <code>ActionContextConfig</code>;
       split <code>canRun</code> → <code>isVisible</code> + <code>canDispatch</code>; widen
       <code>ActionHandler</code> return to allow a "not handled" sentinel (<code>boolean</code>;
-      <code>void</code> = handled, for back-compat). Decide async: declination is a synchronous decision.</li>
+      <code>void</code> = handled, for back-compat). <strong>Async rule:</strong> the not-handled signal must be
+      a <em>synchronous</em> <code>boolean</code> — the run-until-handled loop has to choose the next candidate
+      within the same event and cannot <code>await</code>. A handler returning a <code>Promise</code> counts as
+      "handled" the moment it returns (fall-through stops there); only a synchronous <code>false</code> falls
+      through.</li>
   <li><code>src/shortcuts/effectiveActions.ts</code> — <code>getActiveActionById</code> calls
-      <code>compareContexts</code> (kills the divergence).</li>
+      <code>compareContexts</code> (kills the divergence). <strong>This is a behavior change, not a no-op
+      refactor:</strong> today <code>getActiveActionById</code> is pure reverse-activation-order with <em>no</em>
+      <code>global</code> carve-out (verified — zero <code>global</code> references in the file). Routing it
+      through the comparator means a <code>global</code>-vs-scoped id collision that resolves by recency today
+      will instead resolve to <code>global</code> as reserved top tier — so <code>runActionById</code> / the
+      command palette need their own regression test, not just the keyboard path.</li>
   <li><code>src/shortcuts/HotkeyReconciler.tsx</code> — <strong>the big change.</strong> Replace the
       per-action <code>window.addEventListener</code> install loop with <em>one</em> keydown + one keyup
       coordinator that: normalize event → <code>ChordDescriptor</code> (Phase 0) → gather candidates whose
@@ -190,11 +233,22 @@ absolutely inviolable, modals must bind a non-<code>Escape</code> cancel key —
   <li>Call sites that pass deps: keep working via the seam (see below).</li>
 </ul>
 
+<p><strong>Caution — <code>stopPropagation</code> changes meaning under one coordinator:</strong> today each
+action installs its own <code>window</code> listener, so a binding's <code>stopPropagation</code> suppresses the
+<em>sibling</em> action-listeners (that sibling-listener model is the root of the double-fire). With one
+coordinator, losing candidates are loop entries, not separate listeners — there's nothing left among them for
+<code>stopPropagation</code> to stop. It still matters versus the separate <em>hold</em> observer and any
+app-level listeners. Audit every binding that sets <code>stopPropagation</code>, decide what it should now mean,
+and add a regression test — this is a behavior change hiding inside "preserve <code>eventOptions</code>."</p>
+
 <p><strong>Deps seam (the Phase-1 slice of the dependency model):</strong> one function
 <code>resolveDeps(action, active, supplied?) → deps | null</code> that merges the action's active-context deps
 with optional <em>caller-supplied</em> deps, runs the context's <code>validateDependencies</code>, and is the
-<em>only</em> place the widened→narrow cast happens. <code>null</code> ⇒ not dispatchable (this is what
-<code>canDispatch</code>'s dep-availability check returns). Build it caller-suppliable now so swipe's
+<em>only</em> place the widened→narrow cast happens. <code>null</code> ⇒ not dispatchable — and in the
+run-until-handled loop that means <strong>skip this candidate and try the next</strong>, never abort the loop.
+The three fall-through triggers — <code>canDispatch</code> false, <code>resolveDeps</code> null, handler returns
+<code>false</code> — are all "try the next candidate" and the loop must treat them identically. Build it
+caller-suppliable now so swipe's
 <code>runBlockAction</code> fork can later pass <code>{block, uiStateBlock}</code> through <code>resolve()</code>
 instead of bypassing it — even though the swipe migration itself is Phase 3.</p>
 
@@ -211,8 +265,9 @@ so the cast lives at the contributor's definition site, not the pipeline); fold
 <code>ActionOverride</code> + <code>ActionDecorator</code> into it; keep <code>keybindingOverridesFacet</code>
 as the one cross-action pass. Add the genuine unbind primitive (<code>decorate → null</code>, parity with
 <code>apply</code>).</p>
-<p><strong>Why separate PR, sequenced close behind:</strong> touches every contributor → wants its own
-reviewable change + codemod. Stacking into Phase 1 makes it unreviewable.</p>
+<p><strong>Why separate PR, sequenced close behind:</strong> touches each transform contributor (~3–4 in-repo
+sites — see the verified inventory below) → wants its own reviewable change + codemod. Stacking into Phase 1
+makes it unreviewable.</p>
 <p><strong>Retires:</strong> weakness 2 (override/decorator asymmetry, the "which do I use?" folklore); the
 <code>as never</code> casts (weakness 6 symptom); collapses vim's skip-decorators <em>and</em> the downstream
 <code>blockSelectionClickDecoratorsFacet</code> into one mechanism.</p>
@@ -230,8 +285,11 @@ type ActionTransform = {
       into one transform facet (or keep two facet ids but one type + one apply pass).</li>
   <li><code>effectiveActions.ts</code> — single ordered transform pass; <code>null</code> drops the action
       (the genuine unbind primitive). Document phase ordering vs the cross-action keybinding-override pass.</li>
-  <li><strong>Codemod</strong> the ~handful of existing decorators/overrides (srs-rescheduling, vim skip-decorators
-      once they exist post-Phase-1, etc.) to the new type.</li>
+  <li><strong>Codemod</strong> the existing in-repo decorators/overrides to the new type. Verified inventory:
+      <code>srs-rescheduling</code>'s <code>srsRescheduleDecorator</code> / <code>srsSwipeRightDecorator</code> /
+      <code>srsTodoCycleDecorators</code> (<code>canRun</code>-wideners + handler-wrappers) and
+      <code>spatial-navigation</code>'s decorators, plus the keybinding-override pass. There are <em>no</em> "vim
+      skip-decorators" in this repo — those belong to the external agenda user and are out of scope here.</li>
 </ul>
 </div>
 
@@ -307,15 +365,19 @@ and split the one <code>activate</code> verb into "establish scope" (containment
 <ul class="tight">
   <li><strong>Phase 1 and Phase 3 are separate PRs</strong> regardless of doc organization — "fix the
       double-fire" and "build the unified input resolver" are different-sized commitments and reviews.</li>
+  <li><strong>Phase 1 itself is recommended as two PRs</strong> (see "what's coupled vs. what can split"): the
+      bug-fixing comparator/priority/<code>canDispatch</code>-pre-gate first, the fire-time coordinator + Option-D
+      sentinel second (landing with the spatial branch). Option D stays the committed target.</li>
   <li>Phase 0 can ride with Phase 1 or land just ahead of it.</li>
   <li>Phase 2 is its own PR + codemod.</li>
   <li>This plan and the two analysis docs stay docs-only; no code in the precedence PR (#57).</li>
 </ul>
 
 <h2>One-line summary</h2>
-<p>Phase 0 (canonicalizer) → Phase 1 (resolver + precedence + canDispatch + deps seam = the bug fix, done as
-the spine) → Phase 2 (transform unification) → Phase 3 (input unification, downstream). Focus-tree rework and
-full dependency DI run as separate tracks gated on their own evidence, never blocking the spine.</p>
+<p>Phase 0 (canonicalizer: lift + sequence parsing) → Phase 1 (resolver + precedence + canDispatch + deps seam
+= the spine; recommended as two PRs — bug fix, then fire-time/Option-D coordinator with the spatial branch) →
+Phase 2 (transform unification) → Phase 3 (input unification, downstream). Focus-tree rework and full
+dependency DI run as separate tracks gated on their own evidence, never blocking the spine.</p>
 
 </body>
 </html>

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -125,25 +125,33 @@ Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds var
       keyboard paths can't diverge.</li>
   <li><code>priority?: number</code> (named tiers) on <code>ActionContextConfig</code> → fixes the surface
       early/late inversion.</li>
-  <li><code>canRun</code> → <code>isVisible</code> (UI) + <code>canDispatch</code> (declinable dispatch gate).
-      <code>canDispatch</code> ships <em>with</em> the coordinator — it's what "run-until-handled" calls.</li>
+  <li><code>canRun</code> → <code>isVisible</code> (UI) + <code>canDispatch</code> (dispatch gate).
+      <code>canDispatch</code> ships <em>with</em> the coordinator — it's the skip predicate the single-winner
+      loop iterates on (PR&nbsp;1); the handler-return sentinel joins it as a second skip-condition in PR&nbsp;2.</li>
   <li><strong>Deps seam:</strong> resolve deps from <strong>{active scopes} ∪ {caller/trigger-supplied}</strong>,
       narrowed at <em>one</em> explicit validated boundary — not active-map-only, not scattered casts.</li>
 </ul>
-<p><strong>What's genuinely coupled vs. what can split:</strong> <code>resolve</code> + <code>compareContexts</code>
-+ <code>priority</code> + single-winner dedup are coupled — precedence without single-winner doesn't fix the
-bug. But the <em>fire-time coordinator rewrite</em> (one listener, run-until-handled, the declinable
-handler-return sentinel = Option D) is separable from the bug fix. <strong>Recommended sequencing (two PRs):</strong>
-<em>PR&nbsp;1</em> ships the comparator + <code>priority</code> + <code>canDispatch</code> as a synchronous
-<em>pre-gate</em> + single-winner dedup, <strong>keeping the per-action listener model</strong> — this alone
-closes the double-fire and fixes the early/late inversion, and stays small enough to bisect if shortcuts break.
-<em>PR&nbsp;2</em> swaps to the fire-time coordinator and widens the handler return for declinable fall-through
-(Option&nbsp;D), landing with / just ahead of the spatial-selection branch that is its only fall-through
-consumer. <strong>Option&nbsp;D remains the committed target</strong> (per the downstream input-unification
-need) — this is sequencing, not a retreat to activation-time-only. The risk it manages: the coordinator
-rewrite is the single riskiest mechanical change and its sole fall-through consumer is a branch not present in
-this checkout, so if that branch slips, PR&nbsp;1 has still shipped the user-visible fix. (The earlier
-"splitting ships dead code" framing only holds once both consumers are real — true at PR&nbsp;2 time, not before.)</p>
+<p><strong>What's genuinely coupled vs. what can split (and why the split costs no rework):</strong> the
+<em>resolver core</em> — <code>resolve</code> + <code>compareContexts</code> + <code>priority</code> + the
+Phase-0 canonicalizer + the <code>canDispatch</code> concept + the deps seam — is built <strong>once</strong>
+and shared by both PRs; nothing in it is thrown away. The split is purely about the <em>dispatch contract</em>:
+<strong>PR&nbsp;1</strong> builds the single coordinator (one keydown + one keyup listener) with
+<strong>single-winner selection</strong>: normalize event → gather matching candidates → order via
+<code>compareContexts</code> → iterate and dispatch the <em>first whose <code>canDispatch</code> passes</em>.
+That loop already exists, so it closes the double-fire and fixes the early/late inversion, and depends on nothing
+downstream. <strong>PR&nbsp;2</strong> adds <em>only</em> the declinable fall-through: widen the handler return
+to a not-handled sentinel and add "handler returned <code>false</code>" as one more skip-condition to the loop
+PR&nbsp;1 already wrote (Option&nbsp;D). That is <strong>pure addition — no listener wiring is rewritten or
+discarded.</strong> So the split boundary is "everything the bug fix needs" (PR&nbsp;1, incl. the coordinator)
+vs. "the dispatch-contract change the downstream input work needs" (PR&nbsp;2): PR&nbsp;1 can merge immediately;
+PR&nbsp;2 lands with / just ahead of the spatial-selection branch that is its only fall-through consumer.
+<strong>Option&nbsp;D remains the committed target.</strong> Note the trade: building the coordinator in
+PR&nbsp;1 (rather than keeping per-action listeners and deferring the rewrite) front-loads the one mechanically
+risky change — the reconciler rewrite, which carries the documented <code>useEffectEvent</code> regression
+history — into the bug-fix PR. It is not speculative there: single-winner dispatch needs a single dispatcher
+anyway. The earlier "negative work" warning applies only to the <em>other</em> way to fix the bug
+(activation-time install-filtering / per-listener self-check), which this plan explicitly does not do precisely
+because it would be thrown out at PR&nbsp;2.</p>
 <p><strong>Retires:</strong> the double-fire (bug); critique weakness 1 (keyboard/dispatch divergence) and the
 swipe fork's reason-to-exist; weakness 3 (canRun-as-gate); weakness 4 symptom (priority escapes lifecycle
 ordering).</p>
@@ -252,10 +260,14 @@ caller-suppliable now so swipe's
 <code>runBlockAction</code> fork can later pass <code>{block, uiStateBlock}</code> through <code>resolve()</code>
 instead of bypassing it — even though the swipe migration itself is Phase 3.</p>
 
-<p><strong>Suggested internal order within the PR:</strong> (1) <code>resolve</code> + <code>compareContexts</code>
-pure, with unit tests — no wiring; (2) <code>priority</code> type + <code>getActiveActionById</code> swap;
-(3) the <code>canRun</code> split; (4) rewrite the reconciler install loop onto the coordinator; (5)
-deps seam; (6) integration tests. Steps 1–3 are independently reviewable even within the one PR.</p>
+<p><strong>Suggested internal order (steps 1–6 = PR&nbsp;1; step 7 = PR&nbsp;2):</strong> (1) <code>resolve</code>
++ <code>compareContexts</code> pure, with unit tests — no wiring; (2) <code>priority</code> type +
+<code>getActiveActionById</code> swap; (3) the <code>canRun</code>→<code>isVisible</code>/<code>canDispatch</code>
+split (<code>canDispatch</code> as the single-winner loop's skip predicate, no handler-return sentinel yet);
+(4) rewrite the reconciler install loop onto the single coordinator (single-winner dispatch); (5) deps seam;
+(6) integration tests → <strong>PR&nbsp;1 merges here, bug fixed.</strong> (7) PR&nbsp;2: widen the handler
+return to a not-handled sentinel and add it as a skip-condition in the existing loop (Option&nbsp;D), with the
+spatial branch. Steps 1–3 are independently reviewable even within PR&nbsp;1.</p>
 </div>
 
 <div class="phase">
@@ -365,19 +377,22 @@ and split the one <code>activate</code> verb into "establish scope" (containment
 <ul class="tight">
   <li><strong>Phase 1 and Phase 3 are separate PRs</strong> regardless of doc organization — "fix the
       double-fire" and "build the unified input resolver" are different-sized commitments and reviews.</li>
-  <li><strong>Phase 1 itself is recommended as two PRs</strong> (see "what's coupled vs. what can split"): the
-      bug-fixing comparator/priority/<code>canDispatch</code>-pre-gate first, the fire-time coordinator + Option-D
-      sentinel second (landing with the spatial branch). Option D stays the committed target.</li>
+  <li><strong>Phase 1 itself is recommended as two PRs</strong> (see "what's coupled vs. what can split"):
+      <em>PR&nbsp;1</em> = the coordinator + comparator + <code>priority</code> + single-winner dispatch (the
+      bug fix, depends on nothing downstream); <em>PR&nbsp;2</em> = the declinable handler-return sentinel
+      (Option&nbsp;D) added on top, landing with the spatial branch. The split costs no rework — PR&nbsp;2 is
+      pure addition to PR&nbsp;1's loop. Option D stays the committed target.</li>
   <li>Phase 0 can ride with Phase 1 or land just ahead of it.</li>
   <li>Phase 2 is its own PR + codemod.</li>
   <li>This plan and the two analysis docs stay docs-only; no code in the precedence PR (#57).</li>
 </ul>
 
 <h2>One-line summary</h2>
-<p>Phase 0 (canonicalizer: lift + sequence parsing) → Phase 1 (resolver + precedence + canDispatch + deps seam
-= the spine; recommended as two PRs — bug fix, then fire-time/Option-D coordinator with the spatial branch) →
-Phase 2 (transform unification) → Phase 3 (input unification, downstream). Focus-tree rework and full
-dependency DI run as separate tracks gated on their own evidence, never blocking the spine.</p>
+<p>Phase 0 (canonicalizer: lift + sequence parsing) → Phase 1 (resolver core = the spine, built once;
+recommended as two PRs — coordinator + single-winner bug fix, then Option-D declinable fall-through added on
+top with the spatial branch, no rework) → Phase 2 (transform unification) → Phase 3 (input unification,
+downstream). Focus-tree rework and full dependency DI run as separate tracks gated on their own evidence, never
+blocking the spine.</p>
 
 </body>
 </html>

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Action system — implementation plan &amp; sequencing</title>
+<style>
+  body { font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         max-width: 980px; margin: 2rem auto; padding: 0 1.25rem; color: #1f2328; }
+  h1 { font-size: 1.6rem; margin-bottom: .25rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #d0d7de; padding-bottom: .25rem; }
+  h3 { font-size: 1rem; margin-top: 1.25rem; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; }
+  pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+        padding: .75rem .9rem; overflow-x: auto; }
+  code { background: #f6f8fa; padding: .1em .3em; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .65rem; vertical-align: top; text-align: left; }
+  th { background: #f6f8fa; }
+  ul.tight { margin: .4rem 0; }
+  .done { color: #1a7f37; }
+  .open { color: #cf222e; }
+  .note { background: #fff8c5; border-left: 4px solid #d4a72c; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .axes { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .phase { background: #f6f8fa; border: 1px solid #d0d7de; border-left: 4px solid #0969da;
+           border-radius: 4px; padding: .75rem 1rem; margin: 1rem 0; }
+  .phase h3 { margin-top: 0; }
+  .sep { background: #fdf4ff; border-left: 4px solid #8250df; padding: .75rem 1rem;
+         border-radius: 4px; margin: 1rem 0; }
+  small { color: #57606a; }
+  .filepath { color: #57606a; font-size: 11.5px; }
+  .pill { display: inline-block; font-size: 11px; font-weight: 700; padding: .05em .5em;
+          border-radius: 10px; vertical-align: middle; }
+  .pill.bug { background: #ffebe9; color: #cf222e; }
+  .pill.arch { background: #ddf4ff; color: #0969da; }
+  .pill.down { background: #fff1e5; color: #bc4c00; }
+</style>
+</head>
+<body>
+
+<h1>Action system — implementation plan &amp; sequencing</h1>
+<small>Synthesis of the precedence + critique + prior-art + input-unification discussion — 2026-05-30</small>
+
+<p>Consolidates the decisions from <code>docs/shortcut-context-precedence.html</code> (the bug + precedence
+options) and <code>docs/action-system-critique.html</code> (the architectural critique), plus the prior-art
+survey, the focus-tree activation exploration, and the downstream input-unification constraint, into one
+sequenced plan. This doc is the "what to build, in what order" — the other two are the "why."</p>
+
+<div class="axes">
+<strong>The spine: one component everything hangs off.</strong> Every thread converges on
+<code>resolve(activeSet, trigger) → action</code>. The precedence bug needs it (single winner); the critique
+names it (P1); input-unification consumes it (mouse/touch through the same path); the focus-tree model only
+changes what <em>produces</em> <code>activeSet</code>. So the plan is "build the spine, hang things off it,"
+not a list of independent fixes. <strong>Don't</strong> build the narrow dedup-in-loop fix — given a committed
+input-unification consumer, it's work that gets torn out.
+</div>
+
+<h2>Decisions ledger</h2>
+<table>
+<tr><th>Question</th><th>Decision</th><th>Status</th></tr>
+<tr><td>Is the double-fire a bug?</td><td>Yes — single winner per chord; nothing intends two actions per chord.</td><td class="done">settled</td></tr>
+<tr><td>Dedup-in-loop vs resolver core?</td><td>Resolver core. Dedup-in-loop is negative work given input unification.</td><td class="done">settled</td></tr>
+<tr><td>Activation-time (A) vs fire-time declinable (D)?</td><td>D — a named downstream consumer needs declinable dispatch (click "not mine, fall through").</td><td class="done">settled</td></tr>
+<tr><td>Precedence signal?</td><td>Context-level <strong>priority via named tiers</strong> (CodeMirror <code>Prec</code> precedent), not raw integers; not per-binding.</td><td class="done">settled</td></tr>
+<tr><td><code>global</code> on a chord collision?</td><td>Reserved top tier — never shadowed by a non-global binding.</td><td class="done">settled</td></tr>
+<tr><td><code>modal</code>?</td><td>Retained, orthogonal — "own all chords, even unbound." Above priority.</td><td class="done">settled</td></tr>
+<tr><td>Trigger type?</td><td>Normalized input descriptor (<code>{kind, modifiers, phase, role}</code>), not <code>KeyboardEvent</code>; phase/role first-class.</td><td class="done">settled</td></tr>
+<tr><td>Replace facets / flatten contexts?</td><td>No. Keep facet contribution + scoping. Unify resolution only.</td><td class="done">settled</td></tr>
+<tr><td><code>global</code> vs active <code>modal</code> on same chord (Escape)?</td><td>Lean: modal is the one tier allowed to override global. Needs explicit sign-off.</td><td class="open">OPEN</td></tr>
+<tr><td>Equal-priority determinism?</td><td>Fall back to recency for now; revisit only if a real case bites.</td><td class="open">deferred</td></tr>
+<tr><td>Full provider/DI dependency model?</td><td>Build only the caller-supplied <em>seam</em> now; full token registry deferred until "dep shapes grow faster than contexts."</td><td class="open">deferred</td></tr>
+<tr><td>Focus-tree activation model?</td><td>Separate prototype track; not a dependency of any phase below.</td><td class="open">prototype</td></tr>
+</table>
+
+<h2>Sequencing</h2>
+
+<div class="phase">
+<h3>Phase 0 — Shared canonicalizer <span class="pill arch">enabling</span></h3>
+<p><strong>What:</strong> lift <code>normalizeChord</code> (<span class="filepath">keybindings-settings/keyCapture.ts:205</span>)
+into <code>src/shortcuts/</code>, add modifier sorting, shape it as <strong>chord↔descriptor</strong> from day
+one (not chord-only). Retrofit <code>keybindingConflicts.ts</code> off it.</p>
+<p><strong>Why first:</strong> Phases 1–3 all assume canonical comparison. Cheap, no behavior change, unblocks
+everything. <span class="filepath">Addresses: precedence-doc "canonicalization is not free" review finding.</span></p>
+<p><strong>Done when:</strong> alias-equivalent chords (<code>Meta+K</code> / <code>$mod+k</code>) and
+reordered modifiers compare equal; one shared helper, used by dedup + conflict detection.</p>
+</div>
+
+<div class="phase">
+<h3>Phase 1 — Resolver core + precedence + canDispatch <span class="pill bug">closes the bug</span> <span class="pill arch">lays the spine</span></h3>
+<p><strong>What (one PR, these are genuinely coupled):</strong></p>
+<ul class="tight">
+  <li><code>resolve(activeSet, trigger) → action</code> as a <strong>fire-time, declinable coordinator</strong>
+      (precedence-doc Option D): one keydown/keyup listener, <code>trigger → ordered candidates →
+      run-until-handled</code>, replacing the N per-action <code>window</code> listeners. Route the keyboard
+      path, <code>runActionById</code>, and <code>useRunAction</code> through it.</li>
+  <li>Comparator <code>(priority desc, then activation-recency desc)</code>, <code>global</code> as reserved
+      top tier, <code>modal</code> preserved. Shared with <code>getActiveActionById</code> so the dispatch and
+      keyboard paths can't diverge.</li>
+  <li><code>priority?: number</code> (named tiers) on <code>ActionContextConfig</code> → fixes the surface
+      early/late inversion.</li>
+  <li><code>canRun</code> → <code>isVisible</code> (UI) + <code>canDispatch</code> (declinable dispatch gate).
+      <code>canDispatch</code> ships <em>with</em> the coordinator — it's what "run-until-handled" calls.</li>
+  <li><strong>Deps seam:</strong> resolve deps from <strong>{active scopes} ∪ {caller/trigger-supplied}</strong>,
+      narrowed at <em>one</em> explicit validated boundary — not active-map-only, not scattered casts.</li>
+</ul>
+<p><strong>Why coupled:</strong> the coordinator with nothing to gate is half a feature; <code>canDispatch</code>
+without the coordinator has no caller; precedence without single-winner doesn't fix the bug. Splitting them
+ships dead code in either direction.</p>
+<p><strong>Retires:</strong> the double-fire (bug); critique weakness 1 (keyboard/dispatch divergence) and the
+swipe fork's reason-to-exist; weakness 3 (canRun-as-gate); weakness 4 symptom (priority escapes lifecycle
+ordering).</p>
+<p><strong>Tests:</strong> higher-priority context wins a same-key collision even when activated earlier;
+deactivation restores the lower binding; equal priority → last-wins; <code>modal</code> suppresses
+non-colliding chords; <code>global</code> survives a modal; same key different phase (hold <code>s</code> vs
+keyup <code>s</code>) does NOT dedup; alias-equivalent chords DO dedup; a declining winner falls through to
+the next candidate; sequence chords (<code>d d</code>) still fire under the coordinator.</p>
+<p><strong>Carries the load-bearing invariant comment:</strong> resolution is correct because
+<code>eventFilter</code> only expands, never declines-and-defers — declinable handling is the supported
+fall-through, not filter scoping.</p>
+</div>
+
+<div class="phase">
+<h3>Phase 2 — Unify the transform pipeline <span class="pill arch">cleanup</span></h3>
+<p><strong>What:</strong> one erased <code>(action) → action | null</code> transform type (no <code>T</code>,
+so the cast lives at the contributor's definition site, not the pipeline); fold
+<code>ActionOverride</code> + <code>ActionDecorator</code> into it; keep <code>keybindingOverridesFacet</code>
+as the one cross-action pass. Add the genuine unbind primitive (<code>decorate → null</code>, parity with
+<code>apply</code>).</p>
+<p><strong>Why separate PR, sequenced close behind:</strong> touches every contributor → wants its own
+reviewable change + codemod. Stacking into Phase 1 makes it unreviewable.</p>
+<p><strong>Retires:</strong> weakness 2 (override/decorator asymmetry, the "which do I use?" folklore); the
+<code>as never</code> casts (weakness 6 symptom); collapses vim's skip-decorators <em>and</em> the downstream
+<code>blockSelectionClickDecoratorsFacet</code> into one mechanism.</p>
+</div>
+
+<div class="phase">
+<h3>Phase 3 — Input unification <span class="pill down">downstream branch</span></h3>
+<p><strong>What:</strong> add mouse/touch descriptor kinds to the Phase-0 matcher; migrate the ~5 input facets
+(<code>blockClickHandlersFacet</code>, <code>blockContentSurfacePropsFacet</code>,
+<code>blockGestureConflictsFacet</code>, <code>blockContentDecoratorsFacet</code>,
+<code>blockSelectionClickDecoratorsFacet</code>) onto <code>resolve()</code>; collapse swipe's
+<code>runBlockAction</code> fork back into the one path.</p>
+<p><strong>Owner:</strong> the spatial-selection branch, not this track. This plan's job through Phase 2 is to
+<em>not foreclose</em> it — which the trigger-descriptor, <code>canDispatch</code>, and caller-supplied deps
+seam decisions all ensure.</p>
+</div>
+
+<h3>Opportunistic — fold in where already touching the code (not their own phases)</h3>
+<ul class="tight">
+  <li>Conflict-UI: broaden <code>contextsOverlap</code> (<span class="filepath">keybindingConflicts.ts:34</span>)
+      to cross-context overlap <em>first</em>, then relabel priority-shadowed chords as intentional ("shadowed
+      by X while active") rather than warnings.</li>
+  <li>De-singleton <code>runActionById</code> (weakness 5) → runtime-scoped service from context.</li>
+  <li>Context generics tidy (weakness 6 residue) — only if the area's already open.</li>
+</ul>
+
+<h2>Dependency thread (why Phase 1's deps seam matters)</h2>
+<div class="note">
+The deps work has <strong>two axes</strong>: <em>typing</em> (who owns the dep type — context vs handler) and
+<em>supply</em> (who produces the value, when — pushed at activation vs provided at dispatch). "Handler-declared
+deps" only fixes typing; <strong>supply is the coherence issue.</strong> Today's push-only model means "to
+dispatch an action you must be its active context" — which is precisely why swipe's <code>runBlockAction</code>
+forks (it holds the deps but can't hand them to the dispatcher). Phase 1 builds only the <em>seam</em>
+(deps from <code>{active scopes} ∪ {caller-supplied}</code>); the full provider/capability DI model
+(scopes provide typed tokens, actions declare needs, missing token ⇒ not dispatchable ⇒ <em>that is</em>
+<code>canDispatch</code>) is deferred until a third data point or the focus-tree prototype — they are the same
+model at different levels of "derive from tree." See critique weakness 6 for the full treatment.
+</div>
+
+<h2>The separate bet — do NOT gate anything on it</h2>
+<div class="sep">
+<strong>Focus-tree activation model.</strong> Replace the flat, runtime-maintained <code>ActiveContextsMap</code>
+with an active set <em>derived from the focus/DOM tree</em>, and split the one <code>activate</code> verb into
+"establish scope" (containment, structural) vs "override" (precedence, declared). This is the genuine
+best-in-class move — it retires the timing-as-precedence <em>bug class</em> at the root (weakness 4) by killing
+the registry that can desync.
+<ul class="tight" style="margin-top:.5rem">
+  <li><strong>It does NOT fix the surface bug</strong> — the surface wants to override <em>against</em>
+      containment depth (it's the ancestor; the block is deeper), which needs the explicit priority/override
+      signal in any architecture. Structural depth alone gives the same wrong answer as last-wins.</li>
+  <li><strong>It composes with the spine, doesn't compete:</strong> it changes what <em>produces</em>
+      <code>activeSet</code>; <code>resolve()</code> consumes one either way. And the provider/capability deps
+      model is literally this model with React-context providers as the chain.</li>
+  <li><strong>Heaviest change discussed</strong> (~27 activation sites + typed-deps threading + non-focus-shaped
+      scopes like multi-select). Recommend a throwaway-branch prototype to validate deps-threading and
+      multi-select before it's a real proposal. Phase 1's <code>priority</code> already patches the bug symptom,
+      so there's no urgency.</li>
+</ul>
+</div>
+
+<h2>PR boundaries (firm)</h2>
+<ul class="tight">
+  <li><strong>Phase 1 and Phase 3 are separate PRs</strong> regardless of doc organization — "fix the
+      double-fire" and "build the unified input resolver" are different-sized commitments and reviews.</li>
+  <li>Phase 0 can ride with Phase 1 or land just ahead of it.</li>
+  <li>Phase 2 is its own PR + codemod.</li>
+  <li>This plan and the two analysis docs stay docs-only; no code in the precedence PR (#57).</li>
+</ul>
+
+<h2>One-line summary</h2>
+<p>Phase 0 (canonicalizer) → Phase 1 (resolver + precedence + canDispatch + deps seam = the bug fix, done as
+the spine) → Phase 2 (transform unification) → Phase 3 (input unification, downstream). Focus-tree rework and
+full dependency DI run as separate tracks gated on their own evidence, never blocking the spine.</p>
+
+</body>
+</html>

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -315,7 +315,13 @@ they bind?</strong>
 shared comparator <code>(priority desc, then activation-recency desc)</code> used by <em>both</em> the keyboard
 path and <code>getActiveActionById</code>, add <code>priority?: number</code> (default <code>0</code>) so the
 reporting surface outranks <code>normal-mode</code> and the 8 skip-decorators collapse to one line, and keep
-<code>modal</code> as the extreme tier. Drop B (suppression, not precedence; name-coupled) and C (A with coupling).</p>
+<code>modal</code> as the extreme tier. <strong><code>global</code> is a reserved top tier, outside normal
+collision precedence:</strong> a <code>global</code> binding is never shadowed by a non-global one on a shared
+chord, regardless of priority or activation order. Without this carve-out the comparator violates the doc's own
+"app-wide chords must survive" requirement — <code>global</code> activates early and defaults to priority 0, so a
+later same-priority context would otherwise win Cmd+K / Escape. (<code>computeInstallableContexts</code> only
+keeps <code>global</code> in the install <em>set</em>; it does not rank it within a collision, so the dedup pass
+must special-case it.) Drop B (suppression, not precedence; name-coupled) and C (A with coupling).</p>
 <p style="margin:.5rem 0"><strong>If NO — every case is "this layer wins these keys, full stop":</strong>
 ship <strong>A + activation-time</strong> resolution (dedup in the reconcile loop that already runs). Smallest
 change; no handler-contract churn. This is the default recommendation absent evidence otherwise.</p>
@@ -352,6 +358,13 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
       pre-resolution breaks (the loser is already uninstalled). That's the same wall as the D question — Option D
       <em>is</em> the supported way to do declinable handling. Document the invariant next to the dedup so a future
       reader knows shipping declinable handling means moving to fire-time, not bolting onto the filter.</li>
+  <li><strong>Global vs. a modal/high-priority context on the same chord.</strong> The "global is a reserved
+      top tier" rule says global never loses a collision — but that collides with the old doc's example of
+      scrub-mode's <code>Escape</code> overriding global's <code>Escape</code>. Reconcile explicitly: either
+      (a) global always wins and modal contexts must bind a <em>different</em> cancel key, or (b) global wins
+      except against an active <code>modal</code> context (modal is the one tier allowed to override global,
+      consistent with it already being the only thing global doesn't shadow). (b) is more flexible and matches
+      today's modal semantics; pick one and write it down so the dedup's global special-case is unambiguous.</li>
   <li><strong>Chord canonicalization is NOT free today.</strong> Grouping by chord needs equivalent
       bindings to compare equal — but <code>keybindingConflicts.ts</code> does <em>not</em> canonicalize;
       it buckets raw strings via <code>toChordArray</code>, so <code>Meta+K</code> vs <code>$mod+k</code>,
@@ -411,8 +424,15 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
       single keydown/keyup coordinator: one listener per phase that maps the event's chord to candidates in
       precedence order and runs until one reports handled. Preserve <code>withRecoveredLetterKey</code>,
       <code>shouldHandleEvent</code>, hold-binding handling, and <code>eventOptions</code> precedence.</li>
+  <li><strong>Preserve sequence-chord state.</strong> A coordinator that maps each keydown's <em>current</em>
+      chord to candidates loses the multi-press sequence state machine tinykeys maintains today — the repo has
+      live sequence defaults (<code>d d</code>, <code>g g</code> in <span class="filepath">vim-normal-mode/actions.ts</span>).
+      The fire-time coordinator must keep a tinykeys (or equivalent) sequence matcher per candidate rather than
+      reduce each event to a single chord, or those bindings become unreachable. Test sequences explicitly under
+      the coordinator.</li>
   <li>Tests — all of the activation-time tests, plus: a declining winner falls through to the next candidate;
-      a handling winner suppresses the rest; decline order respects priority then recency.</li>
+      a handling winner suppresses the rest; decline order respects priority then recency; <strong>sequence
+      chords (<code>d d</code>) still fire under the coordinator</strong>.</li>
 </ul>
 <p><small>Per repo testing guidance: no tests that merely re-state default binding strings.</small></p>
 

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -83,6 +83,17 @@ latest-activated context wins" is <em>already the law</em> for one dispatch path
 the inconsistent one. Any fix should make the two paths agree.
 </div>
 
+<div class="note">
+<strong>But the double-fire accidentally provides one real capability: conditional fall-through.</strong>
+Because both handlers run today, a context can bind a chord, check a condition in its handler, and
+<em>no-op</em> — and the lower context's handler <em>still ran</em>. The event "fell through" by accident.
+A naïve single-winner fix <strong>removes</strong> this: if only the winner installs the chord and its
+handler bails, nothing else happens — the lower layer never had a listener. Whether that capability is
+worth keeping is the hinge between the two implementation strategies (activation-time vs fire-time
+resolution) and gets its own option below — see <a href="#declinable">Option D</a>. It is not a footnote;
+it changes the recommendation.
+</div>
+
 <h2>What we learned looking with new eyes (codebase facts)</h2>
 <table>
 <tr><th>Fact</th><th>Where</th><th>Why it matters here</th></tr>
@@ -114,9 +125,11 @@ the inconsistent one. Any fix should make the two paths agree.
 <tr>
   <td><code>eventFilter</code> is OR-only / opt-in</td>
   <td><span class="filepath">HotkeyReconciler.tsx:86–96</span></td>
-  <td>A context's filter can only <em>expand</em> what it accepts; no context can decline a chord and
-      defer it to a lower layer. <strong>This is the invariant that makes activation-time resolution
-      safe</strong> (there is never anything to "fall through" to). Load-bearing — see Open questions.</td>
+  <td>A context's filter can only <em>expand</em> what it accepts; it can pre-decide "I want this event"
+      but cannot <em>decline a chord after inspecting it and defer to a lower layer</em>. So there is no
+      <em>declarative</em> fall-through today — the only fall-through that exists is the accidental
+      handler-level one the double-fire provides. If we want declinable handling as a real feature, it has
+      to come from the dispatch model (Option D), not from <code>eventFilter</code>.</td>
 </tr>
 <tr>
   <td>The agenda plugin is <em>not</em> in this repo</td>
@@ -233,47 +246,112 @@ old doc's Model B.)</p>
       ship both.</li>
 </ul>
 
+<h3 id="declinable">Option D — Declinable resolution (fall-through)</h3>
+<p>The previous options answer "<em>who</em> wins a chord." This one answers a different, partly
+orthogonal question: "<em>when</em> does the winner get to say <em>not me — let the next layer have it</em>?"
+It's the one capability today's accidental double-fire actually provides (a higher context's handler can
+no-op and the lower one still ran), and a naïve single-winner fix silently deletes it.</p>
+
+<p>The model: dispatch consults active contexts in precedence order (whatever 0/A picks). The first that
+binds the chord runs — but its handler may report <strong>"not handled,"</strong> and dispatch then tries
+the next candidate in order. No double-fire (at most one handler ultimately acts), but conditional
+yielding works. This is the dispatch-gating sibling of <code>canRun</code>: a predicate that, when it
+declines, <em>defers</em> instead of <em>suppressing</em>.</p>
+<pre><code>// handler returns false / "not handled" => dispatch falls through to next candidate
+handler: (deps, event) =&gt; {
+  if (!surfaceWantsThisKeyRightNow(deps)) return false   // let normal-mode have it
+  doSurfaceThing(deps)
+  return true
+}</code></pre>
+<p>Precedent: Emacs (a command keymap entry of <code>nil</code> / a command that signals it didn't handle
+falls through to the next keymap), CodeMirror (a keymap <code>run</code> returning <code>false</code> tries
+the next handler). This is the standard layered-keymap escape valve.</p>
+<ul class="tight">
+  <li class="pro">Preserves the only genuine capability the double-fire gave us, but cleanly (one effect, not two).</li>
+  <li class="pro">Composes with A — precedence picks the order; decline walks down that order. They're different axes.</li>
+  <li class="pro">Lets a high-priority surface own a key <em>conditionally</em> without re-implementing the
+      lower layer's behavior for the cases it wants to pass through.</li>
+  <li class="con"><strong>Forces fire-time resolution.</strong> The winner is now per-<em>event</em> (depends on what
+      handlers return), so you can't pre-resolve at activation time by skipping installs. That means a real
+      dispatch coordinator — a single keydown listener that owns chord → ordered-candidates → run-until-handled —
+      replacing today's independent per-action listeners. Bigger change than the activation-time dedup.</li>
+  <li class="con">Handler contract grows a return value (<code>boolean</code> / "handled"). Existing handlers
+      return <code>void | Promise&lt;void&gt;</code>; "no return = handled" keeps them working, but async handlers
+      that want to decline must resolve to the sentinel, and "did it handle?" for an async handler is awkward
+      (you'd likely restrict decline to a synchronous pre-check).</li>
+  <li class="meh">Only worth it if surfaces actually need to <em>conditionally</em> yield a key they bind.
+      If every case is "this layer wins these keys, full stop," D is unnecessary machinery and activation-time
+      wins on simplicity.</li>
+</ul>
+
+<div class="axes">
+<strong>Two axes, not five rivals.</strong> Winner-selection (0 / A / B / C) and resolution-strategy
+(activation-time vs fire-time/declinable, i.e. whether D is in) are independent. The real choice is a
+2×2: <em>{last-wins | priority}</em> × <em>{activation-time | fire-time-declinable}</em>. <code>modal</code>
+sits above both as the "own everything, even unbound" tier and is unaffected.
+</div>
+
 <h2>Scorecard</h2>
+<p><small>0 / A / B / C are winner-selection rules; D is a resolution-strategy that layers on top of
+any of them. The column shows D combined with priority (A) since that's the live candidate.</small></p>
 <table class="scorecard">
-<tr><th></th><th>0 · last-wins</th><th>A · priority</th><th>B · supersedes</th><th>C · shadowChordsFrom</th></tr>
-<tr><td>Closes double-fire</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
-<tr><td>Fixes early/late inversion</td><td class="lose">no</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
-<tr><td>Additive for non-bound keys</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
-<tr><td>New config surface</td><td class="win">none</td><td class="meh">1 number</td><td class="lose">nested map</td><td class="meh">1 list</td></tr>
-<tr><td>Avoids host-name coupling</td><td class="win">yes</td><td class="win">yes</td><td class="lose">no</td><td class="lose">no</td></tr>
-<tr><td>Handles <code>d</code> vs <code>d d</code></td><td class="lose">n/a</td><td class="meh">no*</td><td class="win">yes</td><td class="meh">no*</td></tr>
-<tr><td>Reads locally (1 file)</td><td class="lose">no (timing)</td><td class="win">yes</td><td class="win">yes</td><td class="meh">mostly</td></tr>
+<tr><th></th><th>0 · last-wins</th><th>A · priority</th><th>B · supersedes</th><th>C · shadowChordsFrom</th><th>D · declinable (+A)</th></tr>
+<tr><td>Closes double-fire</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
+<tr><td>Fixes early/late inversion</td><td class="lose">no</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
+<tr><td>Additive for non-bound keys</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
+<tr><td>Conditional fall-through</td><td class="lose">no</td><td class="lose">no</td><td class="lose">no</td><td class="lose">no</td><td class="win">yes</td></tr>
+<tr><td>New config surface</td><td class="win">none</td><td class="meh">1 number</td><td class="lose">nested map</td><td class="meh">1 list</td><td class="meh">1 number + handler return</td></tr>
+<tr><td>Avoids host-name coupling</td><td class="win">yes</td><td class="win">yes</td><td class="lose">no</td><td class="lose">no</td><td class="win">yes</td></tr>
+<tr><td>Handles <code>d</code> vs <code>d d</code></td><td class="lose">n/a</td><td class="meh">no*</td><td class="win">yes</td><td class="meh">no*</td><td class="meh">no*</td></tr>
+<tr><td>Implementation cost</td><td class="win">dedup in loop</td><td class="win">dedup in loop</td><td class="win">dedup in loop</td><td class="win">dedup in loop</td><td class="lose">new dispatch coordinator</td></tr>
+<tr><td>Reads locally (1 file)</td><td class="lose">no (timing)</td><td class="win">yes</td><td class="win">yes</td><td class="meh">mostly</td><td class="win">yes</td></tr>
 </table>
 <p><small>* exact-chord granularity; no in-repo case needs cross-granularity shadowing today.</small></p>
 
 <div class="verdict">
-<strong>Recommendation: Option 0 as the default + Option A as the escape hatch.</strong>
-<ol style="margin:.5rem 0 0">
-  <li><strong>Fix the double-fire</strong> by installing a single winner per chord in the existing
-      reconcile loop. This alone is most of the value and is unambiguously a bug fix.</li>
-  <li><strong>Winner = shared comparator</strong> <code>(priority desc, then activation-recency desc)</code>,
-      factored once and used by <em>both</em> the keyboard dedup and <code>getActiveActionById</code>, so the
-      two dispatch paths can't diverge.</li>
-  <li><strong><code>priority?: number</code></strong> on <code>ActionContextConfig</code>, default <code>0</code>.
-      The reporting surface sets it above <code>normal-mode</code>; the 8 skip-decorators collapse to one line.</li>
-  <li><strong>Keep <code>modal</code></strong> as the extreme tier (own all chords, even unbound). Conceptually
-      "very high priority + suppress the rest."</li>
-  <li><strong>Drop B and C.</strong> C is A with coupling. B is suppression, not precedence — keep it in
-      reserve only if a real same-key, action-targeted, cross-granularity case appears in-repo (none today).</li>
-</ol>
-Skip-decorators were the wrong layer: imperative no-ops fighting the architecture, and <code>canRun</code>
-can't gate dispatch anyway. If a genuine static "remove this action everywhere" need arises, the clean tool
-is letting <code>ActionDecorator.decorate</code> return <code>null</code> (parity with
-<code>ActionOverride.apply</code>) — a separate concern from precedence.
+<strong>Recommendation hinges on one question: do surfaces need to <em>conditionally</em> yield a chord
+they bind?</strong>
+<p style="margin:.5rem 0">Common to both answers: fix the double-fire (single winner per chord), winner =
+shared comparator <code>(priority desc, then activation-recency desc)</code> used by <em>both</em> the keyboard
+path and <code>getActiveActionById</code>, add <code>priority?: number</code> (default <code>0</code>) so the
+reporting surface outranks <code>normal-mode</code> and the 8 skip-decorators collapse to one line, and keep
+<code>modal</code> as the extreme tier. Drop B (suppression, not precedence; name-coupled) and C (A with coupling).</p>
+<p style="margin:.5rem 0"><strong>If NO — every case is "this layer wins these keys, full stop":</strong>
+ship <strong>A + activation-time</strong> resolution (dedup in the reconcile loop that already runs). Smallest
+change; no handler-contract churn. This is the default recommendation absent evidence otherwise.</p>
+<p style="margin:.5rem 0 0"><strong>If YES — a surface wants to own a key sometimes and pass it through
+otherwise:</strong> ship <strong>A + D (fire-time, declinable)</strong>. Costs a real dispatch coordinator and
+a handler return value, but it's the clean version of the capability the double-fire gives us by accident, and
+retrofitting it later means redoing the dispatch path. <em>This is the open decision for the reader</em> — see
+the question at the top of Open questions.</p>
+</div>
+
+<div class="note">
+Skip-decorators were the wrong layer regardless: imperative no-ops fighting the architecture, and
+<code>canRun</code> can't gate dispatch anyway. Note that <strong>Option D is the principled replacement for
+exactly what the skip-decorators were faking</strong> — "run my handler, decide it doesn't apply, let the host
+act" is precisely conditional fall-through, done in dispatch instead of by mutating the action catalog. If the
+8 decorators are <em>unconditional</em> no-ops (always suppress host), A alone replaces them; if any are
+<em>conditional</em> (suppress host only sometimes), that's the in-repo evidence that D is needed. <strong>Worth
+auditing those decorators before deciding.</strong> Separately, for a genuine static "remove this action
+everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code> return <code>null</code>
+(parity with <code>ActionOverride.apply</code>).
 </div>
 
 <h2>Open questions / risks</h2>
 <ul class="tight">
-  <li><strong>The <code>eventFilter</code> invariant is load-bearing.</strong> Activation-time resolution
-      is correct <em>only because</em> no context can decline-and-defer a chord. If someone later writes a
-      filter meant to scope a chord down and hand it to a lower layer, pre-resolution breaks (the loser is
-      already uninstalled) and you'd need fire-time resolution. Document this next to the dedup so a future
-      reader knows what they'd be voiding.</li>
+  <li><strong>THE decision: is conditional fall-through (Option D) needed?</strong> Everything else is
+      settled; this isn't. Decider: audit the 8 skip-decorators on the user's surface. If they always no-op the
+      host action when the surface is active → unconditional → A alone suffices, ship activation-time. If any
+      no-op the host <em>only under a condition</em> (and otherwise want the host to run) → that's conditional
+      fall-through in disguise → ship D (fire-time). Picking activation-time and discovering a conditional case
+      later is a dispatch-path rewrite, so decide this deliberately, not by default.</li>
+  <li><strong>The <code>eventFilter</code> invariant is load-bearing for activation-time.</strong> Pre-resolution
+      is correct <em>only because</em> no context can decline-and-defer a chord today. If we ship activation-time
+      and someone later writes a filter (or handler) meant to scope a chord down and hand it to a lower layer,
+      pre-resolution breaks (the loser is already uninstalled). That's the same wall as the D question — Option D
+      <em>is</em> the supported way to do declinable handling. Document the invariant next to the dedup so a future
+      reader knows shipping declinable handling means moving to fire-time, not bolting onto the filter.</li>
   <li><strong>Chord canonicalization.</strong> Grouping by chord needs the same normalization
       <code>keybindingConflicts.ts</code> already does (alternatives like <code>['$mod+z','ctrl+z']</code>,
       code-form chords). Reuse it; don't reinvent. (Not unique to this approach — any single-winner scheme
@@ -287,16 +365,32 @@ is letting <code>ActionDecorator.decorate</code> return <code>null</code> (parit
       action-targeted suppression, add it then as a narrow supplement — don't pre-build it.</li>
 </ul>
 
-<h2>Rough surface area (if we proceed with 0 + A)</h2>
+<h2>Rough surface area</h2>
+<p><strong>Shared by both strategies (A core):</strong></p>
 <ul class="tight">
   <li><code>types.ts</code> — add <code>priority?: number</code> to <code>ActionContextConfig</code> (+ doc comment).</li>
   <li><code>effectiveActions.ts</code> — extract <code>compareContexts</code>; rewrite
       <code>getActiveActionById</code> to use it.</li>
+</ul>
+<p><strong>If activation-time (A only):</strong></p>
+<ul class="tight">
   <li><code>HotkeyReconciler.tsx</code> — per-chord dedup in the install loop using the shared comparator;
-      document the <code>eventFilter</code> invariant.</li>
+      install only the winner; document the <code>eventFilter</code> invariant.</li>
   <li>Tests — higher-priority context wins a same-key collision even when activated earlier; deactivating it
       restores the lower binding; equal priority falls back to last-wins; <code>modal</code> still suppresses
       non-colliding chords; <code>global</code> survives.</li>
+</ul>
+<p><strong>If fire-time (A + D):</strong></p>
+<ul class="tight">
+  <li><code>types.ts</code> — widen <code>ActionHandler</code> return to allow a "not handled" sentinel
+      (e.g. <code>boolean</code>; <code>void</code> = handled, for back-compat). Decide async semantics
+      (likely: decline must be a synchronous decision).</li>
+  <li><code>HotkeyReconciler.tsx</code> — replace independent per-action <code>window</code> listeners with a
+      single keydown/keyup coordinator: one listener per phase that maps the event's chord to candidates in
+      precedence order and runs until one reports handled. Preserve <code>withRecoveredLetterKey</code>,
+      <code>shouldHandleEvent</code>, hold-binding handling, and <code>eventOptions</code> precedence.</li>
+  <li>Tests — all of the activation-time tests, plus: a declining winner falls through to the next candidate;
+      a handling winner suppresses the rest; decline order respects priority then recency.</li>
 </ul>
 <p><small>Per repo testing guidance: no tests that merely re-state default binding strings.</small></p>
 

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -151,9 +151,14 @@ it changes the recommendation.
       <code>priority: number</code> (Model C) as non-local and full of magic-number cliffs. That critique
       still stands — and it's <em>specifically about per-binding numbers</em>. Context-level precedence
       (one number per context, ~9 of them) dodges it.</li>
-  <li><strong>Teach the conflict UI about intentional shadowing.</strong> <code>findKeybindingConflicts</code>
-      (<span class="filepath">keybindingConflicts.ts</span>) will flag a deliberately-shadowed chord as a
-      collision. Whatever we ship, the UI should render "shadowed by X while active," not "conflict."</li>
+  <li><strong>Teach the conflict UI about intentional shadowing — but broaden its overlap model first.</strong>
+      Subtle: <code>findKeybindingConflicts</code> today won't even <em>see</em> the surface-vs-<code>normal-mode</code>
+      shadow. Its <code>contextsOverlap</code> (<span class="filepath">keybindingConflicts.ts:34</span>) is
+      <code>a === b || a === 'global' || b === 'global'</code> — two <em>different non-global</em> contexts are
+      treated as non-overlapping, so a high-priority surface shadowing <code>normal-mode</code> on the same chord
+      is never returned as a conflict. So there is nothing to "relabel" until the conflict model is extended to
+      consider cross-context, priority-aware overlap (feed it activation/priority metadata). The relabel is the
+      <em>second</em> step; broadening detection is the first.</li>
 </ul>
 <p class="meh" style="list-style:none">Where the old doc constrains wrongly: it framed the choice as
 modal-vs-additive and scoped selective precedence out as a "known limit." The report <em>is</em> that
@@ -388,8 +393,12 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
   <li><strong>Equal-priority fragility persists.</strong> When two same-priority contexts activate off one
       focus event, the tiebreak is incidental timing. Acceptable for stacked modes; if a real case wants
       determinism, that's the moment to reconsider — not now.</li>
-  <li><strong>Conflict-UI follow-up.</strong> Extend <code>findKeybindingConflicts</code> to mark
-      priority-shadowed chords as intentional rather than warnings. Can ship after the core change.</li>
+  <li><strong>Conflict-UI follow-up (two steps, in order).</strong> (1) Broaden
+      <code>findKeybindingConflicts</code>' <code>contextsOverlap</code> (<span class="filepath">keybindingConflicts.ts:34</span>)
+      so two different non-global contexts that can co-activate are considered overlapping — today they aren't, so
+      cross-context shadows are invisible to it. (2) Then mark priority-shadowed chords as intentional ("shadowed
+      by X while active") rather than warnings. Both can ship after the core change; step 1 is a prerequisite for
+      step 2 doing anything.</li>
   <li><strong>Granularity escape hatch.</strong> If an in-repo same-key-vs-sequence case ever needs B's
       action-targeted suppression, add it then as a narrow supplement — don't pre-build it.</li>
 </ul>

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -192,11 +192,14 @@ existing comparator.</p>
 needs an escape hatch for the inversion.</p>
 
 <h3>Option A — Context-level priority</h3>
-<p>Add one optional field to <code>ActionContextConfig</code>; default <code>0</code>. Winner =
-highest priority, ties broken by activation recency (Option 0 as the tiebreak).</p>
+<p>Add one optional field to <code>ActionContextConfig</code>. Winner = highest priority, ties broken by
+activation recency (Option 0 as the tiebreak). <em>(Final encoding settled on <strong>named tiers</strong>
+<code>'low' | 'default' | 'high'</code> rather than raw integers — CodeMirror <code>Prec</code> precedent, and it
+sidesteps the magic-number cliffs flagged above; see the implementation plan. Shown below as the option was
+originally framed.)</em></p>
 <pre><code>actionContextsFacet.of({
   type: SURFACE_CONTEXT,
-  priority: 100,          // &gt; normal-mode's default (0)
+  priority: 'high',       // beats normal-mode's 'default'
   // ...
 })</code></pre>
 <ul class="tight">
@@ -318,13 +321,14 @@ any of them. The column shows D combined with priority (A) since that's the live
 they bind?</strong>
 <p style="margin:.5rem 0">Common to both answers: fix the double-fire (single winner per chord), winner =
 shared comparator <code>(priority desc, then activation-recency desc)</code> used by <em>both</em> the keyboard
-path and <code>getActiveActionById</code>, add <code>priority?: number</code> (default <code>0</code>) so the
+path and <code>getActiveActionById</code>, add <code>priority</code> (named tiers
+<code>'low' | 'default' | 'high'</code>, default <code>'default'</code>) so the
 reporting surface outranks <code>normal-mode</code> and the 8 skip-decorators collapse to one line, and keep
 <code>modal</code> as the extreme tier. <strong><code>global</code> is a reserved top tier, outside normal
 collision precedence:</strong> a <code>global</code> binding is never shadowed by a non-global one on a shared
 chord, regardless of priority or activation order. Without this carve-out the comparator violates the doc's own
-"app-wide chords must survive" requirement — <code>global</code> activates early and defaults to priority 0, so a
-later same-priority context would otherwise win Cmd+K / Escape. (<code>computeInstallableContexts</code> only
+"app-wide chords must survive" requirement — <code>global</code> activates early and (absent the carve-out)
+would sit at the <code>'default'</code> tier, so a later same-priority context would otherwise win Cmd+K / Escape. (<code>computeInstallableContexts</code> only
 keeps <code>global</code> in the install <em>set</em>; it does not rank it within a collision, so the dedup pass
 must special-case it.) Drop B (suppression, not precedence; name-coupled) and C (A with coupling).</p>
 <p style="margin:.5rem 0 0"><strong>Resolved (2026-05-30): ship A + D (fire-time, declinable), built as the
@@ -423,7 +427,8 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
 <h2>Rough surface area</h2>
 <p><strong>Shared by both strategies (A core):</strong></p>
 <ul class="tight">
-  <li><code>types.ts</code> — add <code>priority?: number</code> to <code>ActionContextConfig</code> (+ doc comment).</li>
+  <li><code>types.ts</code> — add <code>priority</code> (named tiers <code>'low' | 'default' | 'high'</code>,
+      default <code>'default'</code>) to <code>ActionContextConfig</code> (+ doc comment).</li>
   <li><code>effectiveActions.ts</code> — extract <code>compareContexts</code>; rewrite
       <code>getActiveActionById</code> to use it.</li>
   <li><strong>New shared chord canonicalizer</strong> in <code>src/shortcuts/</code> — lift

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Shortcut context precedence — options &amp; decision aid</title>
+<style>
+  body { font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         max-width: 980px; margin: 2rem auto; padding: 0 1.25rem; color: #1f2328; }
+  h1 { font-size: 1.6rem; margin-bottom: .25rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #d0d7de; padding-bottom: .25rem; }
+  h3 { font-size: 1rem; margin-top: 1.25rem; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; }
+  pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px;
+        padding: .75rem .9rem; overflow-x: auto; }
+  code { background: #f6f8fa; padding: .1em .3em; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .65rem; vertical-align: top; text-align: left; }
+  th { background: #f6f8fa; }
+  .pro { color: #1a7f37; }
+  .pro::before { content: "+ "; font-weight: 700; }
+  .con { color: #cf222e; }
+  .con::before { content: "\2212 "; font-weight: 700; }
+  .meh { color: #9a6700; }
+  .meh::before { content: "~ "; font-weight: 700; }
+  ul.tight { margin: .4rem 0; }
+  .note { background: #fff8c5; border-left: 4px solid #d4a72c; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .axes { background: #ddf4ff; border-left: 4px solid #0969da; padding: .6rem .85rem;
+          border-radius: 4px; margin: 1rem 0; }
+  .verdict { background: #dafbe1; border-left: 4px solid #1a7f37; padding: .75rem 1rem;
+             border-radius: 4px; margin: 1.5rem 0; }
+  .scorecard td:first-child { font-weight: 600; width: 24%; }
+  .scorecard td.win { background: #f0fdf4; }
+  .scorecard td.lose { background: #fff1f0; }
+  .scorecard td.meh { background: #fffbe6; color: #1f2328; }
+  small { color: #57606a; }
+  .filepath { color: #57606a; font-size: 11.5px; }
+</style>
+</head>
+<body>
+
+<h1>Shortcut context precedence</h1>
+<small>Options &amp; decision aid for cross-context shortcut collisions — 2026-05-30</small>
+
+<p>Companion to <code>docs/shortcut-conflict-resolution.md</code> (2026-05-25), which introduced
+the <code>modal</code> flag (now shipped). This doc revisits the area with fresh eyes for a new
+class of report and proposes a precedence model. Where the older doc still holds, it says so;
+where it constrains the design wrongly, it says that too.</p>
+
+<h2>The report</h2>
+<p>A user built a <strong>new display surface for blocks</strong>. The surface registers its own
+action context with a handful of bindings. When you click a block inside that surface, the block
+gains focus and <code>normal-mode</code> activates <em>on top of</em> the surface context. Both
+contexts are now active, and any chord they share <strong>fires both handlers</strong>. Their
+current workaround is a pile of imperative "skip" decorators that no-op the host action — one per
+colliding action.</p>
+
+<p>Two things the user wants that today's primitives don't give:</p>
+<ol>
+  <li><strong>Additive coexistence</strong> for the keys the surface doesn't care about
+      (<code>modal</code> is too broad — it shadows <em>everything</em>).</li>
+  <li>The surface to <strong>win the chords it does bind</strong>, even though
+      <code>normal-mode</code> activated <em>after</em> it.</li>
+</ol>
+
+<h2>Root cause: the double-fire is incidental, not designed</h2>
+
+<p><code>HotkeyReconciler</code> installs <strong>one <code>window</code> listener per active action</strong>
+(<span class="filepath">HotkeyReconciler.tsx:241–264</span>). On a shared chord, both listeners match and
+both run; <code>preventDefault()</code> stops the browser default and other listeners' propagation in
+some cases, but it does <em>not</em> stop sibling listeners registered separately on the same target/phase.
+So both handlers fire. Nothing in the codebase intends two actions on one chord — if you want two effects
+you write one action. <strong>The double-fire is a side effect of the per-listener install model, not a
+feature.</strong> Treat it as a latent bug to close, not a behavior to preserve.</p>
+
+<div class="note">
+<strong>We already resolve to a single winner — just not on the keyboard path.</strong>
+<code>getActiveActionById</code> (<span class="filepath">effectiveActions.ts:77–93</span>), used by
+<code>runActionById</code> (command palette, programmatic dispatch), walks active contexts in
+<strong>reverse activation order</strong> and returns the <em>first</em> match. So "one winner,
+latest-activated context wins" is <em>already the law</em> for one dispatch path. The keyboard path is
+the inconsistent one. Any fix should make the two paths agree.
+</div>
+
+<h2>What we learned looking with new eyes (codebase facts)</h2>
+<table>
+<tr><th>Fact</th><th>Where</th><th>Why it matters here</th></tr>
+<tr>
+  <td><code>modal: true</code> collapses install set to <code>{global, latest-modal}</code></td>
+  <td><span class="filepath">HotkeyReconciler.tsx:56–66</span></td>
+  <td>The only precedence knob today. All-or-nothing: shadows every non-global context, including
+      chords the modal doesn't bind. Right for palettes; wrong for an additive surface.</td>
+</tr>
+<tr>
+  <td>Activation order is runtime state; re-activation rotates to the end</td>
+  <td><span class="filepath">ActiveContexts.tsx:86–97</span></td>
+  <td>"Latest-activated wins" derives precedence from <em>timing</em>. The surface activates on render
+      (early); <code>normal-mode</code> on click (late) — so timing picks the <em>wrong</em> winner.
+      This is the crux of the report.</td>
+</tr>
+<tr>
+  <td><code>canRun</code> is presentational only — never gates dispatch</td>
+  <td><span class="filepath">types.ts:148–156</span>, all call sites are UI surfaces</td>
+  <td>Rules out "gate the loser with <code>canRun</code>." It can't suppress a keypress.</td>
+</tr>
+<tr>
+  <td>Sequence chords (<code>'d d'</code>, <code>'g g'</code>) are real and live on the non-hold path</td>
+  <td><span class="filepath">vim-normal-mode/actions.ts:67, 208</span></td>
+  <td><code>delete_block</code> is bound to <code>['Delete','Backspace','d d']</code>, not a bare
+      <code>d</code>. A single <code>d</code> and the sequence <code>d d</code> are <em>different chords</em>
+      — they don't collide at the exact-chord level. Matters for granularity (below).</td>
+</tr>
+<tr>
+  <td><code>eventFilter</code> is OR-only / opt-in</td>
+  <td><span class="filepath">HotkeyReconciler.tsx:86–96</span></td>
+  <td>A context's filter can only <em>expand</em> what it accepts; no context can decline a chord and
+      defer it to a lower layer. <strong>This is the invariant that makes activation-time resolution
+      safe</strong> (there is never anything to "fall through" to). Load-bearing — see Open questions.</td>
+</tr>
+<tr>
+  <td>The agenda plugin is <em>not</em> in this repo</td>
+  <td>grep: no <code>AGENDA_CONTEXT</code> / <code>set_deadline</code></td>
+  <td>The example in the user's sketch is external. Don't design core semantics around its exact
+      bindings (e.g. the <code>d</code> vs <code>d d</code> sequence mismatch). Solve the general shape.</td>
+</tr>
+</table>
+
+<h2>What to steal from the old doc</h2>
+<ul class="tight">
+  <li><strong>Keep <code>modal</code>.</strong> Precedence resolves <em>collisions</em>; it does not cover
+      the palette case (palette binds <em>no</em> chords but still must stop <code>normal-mode</code>'s
+      <code>p</code> reaching the search box). <code>modal</code> = "own all chords, even unbound." The
+      two are orthogonal tiers and should coexist.</li>
+  <li><strong>The <code>global</code> carve-out is load-bearing.</strong> Whatever wins, app-wide chords
+      (Cmd+K, Escape) must survive. Keep <code>global</code> always-installed.</li>
+  <li><strong>Resolve at the context level, not per binding.</strong> The old doc rejected binding-level
+      <code>priority: number</code> (Model C) as non-local and full of magic-number cliffs. That critique
+      still stands — and it's <em>specifically about per-binding numbers</em>. Context-level precedence
+      (one number per context, ~9 of them) dodges it.</li>
+  <li><strong>Teach the conflict UI about intentional shadowing.</strong> <code>findKeybindingConflicts</code>
+      (<span class="filepath">keybindingConflicts.ts</span>) will flag a deliberately-shadowed chord as a
+      collision. Whatever we ship, the UI should render "shadowed by X while active," not "conflict."</li>
+</ul>
+<p class="meh" style="list-style:none">Where the old doc constrains wrongly: it framed the choice as
+modal-vs-additive and scoped selective precedence out as a "known limit." The report <em>is</em> that
+limit. We're picking it back up.</p>
+
+<h2>The shared decision underneath every option</h2>
+<div class="axes">
+<strong>Whatever we choose, the bug fix is the same:</strong> stop installing both colliding bindings;
+install a single winner per chord. The reconcile effect already re-runs on every <code>active</code>
+change and already installs/uninstalls per action (<span class="filepath">HotkeyReconciler.tsx:194–271</span>),
+so this is a <em>dedup step inside the loop that already runs</em> — not a new coordinator. The options
+below differ only in <strong>how the winner is chosen</strong>.
+</div>
+
+<h2>Options</h2>
+
+<h3>Option 0 — Last-activated-context wins (no new config)</h3>
+<p>Make the keyboard path obey the same rule the dispatch path already does: on a chord collision among
+active contexts, the latest-activated context's binding installs; the rest are skipped. Pure reuse of the
+existing comparator.</p>
+<ul class="tight">
+  <li class="pro">Closes the double-fire with zero new surface area; unifies keyboard and
+      <code>runActionById</code> paths under one rule.</li>
+  <li class="pro">Most collisions today are "stacked modes" where latest <em>is</em> the right winner.</li>
+  <li class="con"><strong>Gets the report's case wrong.</strong> Surface activates early, <code>normal-mode</code>
+      late → the generic layer wins the collision. Exactly the inversion the user is fighting.</li>
+  <li class="con">Precedence = timing, which is incidental when two contexts activate off the same focus
+      event. Non-local: you can't read a context and know if it'll win.</li>
+</ul>
+<p><strong>Verdict:</strong> necessary foundation, insufficient alone. Ship it as the default, but it
+needs an escape hatch for the inversion.</p>
+
+<h3>Option A — Context-level priority</h3>
+<p>Add one optional field to <code>ActionContextConfig</code>; default <code>0</code>. Winner =
+highest priority, ties broken by activation recency (Option 0 as the tiebreak).</p>
+<pre><code>actionContextsFacet.of({
+  type: SURFACE_CONTEXT,
+  priority: 100,          // &gt; normal-mode's default (0)
+  // ...
+})</code></pre>
+<ul class="tight">
+  <li class="pro"><strong>Fixes the inversion directly.</strong> The surface declares it outranks the
+      baseline; click timing no longer decides. Additive for every chord it doesn't bind.</li>
+  <li class="pro">One number per context (~9 total), most at default. This is the Emacs major/minor-mode
+      model — precedence by layer specificity, which is what the user means by "normal mode shouldn't win."</li>
+  <li class="pro">Ownership sits in the right place: the <em>specific</em> layer declares its rank;
+      <code>normal-mode</code> stays dumb and knows nothing about the surface.</li>
+  <li class="pro">Supersedes the per-decorator workaround with a single line.</li>
+  <li class="meh">Resolves per <em>exact chord</em>. The external agenda's <code>d</code> would not shadow
+      <code>delete_block</code>'s <code>d d</code> (different chords). For in-repo cases this is fine —
+      no same-key precedence gap exists today; flag if one appears.</li>
+  <li class="con">Absolute numbers need a known baseline (0). Mitigate with a tiny named tier set
+      (<code>high</code>/<code>default</code>/<code>low</code>) instead of bare integers if desired.</li>
+  <li class="con">A high-priority context silently shadows lower bindings on shared chords — powerful,
+      needs the conflict-UI surfacing noted above.</li>
+</ul>
+
+<h3>Option B — Explicit supersession (declared suppression)</h3>
+<p>A context lists the actions/contexts it suppresses while active. (This is the user's sketch, and the
+old doc's Model B.)</p>
+<pre><code>actionContextsFacet.of({
+  type: SURFACE_CONTEXT,
+  supersedes: {
+    [ActionContextTypes.NORMAL_MODE]: {
+      actionIds: ['delete_block', 'toggle_properties', /* ... */],  // or '*'
+    },
+  },
+})</code></pre>
+<ul class="tight">
+  <li class="pro">Most explicit — the conflict is documented at the site that introduces it.</li>
+  <li class="pro">Targets <em>action ids</em>, so it suppresses regardless of binding shape — handles the
+      <code>d d</code> sequence case that exact-chord priority misses.</li>
+  <li class="con"><strong>Suppression, not precedence.</strong> It only turns things off. For a key both
+      contexts want where the surface should simply <em>win</em>, you still enumerate host actions —
+      drifting back toward A with more typing.</li>
+  <li class="con">Name-coupled to host action ids; brittle if <code>normal-mode</code> renames or adds an
+      action (new colliding action fires until you add it to the list — silent).</li>
+  <li class="con">Verbose (the report needs ~8 entries). The <code>'*'</code> wildcard tames verbosity but
+      then it's <code>modal</code> with extra steps.</li>
+</ul>
+
+<h3>Option C — Selective per-chord shadowing (<code>shadowChordsFrom</code>)</h3>
+<p>Middle ground: a context shadows listed contexts <em>only for chords it itself binds</em>.</p>
+<pre><code>shadowChordsFrom: [ActionContextTypes.NORMAL_MODE]</code></pre>
+<ul class="tight">
+  <li class="pro">Additive by default, surgical on conflict; no per-action bookkeeping.</li>
+  <li class="con">Still name-coupled to the suppressed context.</li>
+  <li class="con"><strong>It's just priority with a target list.</strong> "I beat normal-mode specifically"
+      is the coupled special case of "I beat anything lower." A is the decoupled version. No reason to
+      ship both.</li>
+</ul>
+
+<h2>Scorecard</h2>
+<table class="scorecard">
+<tr><th></th><th>0 · last-wins</th><th>A · priority</th><th>B · supersedes</th><th>C · shadowChordsFrom</th></tr>
+<tr><td>Closes double-fire</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
+<tr><td>Fixes early/late inversion</td><td class="lose">no</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
+<tr><td>Additive for non-bound keys</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td><td class="win">yes</td></tr>
+<tr><td>New config surface</td><td class="win">none</td><td class="meh">1 number</td><td class="lose">nested map</td><td class="meh">1 list</td></tr>
+<tr><td>Avoids host-name coupling</td><td class="win">yes</td><td class="win">yes</td><td class="lose">no</td><td class="lose">no</td></tr>
+<tr><td>Handles <code>d</code> vs <code>d d</code></td><td class="lose">n/a</td><td class="meh">no*</td><td class="win">yes</td><td class="meh">no*</td></tr>
+<tr><td>Reads locally (1 file)</td><td class="lose">no (timing)</td><td class="win">yes</td><td class="win">yes</td><td class="meh">mostly</td></tr>
+</table>
+<p><small>* exact-chord granularity; no in-repo case needs cross-granularity shadowing today.</small></p>
+
+<div class="verdict">
+<strong>Recommendation: Option 0 as the default + Option A as the escape hatch.</strong>
+<ol style="margin:.5rem 0 0">
+  <li><strong>Fix the double-fire</strong> by installing a single winner per chord in the existing
+      reconcile loop. This alone is most of the value and is unambiguously a bug fix.</li>
+  <li><strong>Winner = shared comparator</strong> <code>(priority desc, then activation-recency desc)</code>,
+      factored once and used by <em>both</em> the keyboard dedup and <code>getActiveActionById</code>, so the
+      two dispatch paths can't diverge.</li>
+  <li><strong><code>priority?: number</code></strong> on <code>ActionContextConfig</code>, default <code>0</code>.
+      The reporting surface sets it above <code>normal-mode</code>; the 8 skip-decorators collapse to one line.</li>
+  <li><strong>Keep <code>modal</code></strong> as the extreme tier (own all chords, even unbound). Conceptually
+      "very high priority + suppress the rest."</li>
+  <li><strong>Drop B and C.</strong> C is A with coupling. B is suppression, not precedence — keep it in
+      reserve only if a real same-key, action-targeted, cross-granularity case appears in-repo (none today).</li>
+</ol>
+Skip-decorators were the wrong layer: imperative no-ops fighting the architecture, and <code>canRun</code>
+can't gate dispatch anyway. If a genuine static "remove this action everywhere" need arises, the clean tool
+is letting <code>ActionDecorator.decorate</code> return <code>null</code> (parity with
+<code>ActionOverride.apply</code>) — a separate concern from precedence.
+</div>
+
+<h2>Open questions / risks</h2>
+<ul class="tight">
+  <li><strong>The <code>eventFilter</code> invariant is load-bearing.</strong> Activation-time resolution
+      is correct <em>only because</em> no context can decline-and-defer a chord. If someone later writes a
+      filter meant to scope a chord down and hand it to a lower layer, pre-resolution breaks (the loser is
+      already uninstalled) and you'd need fire-time resolution. Document this next to the dedup so a future
+      reader knows what they'd be voiding.</li>
+  <li><strong>Chord canonicalization.</strong> Grouping by chord needs the same normalization
+      <code>keybindingConflicts.ts</code> already does (alternatives like <code>['$mod+z','ctrl+z']</code>,
+      code-form chords). Reuse it; don't reinvent. (Not unique to this approach — any single-winner scheme
+      needs it.)</li>
+  <li><strong>Equal-priority fragility persists.</strong> When two same-priority contexts activate off one
+      focus event, the tiebreak is incidental timing. Acceptable for stacked modes; if a real case wants
+      determinism, that's the moment to reconsider — not now.</li>
+  <li><strong>Conflict-UI follow-up.</strong> Extend <code>findKeybindingConflicts</code> to mark
+      priority-shadowed chords as intentional rather than warnings. Can ship after the core change.</li>
+  <li><strong>Granularity escape hatch.</strong> If an in-repo same-key-vs-sequence case ever needs B's
+      action-targeted suppression, add it then as a narrow supplement — don't pre-build it.</li>
+</ul>
+
+<h2>Rough surface area (if we proceed with 0 + A)</h2>
+<ul class="tight">
+  <li><code>types.ts</code> — add <code>priority?: number</code> to <code>ActionContextConfig</code> (+ doc comment).</li>
+  <li><code>effectiveActions.ts</code> — extract <code>compareContexts</code>; rewrite
+      <code>getActiveActionById</code> to use it.</li>
+  <li><code>HotkeyReconciler.tsx</code> — per-chord dedup in the install loop using the shared comparator;
+      document the <code>eventFilter</code> invariant.</li>
+  <li>Tests — higher-priority context wins a same-key collision even when activated earlier; deactivating it
+      restores the lower binding; equal priority falls back to last-wins; <code>modal</code> still suppresses
+      non-colliding chords; <code>global</code> survives.</li>
+</ul>
+<p><small>Per repo testing guidance: no tests that merely re-state default binding strings.</small></p>
+
+</body>
+</html>

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -327,14 +327,18 @@ chord, regardless of priority or activation order. Without this carve-out the co
 later same-priority context would otherwise win Cmd+K / Escape. (<code>computeInstallableContexts</code> only
 keeps <code>global</code> in the install <em>set</em>; it does not rank it within a collision, so the dedup pass
 must special-case it.) Drop B (suppression, not precedence; name-coupled) and C (A with coupling).</p>
-<p style="margin:.5rem 0"><strong>If NO — every case is "this layer wins these keys, full stop":</strong>
-ship <strong>A + activation-time</strong> resolution (dedup in the reconcile loop that already runs). Smallest
-change; no handler-contract churn. This is the default recommendation absent evidence otherwise.</p>
-<p style="margin:.5rem 0 0"><strong>If YES — a surface wants to own a key sometimes and pass it through
-otherwise:</strong> ship <strong>A + D (fire-time, declinable)</strong>. Costs a real dispatch coordinator and
-a handler return value, but it's the clean version of the capability the double-fire gives us by accident, and
-retrofitting it later means redoing the dispatch path. <em>This is the open decision for the reader</em> — see
-the question at the top of Open questions.</p>
+<p style="margin:.5rem 0 0"><strong>Resolved (2026-05-30): ship A + D (fire-time, declinable), built as the
+resolution core.</strong> The open question below was "does anything need conditional yield?" — a committed
+downstream consumer answers YES: input-unification work (spatial selection) needs a click handler to say "this
+is a selection gesture, not mine — fall through," which is the same declinable mechanism, and needs the single
+fire-time coordinator D builds (chord/descriptor → ordered candidates → run-until-handled) to later own
+mouse/touch too. Given a <em>named</em> consumer (not a speculative one), the YAGNI case for the cheaper
+activation-time A collapses: building A would leave the keyboard path as N <code>window</code> listeners that
+the input work must tear out — negative work. So: build the winner-selection as a reusable
+<code>resolve(activeSet, trigger)</code> the keyboard path, <code>runActionById</code>, and
+<code>useRunAction</code> all call; make <code>trigger</code> a normalized descriptor, not a
+<code>KeyboardEvent</code>; keep <code>phase</code>/<code>role</code> first-class on bindings. A's
+activation-time dedup remains the correct fallback <em>only</em> if the input-unification work is abandoned.</p>
 </div>
 
 <div class="note">
@@ -351,12 +355,20 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
 
 <h2>Open questions / risks</h2>
 <ul class="tight">
-  <li><strong>THE decision: is conditional fall-through (Option D) needed?</strong> Everything else is
-      settled; this isn't. Decider: audit the 8 skip-decorators on the user's surface. If they always no-op the
-      host action when the surface is active → unconditional → A alone suffices, ship activation-time. If any
-      no-op the host <em>only under a condition</em> (and otherwise want the host to run) → that's conditional
-      fall-through in disguise → ship D (fire-time). Picking activation-time and discovering a conditional case
-      later is a dispatch-path rewrite, so decide this deliberately, not by default.</li>
+  <li><strong>THE decision: is conditional fall-through (Option D) needed? — RESOLVED YES (2026-05-30).</strong>
+      A committed downstream consumer (input-unification / spatial selection) needs declinable dispatch: a click
+      handler that says "this is a selection gesture, not mine — fall through" is exactly conditional fall-through,
+      and it wants the same fire-time coordinator extended to own mouse/touch. That converts this from a
+      speculative YAGNI risk into a named requirement, so ship D built as the shared resolver. (The earlier
+      decider — auditing the surface's skip-decorators for conditional no-ops — still applies as corroboration,
+      but the downstream consumer is dispositive on its own.)</li>
+  <li><strong>Normalized trigger descriptor (from the same downstream constraint).</strong> The resolver's
+      event arg must be an opaque/normalized input descriptor — <code>{kind, modifiers, phase, role, …}</code> —
+      not a <code>KeyboardEvent</code>, so mouse/gesture descriptor kinds can be added to the same matcher later.
+      Two specifics this forces: (1) the shared canonicalizer (above) becomes chord↔descriptor, not chord-only;
+      (2) <code>phase</code> and <code>role</code> are first-class binding fields, not keyboard-only — a
+      double-click gesture binds at <code>mousedown</code> on the content node to beat native text selection.
+      Don't bake phase as keyboard-specific.</li>
   <li><strong>The <code>eventFilter</code> invariant is load-bearing for activation-time.</strong> Pre-resolution
       is correct <em>only because</em> no context can decline-and-defer a chord today. If we ship activation-time
       and someone later writes a filter (or handler) meant to scope a chord down and hand it to a lower layer,

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -388,12 +388,17 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
       reordered modifiers, and code-form chords would land in different buckets and install as separate
       listeners. The only real normalizer is <code>normalizeChord</code> in
       <span class="filepath">keybindings-settings/keyCapture.ts:205</span>, and it has limits: it maps
-      modifier aliases (<code>cmd</code>/<code>meta</code>/<code>os</code> → <code>$mod</code>) and lowercases
-      modifier names, but does <strong>not sort modifiers</strong> (so <code>Shift+$mod+k</code> vs
-      <code>$mod+Shift+k</code> still differ) and lives in a plugin, not shared infra. <strong>Action item:</strong>
-      this work must <em>add</em> a shared canonicalizer (lift/extend <code>normalizeChord</code> into
-      <code>src/shortcuts/</code>, add modifier sorting) and use it in both the dedup and ideally
-      <code>keybindingConflicts</code> — it is not a "reuse what exists" freebie.</li>
+      modifier aliases (<code>cmd</code>/<code>meta</code>/<code>os</code> → <code>$mod</code>), lowercases
+      modifier names, <em>and</em> sorts modifiers into a stable order (verified at
+      <span class="filepath">keyCapture.ts:236</span>, tested at
+      <span class="filepath">test/keyCapture.test.ts:147</span> — an earlier draft of this doc wrongly claimed
+      it does not sort). Its <em>real</em> limits: it splits on <code>+</code> only, so it does
+      <strong>not handle sequence chords</strong> — <code>d d</code> / <code>g g</code> get treated as one
+      atomic space-bearing key; it returns a flat string, not a structured descriptor; and it lives in a plugin,
+      not shared infra. <strong>Action item:</strong> this work must <em>add</em> a shared canonicalizer (lift
+      <code>normalizeChord</code> into <code>src/shortcuts/</code>, add <em>sequence-chord parsing</em> + a
+      descriptor shape) and use it in both the dedup and ideally <code>keybindingConflicts</code> — the lift is
+      reuse, but the sequence parsing + descriptor are net-new.</li>
   <li><strong>Dedup key must include <code>phase</code>, not just the chord.</strong>
       <code>ShortcutBindingDefaults</code> supports <code>keydown</code> / <code>keyup</code> / <code>hold</code>,
       and the repo already has phase-distinct same-key bindings that are <em>not</em> a same-event collision:
@@ -421,9 +426,10 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
   <li><code>types.ts</code> — add <code>priority?: number</code> to <code>ActionContextConfig</code> (+ doc comment).</li>
   <li><code>effectiveActions.ts</code> — extract <code>compareContexts</code>; rewrite
       <code>getActiveActionById</code> to use it.</li>
-  <li><strong>New shared chord canonicalizer</strong> in <code>src/shortcuts/</code> — lift/extend
-      <code>normalizeChord</code> (alias-fold + lowercase modifiers + <em>sort modifiers</em>); use it in the
-      dedup and, ideally, retrofit <code>keybindingConflicts.ts</code> off it. This is net-new code, not reuse.</li>
+  <li><strong>New shared chord canonicalizer</strong> in <code>src/shortcuts/</code> — lift
+      <code>normalizeChord</code> (which already alias-folds + lowercases + sorts modifiers) and add
+      <em>sequence-chord parsing</em> + a structured descriptor; use it in the dedup and, ideally, retrofit
+      <code>keybindingConflicts.ts</code> off it. The lift is reuse; the sequence parsing + descriptor are net-new.</li>
 </ul>
 <p><strong>If activation-time (A only):</strong></p>
 <ul class="tight">

--- a/docs/shortcut-context-precedence.html
+++ b/docs/shortcut-context-precedence.html
@@ -352,10 +352,26 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
       pre-resolution breaks (the loser is already uninstalled). That's the same wall as the D question — Option D
       <em>is</em> the supported way to do declinable handling. Document the invariant next to the dedup so a future
       reader knows shipping declinable handling means moving to fire-time, not bolting onto the filter.</li>
-  <li><strong>Chord canonicalization.</strong> Grouping by chord needs the same normalization
-      <code>keybindingConflicts.ts</code> already does (alternatives like <code>['$mod+z','ctrl+z']</code>,
-      code-form chords). Reuse it; don't reinvent. (Not unique to this approach — any single-winner scheme
-      needs it.)</li>
+  <li><strong>Chord canonicalization is NOT free today.</strong> Grouping by chord needs equivalent
+      bindings to compare equal — but <code>keybindingConflicts.ts</code> does <em>not</em> canonicalize;
+      it buckets raw strings via <code>toChordArray</code>, so <code>Meta+K</code> vs <code>$mod+k</code>,
+      reordered modifiers, and code-form chords would land in different buckets and install as separate
+      listeners. The only real normalizer is <code>normalizeChord</code> in
+      <span class="filepath">keybindings-settings/keyCapture.ts:205</span>, and it has limits: it maps
+      modifier aliases (<code>cmd</code>/<code>meta</code>/<code>os</code> → <code>$mod</code>) and lowercases
+      modifier names, but does <strong>not sort modifiers</strong> (so <code>Shift+$mod+k</code> vs
+      <code>$mod+Shift+k</code> still differ) and lives in a plugin, not shared infra. <strong>Action item:</strong>
+      this work must <em>add</em> a shared canonicalizer (lift/extend <code>normalizeChord</code> into
+      <code>src/shortcuts/</code>, add modifier sorting) and use it in both the dedup and ideally
+      <code>keybindingConflicts</code> — it is not a "reuse what exists" freebie.</li>
+  <li><strong>Dedup key must include <code>phase</code>, not just the chord.</strong>
+      <code>ShortcutBindingDefaults</code> supports <code>keydown</code> / <code>keyup</code> / <code>hold</code>,
+      and the repo already has phase-distinct same-key bindings that are <em>not</em> a same-event collision:
+      <code>dateScrubActions.ts</code> binds hold <code>s</code> in <code>normal-mode</code>
+      (<span class="filepath">:75</span>) and keyup <code>s</code> in <code>date-scrub</code>
+      (<span class="filepath">:90</span>). A chord-only bucket would wrongly make one shadow the other. Key the
+      winner bucket on <code>(canonical-chord, phase)</code>, and keep hold handling on its own path (it already
+      installs via a separate observer). Only same-<code>(chord, phase)</code> bindings are a real collision.</li>
   <li><strong>Equal-priority fragility persists.</strong> When two same-priority contexts activate off one
       focus event, the tiebreak is incidental timing. Acceptable for stacked modes; if a real case wants
       determinism, that's the moment to reconsider — not now.</li>
@@ -371,14 +387,20 @@ everywhere" need, the clean tool is letting <code>ActionDecorator.decorate</code
   <li><code>types.ts</code> — add <code>priority?: number</code> to <code>ActionContextConfig</code> (+ doc comment).</li>
   <li><code>effectiveActions.ts</code> — extract <code>compareContexts</code>; rewrite
       <code>getActiveActionById</code> to use it.</li>
+  <li><strong>New shared chord canonicalizer</strong> in <code>src/shortcuts/</code> — lift/extend
+      <code>normalizeChord</code> (alias-fold + lowercase modifiers + <em>sort modifiers</em>); use it in the
+      dedup and, ideally, retrofit <code>keybindingConflicts.ts</code> off it. This is net-new code, not reuse.</li>
 </ul>
 <p><strong>If activation-time (A only):</strong></p>
 <ul class="tight">
-  <li><code>HotkeyReconciler.tsx</code> — per-chord dedup in the install loop using the shared comparator;
-      install only the winner; document the <code>eventFilter</code> invariant.</li>
+  <li><code>HotkeyReconciler.tsx</code> — <code>(canonical-chord, phase)</code> dedup in the install loop using
+      the shared comparator; install only the winner per bucket; keep the hold path distinct; document the
+      <code>eventFilter</code> invariant.</li>
   <li>Tests — higher-priority context wins a same-key collision even when activated earlier; deactivating it
       restores the lower binding; equal priority falls back to last-wins; <code>modal</code> still suppresses
-      non-colliding chords; <code>global</code> survives.</li>
+      non-colliding chords; <code>global</code> survives; <strong>same key on different phases (hold <code>s</code>
+      vs keyup <code>s</code>) does NOT dedup away</strong>; alias-equivalent chords (<code>Meta+K</code> /
+      <code>$mod+k</code>) DO dedup together.</li>
 </ul>
 <p><strong>If fire-time (A + D):</strong></p>
 <ul class="tight">


### PR DESCRIPTION
## What

Adds `docs/shortcut-context-precedence.html` — a decision aid for cross-context shortcut collisions, written as a companion/follow-up to `docs/shortcut-conflict-resolution.md` (which shipped the `modal` flag).

This is **docs only** — no code changes. It exists to get agreement on the resolution rule before touching `HotkeyReconciler.tsx`.

## Why

A user built a new display surface that registers its own action context. Clicking a block inside it activates `normal-mode` *on top of* the surface context, and shared chords **fire both handlers**. Their current workaround is a stack of imperative "skip" decorators (one per colliding action). They want additive coexistence for keys the surface doesn't bind, plus the surface to *win* the chords it does bind.

## Key points

- **The double-fire is incidental, not designed.** `HotkeyReconciler` installs one `window` listener per active action, so colliding bindings both run. `getActiveActionById` already resolves to a single winner ("latest-activated context wins") on the `runActionById` path — the keyboard path is the inconsistent one.
- **Looked at the codebase with fresh eyes** (per request), but carried forward what still holds from the old doc: keep `modal`, keep the `global` carve-out, resolve at context level not per-binding, teach the conflict UI about intentional shadowing.
- **Options compared:** `0` last-activated-wins (no config), `A` context-level `priority`, `B` explicit `supersedes`, `C` `shadowChordsFrom` — with a scorecard.
- **Recommendation:** ship last-wins as the default bug fix + an optional context-level `priority` (default 0) as the escape hatch for the early/late activation inversion; keep `modal`; drop B/C. One shared comparator used by both the keyboard dedup and `getActiveActionById`.
- Notes the load-bearing `eventFilter` invariant (OR/opt-in only) that makes activation-time resolution safe, and that `canRun` is presentational and can't gate dispatch.

## Notes

- The agenda/`AGENDA_CONTEXT` example from the original sketch is **external** (not in this repo); the doc deliberately solves the general shape rather than that plugin's exact `d` vs `d d` bindings.
- Rendered HTML to match the existing `docs/*.html` design-doc convention.

https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg)_