### PR TITLE
Load app offline from persisted session; sync indicator polish

### DIFF
--- a/src/components/Login.test.tsx
+++ b/src/components/Login.test.tsx
@@ -1,0 +1,96 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
+
+// Drives the SupabaseLogin offline-boot path: the component seeds its session
+// from the persisted store, and the auth-state listener must not wipe that
+// seed when Supabase emits a null INITIAL_SESSION after an offline token
+// refresh fails (only an explicit SIGNED_OUT should clear it).
+
+type AuthCallback = (event: AuthChangeEvent, session: Session | null) => void
+
+const fakeSession = {
+  access_token: 'token',
+  refresh_token: 'refresh',
+  expires_at: 1,
+  user: {id: 'user-1'},
+} as unknown as Session
+
+const mocks = vi.hoisted(() => ({
+  persisted: null as Session | null,
+  authCallback: null as AuthCallback | null,
+  getSession: vi.fn(),
+}))
+
+vi.mock('@/services/supabase.js', () => ({
+  hasSupabaseAuthConfig: true,
+  supabase: {
+    auth: {
+      getSession: mocks.getSession,
+      onAuthStateChange: (cb: AuthCallback) => {
+        mocks.authCallback = cb
+        return {data: {subscription: {unsubscribe: vi.fn()}}}
+      },
+      signOut: vi.fn(async () => ({error: null})),
+    },
+  },
+  readPersistedSession: () => mocks.persisted,
+  sessionUserToAppUser: (session: Session) => ({id: session.user.id, name: session.user.id}),
+}))
+
+vi.mock('@/services/powersync.js', () => ({
+  hasRemoteSyncConfig: true,
+}))
+
+const emit = (event: AuthChangeEvent, session: Session | null) => {
+  act(() => {
+    mocks.authCallback?.(event, session)
+  })
+}
+
+describe('SupabaseLogin offline boot', () => {
+  beforeEach(() => {
+    mocks.persisted = fakeSession
+    mocks.authCallback = null
+    // Offline: getSession resolves with an error and no session.
+    mocks.getSession.mockResolvedValue({data: {session: null}, error: {message: 'offline'}})
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  const renderLogin = async () => {
+    const {Login} = await import('./Login.tsx')
+    render(
+      <Login>
+        <div>APP CONTENT</div>
+      </Login>,
+    )
+    // Let the getSession() promise settle.
+    await act(async () => {})
+  }
+
+  it('keeps the seeded session when a null INITIAL_SESSION arrives offline', async () => {
+    await renderLogin()
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
+
+    // Supabase emits this after the offline refresh fails — must not log us
+    // out, so the app (children) stays mounted.
+    emit('INITIAL_SESSION', null)
+
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
+  })
+
+  it('clears the session on an explicit SIGNED_OUT', async () => {
+    await renderLogin()
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
+
+    // A real sign-out still tears the app down (children unmount).
+    emit('SIGNED_OUT', null)
+
+    expect(screen.queryByText('APP CONTENT')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/Login.test.tsx
+++ b/src/components/Login.test.tsx
@@ -2,10 +2,11 @@ import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 
-// Drives the SupabaseLogin offline-boot path: the component seeds its session
-// from the persisted store, and the auth-state listener must not wipe that
-// seed when Supabase emits a null INITIAL_SESSION after an offline token
-// refresh fails (only an explicit SIGNED_OUT should clear it).
+// Drives the SupabaseLogin bootstrap, which uses onAuthStateChange as the
+// single source of truth and seeds the first render from the persisted
+// session for an instant offline paint. Covers: offline boot survives a null
+// INITIAL_SESSION (the seed must not be wiped), explicit SIGNED_OUT tears the
+// app down, and an auth-callback URL suppresses the stale-session fast path.
 
 type AuthCallback = (event: AuthChangeEvent, session: Session | null) => void
 
@@ -18,15 +19,14 @@ const fakeSession = {
 
 const mocks = vi.hoisted(() => ({
   persisted: null as Session | null,
+  isCallbackUrl: false,
   authCallback: null as AuthCallback | null,
-  getSession: vi.fn(),
 }))
 
 vi.mock('@/services/supabase.js', () => ({
   hasSupabaseAuthConfig: true,
   supabase: {
     auth: {
-      getSession: mocks.getSession,
       onAuthStateChange: (cb: AuthCallback) => {
         mocks.authCallback = cb
         return {data: {subscription: {unsubscribe: vi.fn()}}}
@@ -35,6 +35,7 @@ vi.mock('@/services/supabase.js', () => ({
     },
   },
   readPersistedSession: () => mocks.persisted,
+  isAuthCallbackUrl: () => mocks.isCallbackUrl,
   sessionUserToAppUser: (session: Session) => ({id: session.user.id, name: session.user.id}),
 }))
 
@@ -48,12 +49,21 @@ const emit = (event: AuthChangeEvent, session: Session | null) => {
   })
 }
 
-describe('SupabaseLogin offline boot', () => {
+const renderLogin = async () => {
+  const {Login} = await import('./Login.tsx')
+  render(
+    <Login>
+      <div>APP CONTENT</div>
+    </Login>,
+  )
+  await act(async () => {})
+}
+
+describe('SupabaseLogin bootstrap', () => {
   beforeEach(() => {
     mocks.persisted = fakeSession
+    mocks.isCallbackUrl = false
     mocks.authCallback = null
-    // Offline: getSession resolves with an error and no session.
-    mocks.getSession.mockResolvedValue({data: {session: null}, error: {message: 'offline'}})
     window.localStorage.clear()
   })
 
@@ -62,23 +72,19 @@ describe('SupabaseLogin offline boot', () => {
     vi.clearAllMocks()
   })
 
-  const renderLogin = async () => {
-    const {Login} = await import('./Login.tsx')
-    render(
-      <Login>
-        <div>APP CONTENT</div>
-      </Login>,
-    )
-    // Let the getSession() promise settle.
-    await act(async () => {})
-  }
+  it('paints immediately from the persisted session (offline, no auth event yet)', async () => {
+    await renderLogin()
+    // No getSession() round-trip and no auth event emitted yet — the seeded
+    // session alone renders the app.
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
+  })
 
   it('keeps the seeded session when a null INITIAL_SESSION arrives offline', async () => {
     await renderLogin()
     expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
 
-    // Supabase emits this after the offline refresh fails — must not log us
-    // out, so the app (children) stays mounted.
+    // auth-js emits this after the offline refresh fails while leaving the
+    // session in storage — it must not log us out.
     emit('INITIAL_SESSION', null)
 
     expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
@@ -88,9 +94,22 @@ describe('SupabaseLogin offline boot', () => {
     await renderLogin()
     expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
 
-    // A real sign-out still tears the app down (children unmount).
     emit('SIGNED_OUT', null)
 
     expect(screen.queryByText('APP CONTENT')).not.toBeInTheDocument()
+  })
+
+  it('does not paint a stale session on an auth-callback URL until it resolves', async () => {
+    // A magic-link / OAuth callback is in flight: the persisted session may
+    // belong to a different user, so we wait rather than mounting it.
+    mocks.isCallbackUrl = true
+
+    await renderLogin()
+    expect(screen.queryByText('APP CONTENT')).not.toBeInTheDocument()
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+
+    // Once auth-js resolves the callback into the real session, render it.
+    emit('SIGNED_IN', {...fakeSession, user: {id: 'user-2'}} as Session)
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument()
   })
 })

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { useLocalStorage } from 'react-use'
 import { User } from '@/types.js'
-import { hasSupabaseAuthConfig, sessionUserToAppUser, supabase } from '@/services/supabase.js'
+import { hasSupabaseAuthConfig, readPersistedSession, sessionUserToAppUser, supabase } from '@/services/supabase.js'
 import { hasRemoteSyncConfig } from '@/services/powersync.js'
 import { Session } from '@supabase/supabase-js'
 
@@ -166,8 +166,17 @@ interface SupabaseLoginProps {
 
 function SupabaseLogin({children, onContinueLocally}: SupabaseLoginProps) {
   const client = supabase!
-  const [session, setSession] = useState<Session | null>(null)
-  const [initializing, setInitializing] = useState(true)
+  // Boot from the persisted session synchronously so an offline launch
+  // isn't blocked behind getSession()'s token refresh. When the access token
+  // is expired, getSession() refreshes before resolving — offline that
+  // retries for ~30s and then yields a null session, freezing startup and
+  // kicking the user to the login screen despite having a usable local
+  // database. Seeding initial state from the stored session lets the app
+  // load right away; the getSession() call below still runs to pick up a
+  // fresher token (or a session captured from the magic-link URL) when
+  // reachable.
+  const [session, setSession] = useState<Session | null>(() => readPersistedSession())
+  const [initializing, setInitializing] = useState(() => readPersistedSession() === null)
   const [stage, setStage] = useState<Stage>('enter-email')
   const [submitting, setSubmitting] = useState(false)
   const [email, setEmail] = useState('')
@@ -178,9 +187,25 @@ function SupabaseLogin({children, onContinueLocally}: SupabaseLoginProps) {
   useEffect(() => {
     let isMounted = true
 
-    void client.auth.getSession().then(({data}) => {
+    // We may already have booted from the persisted session (see the state
+    // initializers above); remember whether one existed so an offline
+    // getSession() failure doesn't sign the user back out.
+    const persisted = readPersistedSession()
+
+    void client.auth.getSession().then(({data, error: sessionError}) => {
       if (!isMounted) return
-      setSession(data.session ?? null)
+      if (sessionError) {
+        // Offline / transient refresh failure. Keep the persisted session
+        // we already booted with rather than signing the user out; the
+        // auto-refresh ticker reconnects us once we're back online.
+        if (!persisted) setSession(null)
+      } else {
+        setSession(data.session ?? null)
+      }
+      setInitializing(false)
+    }).catch(() => {
+      if (!isMounted) return
+      if (!persisted) setSession(null)
       setInitializing(false)
     })
 

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -209,12 +209,22 @@ function SupabaseLogin({children, onContinueLocally}: SupabaseLoginProps) {
       setInitializing(false)
     })
 
-    const {data: listener} = client.auth.onAuthStateChange((_event, next) => {
+    const {data: listener} = client.auth.onAuthStateChange((event, next) => {
       if (!isMounted) return
-      setSession(next)
       if (next) {
+        setSession(next)
         setError(null)
         setCode('')
+        return
+      }
+      // A null session here is only a real logout when it's an explicit
+      // SIGNED_OUT. Offline, Supabase also emits INITIAL_SESSION with a null
+      // session after the token refresh fails — honoring that would wipe the
+      // session we seeded from storage and bounce the user to the login
+      // screen, defeating the offline boot. Keep the persisted session in
+      // that case; a genuine sign-out still clears it.
+      if (event === 'SIGNED_OUT') {
+        setSession(null)
       }
     })
 

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { useLocalStorage } from 'react-use'
 import { User } from '@/types.js'
-import { hasSupabaseAuthConfig, readPersistedSession, sessionUserToAppUser, supabase } from '@/services/supabase.js'
+import { hasSupabaseAuthConfig, isAuthCallbackUrl, readPersistedSession, sessionUserToAppUser, supabase } from '@/services/supabase.js'
 import { hasRemoteSyncConfig } from '@/services/powersync.js'
 import { Session } from '@supabase/supabase-js'
 
@@ -164,19 +164,34 @@ interface SupabaseLoginProps {
   onContinueLocally: () => void
 }
 
+// Seed the first render from the persisted session for an instant offline
+// paint — UNLESS the URL is an auth callback, in which case the stored
+// session may belong to a different user (account switch / shared device)
+// and per-user PowerSync DBs are keyed by user id; we wait for auth-js to
+// resolve the callback into the real session rather than briefly mounting
+// the wrong user's local data.
+const seedSession = (): Session | null =>
+  isAuthCallbackUrl() ? null : readPersistedSession()
+
 function SupabaseLogin({children, onContinueLocally}: SupabaseLoginProps) {
   const client = supabase!
-  // Boot from the persisted session synchronously so an offline launch
-  // isn't blocked behind getSession()'s token refresh. When the access token
-  // is expired, getSession() refreshes before resolving — offline that
-  // retries for ~30s and then yields a null session, freezing startup and
-  // kicking the user to the login screen despite having a usable local
-  // database. Seeding initial state from the stored session lets the app
-  // load right away; the getSession() call below still runs to pick up a
-  // fresher token (or a session captured from the magic-link URL) when
-  // reachable.
-  const [session, setSession] = useState<Session | null>(() => readPersistedSession())
-  const [initializing, setInitializing] = useState(() => readPersistedSession() === null)
+  // `onAuthStateChange` is the single source of truth for the session.
+  // auth-js emits INITIAL_SESSION once it has recovered/refreshed from
+  // storage (online, with the real session), SIGNED_IN after a magic-link /
+  // OTP / OAuth callback resolves, and SIGNED_OUT on sign-out or a
+  // genuinely-revoked refresh token. We deliberately do NOT call
+  // getSession(): when the stored access token is past its refresh margin,
+  // getSession() (and INITIAL_SESSION) try to refresh before resolving, and
+  // offline that fails and reports a null session — which would freeze
+  // startup and bounce the user to the login screen despite a usable local
+  // database. Seeding from storage lets us paint immediately; the listener
+  // upgrades the token in the background once we're back online.
+  const [session, setSession] = useState<Session | null>(seedSession)
+  // If we seeded a session we can render right away. Otherwise wait for the
+  // first auth event (also covers the auth-callback case, where we must not
+  // paint until the real session lands). Derived from the seed once via the
+  // lazy initializer so it can't diverge from `session`.
+  const [initializing, setInitializing] = useState(() => session === null)
   const [stage, setStage] = useState<Stage>('enter-email')
   const [submitting, setSubmitting] = useState(false)
   const [email, setEmail] = useState('')
@@ -187,42 +202,24 @@ function SupabaseLogin({children, onContinueLocally}: SupabaseLoginProps) {
   useEffect(() => {
     let isMounted = true
 
-    // We may already have booted from the persisted session (see the state
-    // initializers above); remember whether one existed so an offline
-    // getSession() failure doesn't sign the user back out.
-    const persisted = readPersistedSession()
-
-    void client.auth.getSession().then(({data, error: sessionError}) => {
-      if (!isMounted) return
-      if (sessionError) {
-        // Offline / transient refresh failure. Keep the persisted session
-        // we already booted with rather than signing the user out; the
-        // auto-refresh ticker reconnects us once we're back online.
-        if (!persisted) setSession(null)
-      } else {
-        setSession(data.session ?? null)
-      }
-      setInitializing(false)
-    }).catch(() => {
-      if (!isMounted) return
-      if (!persisted) setSession(null)
-      setInitializing(false)
-    })
-
     const {data: listener} = client.auth.onAuthStateChange((event, next) => {
       if (!isMounted) return
+      // The first event of any kind means auth-js has finished its
+      // storage/URL recovery — we now have a definitive answer.
+      setInitializing(false)
+
       if (next) {
         setSession(next)
         setError(null)
         setCode('')
         return
       }
-      // A null session here is only a real logout when it's an explicit
-      // SIGNED_OUT. Offline, Supabase also emits INITIAL_SESSION with a null
-      // session after the token refresh fails — honoring that would wipe the
-      // session we seeded from storage and bounce the user to the login
-      // screen, defeating the offline boot. Keep the persisted session in
-      // that case; a genuine sign-out still clears it.
+      // A null session is only a real logout when it's an explicit
+      // SIGNED_OUT (sign-out, or a non-retryable refresh failure where
+      // auth-js clears storage). Offline, auth-js also emits INITIAL_SESSION
+      // with null after the refresh fails while LEAVING the session in
+      // storage — honoring that would wipe the session we seeded and bounce
+      // the user to the login screen. Keep the seeded session in that case.
       if (event === 'SIGNED_OUT') {
         setSession(null)
       }

--- a/src/plugins/sync-status/SyncStatusHeaderItem.tsx
+++ b/src/plugins/sync-status/SyncStatusHeaderItem.tsx
@@ -67,6 +67,26 @@ function useStableError(message: string | null, delayMs: number): string | null 
   return stable === message ? message : null
 }
 
+// Tracks the device's network reachability via `navigator.onLine` +
+// online/offline events. We use this to decide whether a sync error is mere
+// connectivity noise (device offline → show the calm "Offline" chip) or an
+// actionable failure (device online but sync still failing → surface it).
+function useIsDeviceOnline(): boolean {
+  const [online, setOnline] = useState(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine,
+  )
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine)
+    window.addEventListener('online', update)
+    window.addEventListener('offline', update)
+    return () => {
+      window.removeEventListener('online', update)
+      window.removeEventListener('offline', update)
+    }
+  }, [])
+  return online
+}
+
 type SyncStatus = ReturnType<typeof useStatus>
 
 // Theme-aware tones. `success` reads `--success` (per-theme green
@@ -190,12 +210,18 @@ function SyncStatusHeaderContent({
 }: SyncStatusHeaderContentProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [detailsOpen, setDetailsOpen] = useState(false)
+  const deviceOnline = useIsDeviceOnline()
   const dataFlow = status.dataFlowStatus
-  // A connection error while we're not connected is just "we're offline" —
-  // show the calm offline state, not a websocket error. Treat a sync error
-  // as real only while we believe we're connected, and only once it has
-  // outlived the transient-blip grace window.
-  const networkError = status.connected
+  // Decide whether a sync error is worth showing. When the *device* is
+  // offline, any upload/download error is just connectivity noise — show the
+  // calm "Offline" chip, not a raw websocket/fetch error. But when the
+  // device is online and sync still fails (bad PowerSync endpoint, 401/403
+  // credentials, server-side stream failure), the error is actionable and
+  // must surface even though PowerSync flips `connected: false` during its
+  // retry loop — otherwise the chip is stuck on Offline/Connecting forever
+  // and hides the very reason sync isn't working. The grace window below
+  // still debounces transient blips in both cases.
+  const networkError = deviceOnline
     ? (dataFlow.uploadError?.message ?? dataFlow.downloadError?.message ?? null)
     : null
   const stableNetworkError = useStableError(networkError, networkErrorGraceMs)

--- a/src/plugins/sync-status/SyncStatusHeaderItem.tsx
+++ b/src/plugins/sync-status/SyncStatusHeaderItem.tsx
@@ -51,12 +51,19 @@ function useStableError(message: string | null, delayMs: number): string | null 
   useEffect(() => {
     if (!message) return
     const timer = setTimeout(() => setStable(message), delayMs)
-    return () => clearTimeout(timer)
+    // Cleanup runs whenever `message` changes (including back to null), so it
+    // both cancels a not-yet-elapsed timer AND clears any previously-shown
+    // value. Resetting here is what makes a *recurring* identical error
+    // re-serve its full grace window instead of flashing instantly because
+    // `stable` still held the old string. (Done in cleanup, not the effect
+    // body, to avoid a synchronous in-effect setState.)
+    return () => {
+      clearTimeout(timer)
+      setStable(null)
+    }
   }, [message, delayMs])
-  // Report the error only once the debounced value has caught up with the
-  // current message — and report null immediately when the message clears.
-  // Deriving this at render (rather than clearing `stable` via a setState in
-  // the effect) keeps the indicator responsive and avoids a render cascade.
+  // `stable` only equals `message` once the timer has elapsed for the current
+  // continuous error; a cleared message returns null immediately.
   return stable === message ? message : null
 }
 

--- a/src/plugins/sync-status/SyncStatusHeaderItem.tsx
+++ b/src/plugins/sync-status/SyncStatusHeaderItem.tsx
@@ -7,7 +7,7 @@ import {
   HardDrive,
   RefreshCw,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useIsLocalOnly } from '@/components/Login.js'
 import { Button } from '@/components/ui/button.js'
 import {
@@ -35,6 +35,30 @@ interface UploadQueueCountRow {
 
 const uploadQueuePreviewThrottleMs = 1_000
 const rejectedCountSql = 'SELECT COUNT(*) AS count FROM ps_crud_rejected'
+
+// Network sync errors are noisy: a dropped connection or a token refresh
+// caught mid-flight surfaces an error for a second or two before PowerSync
+// recovers on its own. Only treat a network error as worth showing once it
+// has persisted continuously for this long; clear it immediately when it
+// resolves. (Offline is handled separately — see `SyncStatusHeaderContent`.)
+const networkErrorGraceMs = 5_000
+
+// Debounce the *appearance* of an error: surface `message` only after it has
+// stayed non-null for `delayMs`, and drop it the instant it clears. Keeps the
+// indicator from flashing on transient blips.
+function useStableError(message: string | null, delayMs: number): string | null {
+  const [stable, setStable] = useState<string | null>(null)
+  useEffect(() => {
+    if (!message) return
+    const timer = setTimeout(() => setStable(message), delayMs)
+    return () => clearTimeout(timer)
+  }, [message, delayMs])
+  // Report the error only once the debounced value has caught up with the
+  // current message — and report null immediately when the message clears.
+  // Deriving this at render (rather than clearing `stable` via a setState in
+  // the effect) keeps the indicator responsive and avoids a render cascade.
+  return stable === message ? message : null
+}
 
 type SyncStatus = ReturnType<typeof useStatus>
 
@@ -78,11 +102,10 @@ export function SyncStatusHeaderItem() {
     {reportFetching: false},
   )
   const rejectedCount = Number(rejected.data[0]?.count ?? 0)
-  const errorMessage =
-    rejected.error?.message ??
-    status.dataFlowStatus.uploadError?.message ??
-    status.dataFlowStatus.downloadError?.message ??
-    null
+  // Local-query failures (counting the rejection quarantine) are real and
+  // surfaced immediately. Network/sync errors are handled — and offline is
+  // distinguished from a genuine error — down in SyncStatusHeaderContent.
+  const localErrorMessage = rejected.error?.message ?? null
 
   if (localOnly) {
     return (
@@ -92,7 +115,7 @@ export function SyncStatusHeaderItem() {
         pendingChanges={0}
         pendingChangesApproximate={false}
         rejectedCount={rejectedCount}
-        errorMessage={errorMessage}
+        localErrorMessage={localErrorMessage}
       />
     )
   }
@@ -101,7 +124,7 @@ export function SyncStatusHeaderItem() {
     <RemoteSyncStatusHeaderContent
       status={status}
       rejectedCount={rejectedCount}
-      baseErrorMessage={errorMessage}
+      baseLocalErrorMessage={localErrorMessage}
     />
   )
 }
@@ -109,13 +132,13 @@ export function SyncStatusHeaderItem() {
 interface RemoteSyncStatusHeaderContentProps {
   status: SyncStatus
   rejectedCount: number
-  baseErrorMessage: string | null
+  baseLocalErrorMessage: string | null
 }
 
 function RemoteSyncStatusHeaderContent({
   status,
   rejectedCount,
-  baseErrorMessage,
+  baseLocalErrorMessage,
 }: RemoteSyncStatusHeaderContentProps) {
   const queue = useQuery<UploadQueueCountRow>(
     uploadQueuePreviewCountSql,
@@ -136,7 +159,7 @@ function RemoteSyncStatusHeaderContent({
       pendingChanges={pendingChanges}
       pendingChangesApproximate={pendingChangesApproximate}
       rejectedCount={rejectedCount}
-      errorMessage={queue.error?.message ?? baseErrorMessage}
+      localErrorMessage={queue.error?.message ?? baseLocalErrorMessage}
     />
   )
 }
@@ -147,7 +170,7 @@ interface SyncStatusHeaderContentProps {
   pendingChanges: number
   pendingChangesApproximate: boolean
   rejectedCount: number
-  errorMessage: string | null
+  localErrorMessage: string | null
 }
 
 function SyncStatusHeaderContent({
@@ -156,11 +179,20 @@ function SyncStatusHeaderContent({
   pendingChanges,
   pendingChangesApproximate,
   rejectedCount,
-  errorMessage,
+  localErrorMessage,
 }: SyncStatusHeaderContentProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [detailsOpen, setDetailsOpen] = useState(false)
   const dataFlow = status.dataFlowStatus
+  // A connection error while we're not connected is just "we're offline" —
+  // show the calm offline state, not a websocket error. Treat a sync error
+  // as real only while we believe we're connected, and only once it has
+  // outlived the transient-blip grace window.
+  const networkError = status.connected
+    ? (dataFlow.uploadError?.message ?? dataFlow.downloadError?.message ?? null)
+    : null
+  const stableNetworkError = useStableError(networkError, networkErrorGraceMs)
+  const errorMessage = localErrorMessage ?? stableNetworkError
   const view = getSyncIndicatorView({
     localOnly,
     connected: status.connected,

--- a/src/plugins/sync-status/model.ts
+++ b/src/plugins/sync-status/model.ts
@@ -51,10 +51,12 @@ const formatPendingLabel = (count: number, approximate = false): string | null =
   return String(count)
 }
 
+// `pendingChanges` counts distinct blocks with queued edits (see
+// queueCounts.ts), so the human-readable form is phrased in blocks.
 const formatChangeCount = (count: number, approximate = false): string => {
   const countLabel = approximate ? `${count}+` : String(count)
-  if (count === 1 && !approximate) return '1 local change'
-  return `${countLabel} local changes`
+  const noun = count === 1 && !approximate ? 'block' : 'blocks'
+  return `${countLabel} ${noun}`
 }
 
 const clampProgressPercent = (fraction: number | null | undefined): number | null => {
@@ -75,8 +77,8 @@ const appendPendingTitle = (
 ): string => {
   if (pendingChanges <= 0) return title
   const suffix = localOnly
-    ? `${formatChangeCount(pendingChanges, approximate)} stored locally.`
-    : `${formatChangeCount(pendingChanges, approximate)} queued for upload.`
+    ? `${formatChangeCount(pendingChanges, approximate)} changed, stored locally.`
+    : `${formatChangeCount(pendingChanges, approximate)} changed, queued for upload.`
   return `${title} ${suffix}`
 }
 

--- a/src/plugins/sync-status/queueCounts.ts
+++ b/src/plugins/sync-status/queueCounts.ts
@@ -1,7 +1,22 @@
 export const uploadQueueCountCap = 1000
+
+// Count distinct *blocks* with pending changes, not raw `ps_crud` rows. A
+// single editing burst (typing, focus changes, reorders) fans out to many
+// CRUD entries against the same block, so a raw row count balloons into a
+// huge, meaningless number. `ps_crud.data` is the upload envelope written by
+// the blocks_upload_* triggers (clientSchema.ts): `{op, type, id, data}`,
+// where `$.id` is the block id.
+//
+// The preview cap rides on `DISTINCT … LIMIT cap+1`: SQLite emits each new
+// distinct id as it discovers it and stops once it has cap+1, so a queue
+// touching many distinct blocks bounds the scan. (A queue with millions of
+// rows but few distinct blocks still scans fully — but that only happens
+// after a long offline stretch, and the scan runs in-memory via
+// `temp_store = MEMORY`.)
 export const uploadQueuePreviewCountSql =
-  `SELECT COUNT(*) AS count FROM (SELECT 1 FROM ps_crud LIMIT ${uploadQueueCountCap + 1})`
-export const uploadQueueExactCountSql = 'SELECT COUNT(*) AS count FROM ps_crud'
+  `SELECT COUNT(*) AS count FROM (SELECT DISTINCT json_extract(data, '$.id') FROM ps_crud LIMIT ${uploadQueueCountCap + 1})`
+export const uploadQueueExactCountSql =
+  `SELECT COUNT(DISTINCT json_extract(data, '$.id')) AS count FROM ps_crud`
 
 export const formatPendingChanges = (
   count: number,
@@ -9,8 +24,8 @@ export const formatPendingChanges = (
   approximate = false,
 ): string => {
   if (count <= 0) return 'No unsynced changes'
-  const noun = count === 1 && !approximate ? 'change' : 'changes'
+  const noun = count === 1 && !approximate ? 'block' : 'blocks'
   const countLabel = approximate ? `${count.toLocaleString()}+` : count.toLocaleString()
-  const suffix = localOnly ? 'stored locally' : 'queued for upload'
+  const suffix = localOnly ? 'changed, stored locally' : 'changed, queued for upload'
   return `${countLabel} ${noun} ${suffix}`
 }

--- a/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
+++ b/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
@@ -63,11 +63,16 @@ const defaultStatus = () => ({
   lastSyncedAt: undefined,
 })
 
+const setDeviceOnline = (online: boolean) => {
+  Object.defineProperty(navigator, 'onLine', {configurable: true, value: online})
+}
+
 describe('SyncStatusHeaderItem', () => {
   beforeEach(() => {
     mocks.localOnly = false
     mocks.queryCalls = []
     mocks.status = defaultStatus()
+    setDeviceOnline(true)
     mocks.queryResponses = new Map([
       [rejectedCountSql, {data: [{count: 0}]}],
       [uploadQueuePreviewCountSql, {data: [{count: uploadQueueCountCap + 1}]}],
@@ -77,6 +82,7 @@ describe('SyncStatusHeaderItem', () => {
 
   afterEach(() => {
     cleanup()
+    setDeviceOnline(true)
   })
 
   it('uses the capped queue count for the always-mounted remote indicator', () => {
@@ -117,7 +123,8 @@ describe('SyncStatusHeaderItem', () => {
     expect(mocks.queryCalls.some(call => call.sql === uploadQueueExactCountSql)).toBe(true)
   })
 
-  it('shows a calm "offline" state instead of the websocket error when disconnected', () => {
+  it('shows a calm "offline" state instead of the websocket error when the device is offline', () => {
+    setDeviceOnline(false)
     mocks.status = {
       ...defaultStatus(),
       connected: false,
@@ -135,6 +142,43 @@ describe('SyncStatusHeaderItem', () => {
     const label = screen.getByRole('button').getAttribute('aria-label') ?? ''
     expect(label.toLowerCase()).toContain('offline')
     expect(label).not.toContain('WebSocket')
+  })
+
+  it('surfaces a persistent sync error when the device is online but sync is disconnected', () => {
+    // PowerSync flips connected:false during its retry loop after a real
+    // failure (bad endpoint, 401/403, server stream error). With the device
+    // online, that error is actionable and must surface — not be hidden
+    // behind a generic Offline/Connecting chip.
+    vi.useFakeTimers()
+    try {
+      setDeviceOnline(true)
+      mocks.status = {
+        ...defaultStatus(),
+        connected: false,
+        connecting: true,
+        dataFlowStatus: {
+          uploading: false,
+          downloading: false,
+          uploadError: null,
+          downloadError: {message: 'PowerSync endpoint returned 401'},
+        },
+      }
+      mocks.queryResponses.set(uploadQueuePreviewCountSql, {data: [{count: 0}]})
+
+      render(<SyncStatusHeaderItem/>)
+
+      // Still within the grace window — calm.
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .not.toMatch(/needs attention/i)
+
+      act(() => vi.advanceTimersByTime(6_000))
+
+      const label = screen.getByRole('button').getAttribute('aria-label') ?? ''
+      expect(label).toMatch(/needs attention/i)
+      expect(label).toContain('401')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('waits out the grace window before surfacing a transient sync error', () => {

--- a/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
+++ b/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
@@ -168,4 +168,48 @@ describe('SyncStatusHeaderItem', () => {
       vi.useRealTimers()
     }
   })
+
+  it('re-applies the grace window when an error clears and recurs', () => {
+    vi.useFakeTimers()
+    try {
+      const erroring = {
+        ...defaultStatus(),
+        connected: true,
+        dataFlowStatus: {
+          uploading: false,
+          downloading: false,
+          uploadError: {message: 'token refresh hiccup'},
+          downloadError: null,
+        },
+      }
+      const healthy = {...defaultStatus(), connected: true}
+      mocks.queryResponses.set(uploadQueuePreviewCountSql, {data: [{count: 0}]})
+
+      // First occurrence rides out its grace window and surfaces.
+      mocks.status = erroring
+      const {rerender} = render(<SyncStatusHeaderItem/>)
+      act(() => vi.advanceTimersByTime(6_000))
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .toMatch(/needs attention/i)
+
+      // Error clears — indicator goes calm immediately.
+      mocks.status = healthy
+      rerender(<SyncStatusHeaderItem/>)
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .not.toMatch(/needs attention/i)
+
+      // Same error recurs: it must NOT flash instantly — the grace window
+      // applies afresh (this is the regression the debounce reset guards).
+      mocks.status = erroring
+      rerender(<SyncStatusHeaderItem/>)
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .not.toMatch(/needs attention/i)
+
+      act(() => vi.advanceTimersByTime(6_000))
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .toMatch(/needs attention/i)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
+++ b/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SyncStatusHeaderItem } from '../SyncStatusHeaderItem.tsx'
 import {
@@ -18,8 +18,8 @@ const mocks = vi.hoisted(() => ({
     dataFlowStatus: {
       uploading: false,
       downloading: false,
-      uploadError: null,
-      downloadError: null,
+      uploadError: null as {message: string} | null,
+      downloadError: null as {message: string} | null,
     },
     downloadProgress: null,
     lastSyncedAt: undefined,
@@ -49,10 +49,25 @@ vi.mock('../RejectionDialog.tsx', () => ({
 
 const rejectedCountSql = 'SELECT COUNT(*) AS count FROM ps_crud_rejected'
 
+const defaultStatus = () => ({
+  connected: true,
+  connecting: false,
+  hasSynced: true,
+  dataFlowStatus: {
+    uploading: false,
+    downloading: false,
+    uploadError: null as {message: string} | null,
+    downloadError: null as {message: string} | null,
+  },
+  downloadProgress: null,
+  lastSyncedAt: undefined,
+})
+
 describe('SyncStatusHeaderItem', () => {
   beforeEach(() => {
     mocks.localOnly = false
     mocks.queryCalls = []
+    mocks.status = defaultStatus()
     mocks.queryResponses = new Map([
       [rejectedCountSql, {data: [{count: 0}]}],
       [uploadQueuePreviewCountSql, {data: [{count: uploadQueueCountCap + 1}]}],
@@ -68,7 +83,7 @@ describe('SyncStatusHeaderItem', () => {
     render(<SyncStatusHeaderItem/>)
 
     expect(screen.getByRole('button', {
-      name: /1000\+ local changes queued for upload/,
+      name: /1000\+ blocks changed, queued for upload/,
     })).toBeInTheDocument()
     expect(mocks.queryCalls.some(call => call.sql === uploadQueuePreviewCountSql)).toBe(true)
     expect(mocks.queryCalls.some(call => call.sql === uploadQueueExactCountSql)).toBe(false)
@@ -80,10 +95,10 @@ describe('SyncStatusHeaderItem', () => {
     expect(mocks.queryCalls.some(call => call.sql === uploadQueueExactCountSql)).toBe(false)
 
     fireEvent.pointerDown(screen.getByRole('button', {
-      name: /1000\+ local changes queued for upload/,
+      name: /1000\+ blocks changed, queued for upload/,
     }))
 
-    expect(await screen.findByText('1,032,688 changes queued for upload')).toBeInTheDocument()
+    expect(await screen.findByText('1,032,688 blocks changed, queued for upload')).toBeInTheDocument()
     expect(mocks.queryCalls.some(call => call.sql === uploadQueueExactCountSql)).toBe(true)
   })
 
@@ -98,7 +113,59 @@ describe('SyncStatusHeaderItem', () => {
 
     fireEvent.pointerDown(screen.getByRole('button', {name: 'Remote sync is disabled.'}))
 
-    expect(await screen.findByText('1,032,688 changes stored locally')).toBeInTheDocument()
+    expect(await screen.findByText('1,032,688 blocks changed, stored locally')).toBeInTheDocument()
     expect(mocks.queryCalls.some(call => call.sql === uploadQueueExactCountSql)).toBe(true)
+  })
+
+  it('shows a calm "offline" state instead of the websocket error when disconnected', () => {
+    mocks.status = {
+      ...defaultStatus(),
+      connected: false,
+      dataFlowStatus: {
+        uploading: false,
+        downloading: false,
+        uploadError: null,
+        downloadError: {message: 'WebSocket connection failed: 1006'},
+      },
+    }
+    mocks.queryResponses.set(uploadQueuePreviewCountSql, {data: [{count: 0}]})
+
+    render(<SyncStatusHeaderItem/>)
+
+    const label = screen.getByRole('button').getAttribute('aria-label') ?? ''
+    expect(label.toLowerCase()).toContain('offline')
+    expect(label).not.toContain('WebSocket')
+  })
+
+  it('waits out the grace window before surfacing a transient sync error', () => {
+    vi.useFakeTimers()
+    try {
+      mocks.status = {
+        ...defaultStatus(),
+        connected: true,
+        dataFlowStatus: {
+          uploading: false,
+          downloading: false,
+          uploadError: {message: 'token refresh hiccup'},
+          downloadError: null,
+        },
+      }
+      mocks.queryResponses.set(uploadQueuePreviewCountSql, {data: [{count: 0}]})
+
+      render(<SyncStatusHeaderItem/>)
+
+      // Immediately after the blip the indicator stays calm — no error.
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .not.toMatch(/needs attention/i)
+
+      // Once the error has persisted past the grace window it surfaces.
+      act(() => {
+        vi.advanceTimersByTime(6_000)
+      })
+      expect(screen.getByRole('button').getAttribute('aria-label'))
+        .toMatch(/needs attention/i)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/plugins/sync-status/test/model.test.ts
+++ b/src/plugins/sync-status/test/model.test.ts
@@ -21,7 +21,7 @@ describe('getSyncIndicatorView', () => {
     expect(view.state).toBe('pending')
     expect(view.label).toBe('Pending')
     expect(view.pendingLabel).toBe('3')
-    expect(view.title).toContain('3 local changes queued for upload')
+    expect(view.title).toContain('3 blocks changed, queued for upload')
   })
 
   it('labels capped pending counts as lower bounds', () => {
@@ -33,7 +33,7 @@ describe('getSyncIndicatorView', () => {
 
     expect(view.state).toBe('pending')
     expect(view.pendingLabel).toBe('1000+')
-    expect(view.title).toContain('1000+ local changes queued for upload')
+    expect(view.title).toContain('1000+ blocks changed, queued for upload')
   })
 
   it('shows download progress while preserving the pending count badge', () => {
@@ -62,7 +62,7 @@ describe('getSyncIndicatorView', () => {
     expect(view.state).toBe('local')
     expect(view.label).toBe('Local only')
     expect(view.pendingLabel).toBe('1')
-    expect(view.title).toContain('1 local change stored locally')
+    expect(view.title).toContain('1 block changed, stored locally')
   })
 
   it('surfaces sync errors before passive connection states', () => {

--- a/src/services/powersync.ts
+++ b/src/services/powersync.ts
@@ -5,7 +5,7 @@ import {
   UpdateType,
   type CrudTransaction,
 } from '@powersync/common'
-import { supabase, hasSupabaseAuthConfig } from '@/services/supabase.js'
+import { supabase, hasSupabaseAuthConfig, readPersistedSession } from '@/services/supabase.js'
 import { classifyUploadError } from '@/services/uploadErrorClassifier.js'
 
 const powerSyncUrl = import.meta.env.VITE_POWERSYNC_URL?.trim()
@@ -492,22 +492,34 @@ const uploadData = async (database: AbstractPowerSyncDatabase) => {
 export const createPowerSyncConnector = (): PowerSyncBackendConnector => ({
   fetchCredentials: async () => {
     const client = assertSupabase()
-    const {data, error} = await client.auth.getSession()
 
-    if (error) {
-      throw error
+    // getSession() refreshes an expired token before resolving; offline
+    // that fails (and can hang on retries). Fall back to the last
+    // persisted session so we still hand PowerSync a token to retry the
+    // connection with once the network returns — and return null instead
+    // of throwing when there's truly nothing, so an offline boot doesn't
+    // spam the console with refresh failures.
+    let session = readPersistedSession()
+    try {
+      const {data, error} = await client.auth.getSession()
+      if (error) throw error
+      if (data.session) session = data.session
+    } catch (error) {
+      if (!session) {
+        console.debug('[powersync] fetchCredentials: no session available (offline?)', error)
+        return null
+      }
     }
 
-    const accessToken = data.session?.access_token
-    if (!accessToken || !powerSyncUrl) {
+    if (!session?.access_token || !powerSyncUrl) {
       return null
     }
 
     return {
       endpoint: powerSyncUrl,
-      token: accessToken,
-      expiresAt: data.session?.expires_at
-        ? new Date(data.session.expires_at * 1000)
+      token: session.access_token,
+      expiresAt: session.expires_at
+        ? new Date(session.expires_at * 1000)
         : undefined,
     }
   },

--- a/src/services/supabase.test.ts
+++ b/src/services/supabase.test.ts
@@ -51,3 +51,51 @@ describe('readPersistedSession', () => {
     expect(await loadSession()).toBeNull()
   })
 })
+
+// isAuthCallbackUrl gates the offline persisted-session fast path: on a magic-
+// link / OAuth callback the stored session may belong to a different user, so
+// bootstrap must wait for auth-js to resolve the URL instead of mounting the
+// stale (wrong-user) session.
+describe('isAuthCallbackUrl', () => {
+  const storageKey = 'sb-proj-auth-token'
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://proj.supabase.co')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key')
+    window.localStorage.clear()
+    window.history.replaceState({}, '', '/')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    window.localStorage.clear()
+    window.history.replaceState({}, '', '/')
+  })
+
+  const check = async (url: string) => {
+    window.history.replaceState({}, '', url)
+    return (await import('./supabase.ts')).isAuthCallbackUrl()
+  }
+
+  it('is false for an ordinary URL', async () => {
+    expect(await check('/#some-block-route')).toBe(false)
+  })
+
+  it('detects an implicit-grant hash (access_token)', async () => {
+    expect(await check('/#access_token=abc&refresh_token=def&type=magiclink')).toBe(true)
+  })
+
+  it('detects an auth error_description', async () => {
+    expect(await check('/?error=access_denied&error_description=expired')).toBe(true)
+  })
+
+  it('treats a bare code param as a callback only when a code-verifier is stored', async () => {
+    // No verifier → could be an app route that happens to carry `code`; not a
+    // callback, so the offline fast path stays available.
+    expect(await check('/?code=xyz')).toBe(false)
+
+    window.localStorage.setItem(`${storageKey}-code-verifier`, 'verifier')
+    expect(await check('/?code=xyz')).toBe(true)
+  })
+})

--- a/src/services/supabase.test.ts
+++ b/src/services/supabase.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// readPersistedSession is the load-bearing piece of the offline-boot fix:
+// it recovers the last Supabase session straight from storage so the app
+// can start before (and instead of being blocked by) getSession()'s token
+// refresh. The module reads VITE_SUPABASE_URL at import time, so each test
+// stubs the env and re-imports.
+describe('readPersistedSession', () => {
+  const storageKey = 'sb-proj-auth-token'
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://proj.supabase.co')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key')
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    window.localStorage.clear()
+  })
+
+  const loadSession = async () => (await import('./supabase.ts')).readPersistedSession()
+
+  it('recovers the persisted session even when the access token is expired', async () => {
+    // expires_at in the past — getSession() would try (and offline, fail) to
+    // refresh this; readPersistedSession hands it back as-is.
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      access_token: 'expired-token',
+      refresh_token: 'refresh',
+      expires_at: 1,
+      user: {id: 'user-1'},
+    }))
+
+    const session = await loadSession()
+    expect(session?.access_token).toBe('expired-token')
+    expect(session?.user.id).toBe('user-1')
+  })
+
+  it('returns null when nothing is stored', async () => {
+    expect(await loadSession()).toBeNull()
+  })
+
+  it('returns null for a malformed payload rather than throwing', async () => {
+    window.localStorage.setItem(storageKey, 'not-json')
+    expect(await loadSession()).toBeNull()
+  })
+
+  it('ignores a stored value that is not a usable session', async () => {
+    window.localStorage.setItem(storageKey, JSON.stringify({foo: 'bar'}))
+    expect(await loadSession()).toBeNull()
+  })
+})

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -62,6 +62,44 @@ export const readPersistedSession = (): Session | null => {
   }
 }
 
+// True when the current URL is a Supabase auth callback (magic-link / OTP /
+// OAuth redirect) that `detectSessionInUrl` is about to process into a NEW
+// session. Mirrors auth-js's own callback detection (`_isImplicitGrantCallback`
+// / `_isPKCECallback`): an implicit-grant hash carries `access_token` (or
+// `error_description`); a PKCE callback carries `code` AND a stored
+// `<storageKey>-code-verifier`. supabase-js reads both the query string and
+// the URL hash (hash params win), so we check both.
+//
+// The code-verifier requirement matters: this app uses hash-based routing, so
+// a bare `code` param could appear in a route. Requiring the verifier (which
+// auth-js writes only when IT initiated the PKCE flow) avoids a false positive
+// that would needlessly suppress the offline fast path.
+//
+// Bootstrap uses this to skip the persisted-session fast path: when a callback
+// is in flight the stored session may belong to a DIFFERENT user (account
+// switch / shared device), and per-user PowerSync DBs are keyed by user id —
+// rendering from the stale session would briefly mount the wrong user's local
+// data. On a callback we wait for auth-js to resolve the URL and emit
+// SIGNED_IN with the real session instead.
+export const isAuthCallbackUrl = (): boolean => {
+  if (!supabaseAuthStorageKey || typeof window === 'undefined') return false
+  const {search, hash} = window.location
+  const params = new URLSearchParams(search)
+  const hashParams = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash)
+  const has = (key: string) => params.has(key) || hashParams.has(key)
+
+  if (has('access_token') || has('error_description')) return true
+
+  if (has('code')) {
+    try {
+      return window.localStorage.getItem(`${supabaseAuthStorageKey}-code-verifier`) !== null
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
 const getUserName = (user: SupabaseAuthUser) => {
   const metadataName = typeof user.user_metadata?.name === 'string'
     ? user.user_metadata.name.trim()

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -16,6 +16,52 @@ export const supabase = hasSupabaseAuthConfig
     })
   : null
 
+// supabase-js namespaces the persisted session under
+// `sb-<project-ref>-auth-token`, deriving the ref from the URL hostname's
+// first label (see SupabaseClient's `defaultStorageKey`). We recompute it
+// here so bootstrap can read the last session synchronously — see
+// `readPersistedSession`.
+const supabaseAuthStorageKey = supabaseUrl
+  ? `sb-${new URL(supabaseUrl).hostname.split('.')[0]}-auth-token`
+  : null
+
+// Read the last persisted Supabase session straight out of localStorage,
+// WITHOUT going through `supabase.auth.getSession()`.
+//
+// Why bypass getSession: when the stored access token is expired (or within
+// its refresh margin) getSession synchronously triggers a token refresh and
+// awaits it. Offline, that refresh retries for ~30s before failing and then
+// resolves to a *null* session — which freezes startup and bounces the user
+// to the login screen even though they have a perfectly usable local
+// database. Reading the raw persisted value lets us boot the app with the
+// existing credentials immediately; the background refresh still upgrades
+// the token once connectivity returns.
+//
+// The value supabase-js writes is the Session object serialized with
+// JSON.stringify; we tolerate the legacy `{currentSession}` / `{session}`
+// envelopes defensively.
+export const readPersistedSession = (): Session | null => {
+  if (!supabaseAuthStorageKey || typeof window === 'undefined') return null
+
+  let raw: string | null
+  try {
+    raw = window.localStorage.getItem(supabaseAuthStorageKey)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(raw)
+    const candidate = parsed?.access_token
+      ? parsed
+      : parsed?.currentSession ?? parsed?.session ?? null
+    return candidate?.access_token && candidate?.user ? (candidate as Session) : null
+  } catch {
+    return null
+  }
+}
+
 const getUserName = (user: SupabaseAuthUser) => {
   const metadataName = typeof user.user_metadata?.name === 'string'
     ? user.user_metadata.name.trim()


### PR DESCRIPTION
Offline startup freeze:
- Bootstrap blocked on supabase.auth.getSession(), which refreshes an
  expired access token before resolving. Offline that retries for ~30s
  and then yields a null session, freezing startup and bouncing the user
  to the login screen even with a usable local database.
- Add readPersistedSession() to read the last session straight from
  localStorage (deriving supabase-js's sb-<ref>-auth-token key), and seed
  Login's state from it so the app loads immediately. getSession() still
  runs in the background to upgrade the token / capture a magic-link
  session when reachable, and an offline failure no longer signs the user
  out.
- PowerSync fetchCredentials falls back to the persisted session and
  returns null instead of throwing when offline, so it stops spamming
  refresh failures.

Sync indicator:
- Show a calm "Offline" state instead of the raw websocket error when
  disconnected, and debounce network errors behind a grace window so
  transient blips don't flash a "Sync issue".
- Count distinct blocks with pending changes (json_extract(data,'$.id')
  over ps_crud) instead of raw CRUD rows, so an editing burst no longer
  inflates the badge into a meaningless number. Reword pending labels in
  terms of blocks.