### PR TITLE
Centralize scope-relative structural-edit policy

### DIFF
--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -65,7 +65,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   const childIds = useChildIds(block)
   const uiStateBlock = useUIStateBlock()
   const runtime = useAppRuntime()
-  const {panelId, scopeRootId, renderScopeId} = useBlockContext()
+  const {panelId, scopeRootId, renderScopeId, isNestedSurface} = useBlockContext()
   const navigate = useNavigate()
   const [showHiddenFields, setShowHiddenFields] = useState(false)
   const [syntheticProperties, setSyntheticProperties] = useState<readonly SyntheticPropertyRef[]>([])
@@ -155,7 +155,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   const focusAfterProperties = async () => {
     if (!scopeRootId) return
 
-    const next = await nextVisibleBlock(block, scopeRootId)
+    const next = await nextVisibleBlock(block, scopeRootId, !isNestedSurface)
     if (!next) return
     await next.load()
     await focusBlockEditor(next, {start: 0})

--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -66,7 +66,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   const childIds = useChildIds(block)
   const uiStateBlock = useUIStateBlock()
   const runtime = useAppRuntime()
-  const {panelId, scopeRootId: contextScopeRootId} = useBlockContext()
+  const {panelId, scopeRootId: contextScopeRootId, renderScopeId} = useBlockContext()
   const navigate = useNavigate()
   const [showHiddenFields, setShowHiddenFields] = useState(false)
   const [syntheticProperties, setSyntheticProperties] = useState<readonly SyntheticPropertyRef[]>([])
@@ -136,7 +136,15 @@ export function BlockProperties({block}: BlockPropertiesProps) {
       blockId: target.id,
       ...selection,
     })
-    await focusBlock(uiStateBlock, target.id, {edit: true})
+    // Keep focus in the current render scope. In a nested surface
+    // (backlink/embed) the navigation target (next visible block, etc.)
+    // is resolved within that surface's scope, so focusing without the
+    // scope id would fall back to the panel-outline copy and the editor
+    // would appear not to move.
+    await focusBlock(uiStateBlock, target.id, {
+      edit: true,
+      ...(typeof renderScopeId === 'string' ? {renderScopeId} : {}),
+    })
     requestEditorFocus(uiStateBlock)
   }
 

--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -17,7 +17,6 @@ import {
   editorSelection,
   requestEditorFocus,
   focusBlock,
-  topLevelBlockIdProp,
 } from '@/data/properties.js'
 import { Button } from './ui/button'
 import { nextVisibleBlock } from '@/utils/selection.js'
@@ -66,7 +65,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   const childIds = useChildIds(block)
   const uiStateBlock = useUIStateBlock()
   const runtime = useAppRuntime()
-  const {panelId, scopeRootId: contextScopeRootId, renderScopeId} = useBlockContext()
+  const {panelId, scopeRootId, renderScopeId} = useBlockContext()
   const navigate = useNavigate()
   const [showHiddenFields, setShowHiddenFields] = useState(false)
   const [syntheticProperties, setSyntheticProperties] = useState<readonly SyntheticPropertyRef[]>([])
@@ -154,9 +153,6 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   }
 
   const focusAfterProperties = async () => {
-    const scopeRootId = typeof contextScopeRootId === 'string'
-      ? contextScopeRootId
-      : uiStateBlock.peekProperty(topLevelBlockIdProp)
     if (!scopeRootId) return
 
     const next = await nextVisibleBlock(block, scopeRootId)

--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -66,7 +66,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   const childIds = useChildIds(block)
   const uiStateBlock = useUIStateBlock()
   const runtime = useAppRuntime()
-  const {panelId} = useBlockContext()
+  const {panelId, scopeRootId: contextScopeRootId} = useBlockContext()
   const navigate = useNavigate()
   const [showHiddenFields, setShowHiddenFields] = useState(false)
   const [syntheticProperties, setSyntheticProperties] = useState<readonly SyntheticPropertyRef[]>([])
@@ -146,10 +146,12 @@ export function BlockProperties({block}: BlockPropertiesProps) {
   }
 
   const focusAfterProperties = async () => {
-    const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-    if (!topLevelBlockId) return
+    const scopeRootId = typeof contextScopeRootId === 'string'
+      ? contextScopeRootId
+      : uiStateBlock.peekProperty(topLevelBlockIdProp)
+    if (!scopeRootId) return
 
-    const next = await nextVisibleBlock(block, topLevelBlockId)
+    const next = await nextVisibleBlock(block, scopeRootId)
     if (!next) return
     await next.load()
     await focusBlockEditor(next, {start: 0})

--- a/src/components/references/BlockEmbed.tsx
+++ b/src/components/references/BlockEmbed.tsx
@@ -53,7 +53,7 @@ export function BlockEmbed({
   return (
     <BlockRefAncestorsProvider ancestor={blockId}>
       <div className="blockembed border-l-2 border-muted pl-2 my-1 bg-muted/30 rounded-r">
-        <NestedBlockContextProvider overrides={{...EMBED_CONTEXT_OVERRIDES, renderScopeId}}>
+        <NestedBlockContextProvider overrides={{...EMBED_CONTEXT_OVERRIDES, renderScopeId, scopeRootId: blockId}}>
           <BlockComponent blockId={blockId}/>
         </NestedBlockContextProvider>
       </div>

--- a/src/components/renderer/CodeMirrorContentRenderer.tsx
+++ b/src/components/renderer/CodeMirrorContentRenderer.tsx
@@ -78,8 +78,11 @@ export function CodeMirrorContentRenderer({block}: BlockRendererProps) {
         selection: EditorSelection.cursor(plan.focusOffsetInTarget),
       })
 
+      const scopeRootId = typeof blockContext.scopeRootId === 'string'
+        ? blockContext.scopeRootId
+        : uiStateBlock.peekProperty(topLevelBlockIdProp)
       const result = await pasteEditModeMultilineText(plan, block, repo, {
-        topLevelBlockId: uiStateBlock.peekProperty(topLevelBlockIdProp),
+        scopeRootId,
       })
       const renderScopeId = typeof blockContext.renderScopeId === 'string'
         ? blockContext.renderScopeId

--- a/src/components/renderer/CodeMirrorContentRenderer.tsx
+++ b/src/components/renderer/CodeMirrorContentRenderer.tsx
@@ -6,7 +6,7 @@ import type { ReactCodeMirrorRef } from '@uiw/react-codemirror'
 import { createMinimalMarkdownConfig } from '@/utils/codemirror.js'
 import { BlockEditor } from '@/components/BlockEditor.js'
 import { useUIStateBlock } from '@/data/globalState.js'
-import { editorSelection, focusBlock, topLevelBlockIdProp } from '@/data/properties.js'
+import { editorSelection, focusBlock } from '@/data/properties.js'
 import {
   pasteEditModeMultilineText,
   planEditModeMultilinePaste,
@@ -78,11 +78,8 @@ export function CodeMirrorContentRenderer({block}: BlockRendererProps) {
         selection: EditorSelection.cursor(plan.focusOffsetInTarget),
       })
 
-      const scopeRootId = typeof blockContext.scopeRootId === 'string'
-        ? blockContext.scopeRootId
-        : uiStateBlock.peekProperty(topLevelBlockIdProp)
       const result = await pasteEditModeMultilineText(plan, block, repo, {
-        scopeRootId,
+        scopeRootId: blockContext.scopeRootId,
       })
       const renderScopeId = typeof blockContext.renderScopeId === 'string'
         ? blockContext.renderScopeId

--- a/src/components/renderer/DefaultBlockRenderer.test.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.test.tsx
@@ -220,7 +220,7 @@ describe('DefaultBlockRenderer paste handling', () => {
       'first\nsecond',
       repo.block('block-1'),
       repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
   })
 

--- a/src/components/renderer/DefaultBlockRenderer.test.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.test.tsx
@@ -17,6 +17,7 @@ import { outlineRenderScopeId } from '@/utils/renderScope'
 import { kernelPropertyUiExtension } from '@/components/propertyEditors/typesPropertyUi'
 import { kernelValuePresetsExtension } from '@/components/propertyEditors/kernelValuePresets'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext'
+import { BlockContextProvider } from '@/context/block'
 import { blockLayoutFacet, type BlockLayout } from '@/extensions/blockInteraction'
 import { defaultEditorInteractionExtension } from '@/extensions/defaultEditorInteractions'
 import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet'
@@ -181,12 +182,17 @@ describe('DefaultBlockRenderer paste handling', () => {
   const renderBlock = () =>
     render(
       <AppRuntimeContextProvider value={runtime}>
-        <ActiveContextsProvider>
-          <DefaultBlockRenderer
-            block={repo.block('block-1')}
-            ContentRenderer={TestContentRenderer}
-          />
-        </ActiveContextsProvider>
+        {/* The scope root is normally set by the panel/top-level surface
+            that mounts the block; provide it here so the paste path
+            resolves the same scopeRootId production would. */}
+        <BlockContextProvider initialValue={{scopeRootId: 'root'}}>
+          <ActiveContextsProvider>
+            <DefaultBlockRenderer
+              block={repo.block('block-1')}
+              ContentRenderer={TestContentRenderer}
+            />
+          </ActiveContextsProvider>
+        </BlockContextProvider>
       </AppRuntimeContextProvider>,
     )
 

--- a/src/components/renderer/DefaultBlockRenderer.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.tsx
@@ -363,12 +363,16 @@ export function DefaultBlockRenderer(
   // selection toggles, so facet resolvers and the components they
   // produce keep stable identity. This is what stops UpdateIndicator
   // (and any other content decorator) from remounting on every click.
+  const scopeRootId = typeof blockContext.scopeRootId === 'string'
+    ? blockContext.scopeRootId
+    : topLevelBlockId
   const resolveContext = useMemo<BlockResolveContext>(() => ({
     block,
     repo,
     uiStateBlock,
     types,
     topLevelBlockId,
+    scopeRootId,
     isTopLevel,
     blockContext,
     contentRenderers: [
@@ -387,6 +391,7 @@ export function DefaultBlockRenderer(
     uiStateBlock,
     types,
     topLevelBlockId,
+    scopeRootId,
     isTopLevel,
     blockContext,
     DefaultContentRenderer,
@@ -463,13 +468,13 @@ export function DefaultBlockRenderer(
       const pastedText = e.clipboardData.getData('text/plain')
 
       const pasted = await pasteMultilineText(pastedText, block, repo, {
-        topLevelBlockId,
+        scopeRootId,
       })
       if (pasted[0]) {
         void focusBlock(uiStateBlock, pasted[0].id, {renderScopeId})
       }
     },
-    [block, blockContext.renderScopeId, repo, topLevelBlockId, uiStateBlock],
+    [block, blockContext.renderScopeId, repo, scopeRootId, uiStateBlock],
   )
 
   // Content slot: the content surface div + its surface props + the

--- a/src/components/renderer/DefaultBlockRenderer.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.tsx
@@ -363,9 +363,7 @@ export function DefaultBlockRenderer(
   // selection toggles, so facet resolvers and the components they
   // produce keep stable identity. This is what stops UpdateIndicator
   // (and any other content decorator) from remounting on every click.
-  const scopeRootId = typeof blockContext.scopeRootId === 'string'
-    ? blockContext.scopeRootId
-    : topLevelBlockId
+  const scopeRootId = blockContext.scopeRootId
   const resolveContext = useMemo<BlockResolveContext>(() => ({
     block,
     repo,

--- a/src/components/renderer/PanelRenderer.tsx
+++ b/src/components/renderer/PanelRenderer.tsx
@@ -32,7 +32,7 @@ const PANEL_ACTION_BUTTON_CLASS =
 const PANEL_HISTORY_BUTTON_CLASS =
   `${PANEL_ACTION_BUTTON_CLASS} disabled:text-muted-foreground/40 disabled:hover:bg-background/60 disabled:hover:text-muted-foreground/40`
 
-function PanelMultiSelectActionContext() {
+function PanelMultiSelectActionContext({scopeRootId}: {scopeRootId: string}) {
   const [selectionState] = useSelectionState()
   const repo = useRepo()
 
@@ -42,8 +42,12 @@ function PanelMultiSelectActionContext() {
     return {
       selectedBlocks: selectionState.selectedBlockIds.map(id => repo.block(id)),
       anchorBlock: selectionState.anchorBlockId ? repo.block(selectionState.anchorBlockId) : null,
+      // Multi-select operates over the panel's outline, so its scope
+      // root is the panel's zoom root. Forwarded to per-block structural
+      // actions (indent/outdent/delete) via applyToAllBlocksInSelection.
+      scopeRootId,
     }
-  }, [selectionState, repo])
+  }, [selectionState, repo, scopeRootId])
 
   useActionContext(
     ActionContextTypes.MULTI_SELECT_MODE,
@@ -182,6 +186,7 @@ export function PanelRenderer({block}: BlockRendererProps) {
       overrides={{
         layoutBoundary: false,
         renderScopeId: outlineRenderScopeId(topLevelBlockId),
+        scopeRootId: topLevelBlockId,
       }}
     >
       <BlockComponent blockId={topLevelBlockId}/>
@@ -195,7 +200,7 @@ export function PanelRenderer({block}: BlockRendererProps) {
       className={`panel min-w-0 max-w-full flex flex-col relative ${
         stackedPanel ? 'overflow-visible' : 'h-full flex-grow overflow-hidden'
       } ${isActivePanel ? 'panel-active' : ''}`}>
-      {isActivePanel && <PanelMultiSelectActionContext/>}
+      {isActivePanel && <PanelMultiSelectActionContext scopeRootId={topLevelBlockId}/>}
       {wideScrollSurface ? (
         <div className="pointer-events-none absolute inset-x-0 top-1 z-10">
           <div className="pointer-events-none mx-auto flex w-full max-w-3xl justify-end gap-0.5">

--- a/src/components/renderer/TopLevelRenderer.tsx
+++ b/src/components/renderer/TopLevelRenderer.tsx
@@ -31,6 +31,7 @@ export function TopLevelRenderer({block}: BlockRendererProps) {
           overrides={{
             layoutBoundary: false,
             renderScopeId: outlineRenderScopeId(block.id),
+            scopeRootId: block.id,
           }}
         >
           <BlockComponent blockId={block.id}/>

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -223,6 +223,20 @@ describe('core.createChild', () => {
     expect(await env.childIds('root')).toEqual(['A', id, 'B', 'C'])
   })
 
+  it('reveals a collapsed parent when revealParent is set', async () => {
+    await seedABC()
+    await env.repo.mutate.setProperty({id: 'A', schema: isCollapsedProp, value: true})
+    await env.repo.mutate.createChild({parentId: 'A', id: 'A1', revealParent: true})
+    expect(env.read('A')!.properties[isCollapsedProp.name]).toBe(false)
+  })
+
+  it('leaves a collapsed parent collapsed without revealParent', async () => {
+    await seedABC()
+    await env.repo.mutate.setProperty({id: 'A', schema: isCollapsedProp, value: true})
+    await env.repo.mutate.createChild({parentId: 'A', id: 'A1'})
+    expect(env.read('A')!.properties[isCollapsedProp.name]).toBe(true)
+  })
+
   it('respects position={kind:"before", siblingId}', async () => {
     await seedABC()
     const id = await env.repo.mutate.createChild({parentId: 'root', id: 'X', content: 'before-B', position: {kind: 'before', siblingId: 'B'}})

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -559,23 +559,23 @@ describe('core.outdent', () => {
     expect(env.read('r')!.parentId).toBeNull()
   })
 
-  it('refuses to outdent past topLevelBlockId — direct child stays put', async () => {
+  it('refuses to outdent past scopeRootId — direct child stays put', async () => {
     // Without the boundary, A1 (a direct child of A) would normally
-    // outdent to root. Passing topLevelBlockId=A keeps A1 inside.
+    // outdent to root. Passing scopeRootId=A keeps A1 inside.
     await seedABC()
     await env.repo.mutate.createChild({parentId: 'A', id: 'A1'})
-    const moved = await env.repo.mutate.outdent({id: 'A1', topLevelBlockId: 'A'})
+    const moved = await env.repo.mutate.outdent({id: 'A1', scopeRootId: 'A'})
     expect(moved).toBe(false)
     expect(env.read('A1')!.parentId).toBe('A')
   })
 
-  it('still outdents a deeper descendant when topLevelBlockId is set', async () => {
-    // A → A1 → A1a; passing topLevelBlockId=A allows outdent of A1a
-    // (since its parent A1 ≠ topLevelBlockId).
+  it('still outdents a deeper descendant when scopeRootId is set', async () => {
+    // A → A1 → A1a; passing scopeRootId=A allows outdent of A1a
+    // (since its parent A1 ≠ scopeRootId).
     await seedABC()
     await env.repo.mutate.createChild({parentId: 'A', id: 'A1'})
     await env.repo.mutate.createChild({parentId: 'A1', id: 'A1a'})
-    const moved = await env.repo.mutate.outdent({id: 'A1a', topLevelBlockId: 'A'})
+    const moved = await env.repo.mutate.outdent({id: 'A1a', scopeRootId: 'A'})
     expect(moved).toBe(true)
     expect(env.read('A1a')!.parentId).toBe('A')
   })

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -637,7 +637,7 @@ describe('core.moveVertical', () => {
     await env.repo.mutate.createChild({parentId: 'root', id: 'd'})
     await env.repo.mutate.createChild({parentId: 'd', id: 'e'})
 
-    const moved = await env.repo.mutate.moveVertical({id: 'e', direction: -1})
+    const moved = await env.repo.mutate.moveVertical({id: 'e', direction: -1, scopeRootId: 'root'})
     expect(moved).toBe(true)
     expect(env.read('e')!.parentId).toBe('a')
     expect(await env.childIds('a')).toEqual(['b', 'e'])
@@ -648,7 +648,7 @@ describe('core.moveVertical', () => {
   it('moves a last child down into the next sibling subtree (cross-parent)', async () => {
     // a/b, c/d → move b down → b becomes c's first child, a emptied.
     await seedTwoSubtrees()
-    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1})
+    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1, scopeRootId: 'root'})
     expect(moved).toBe(true)
     expect(env.read('b')!.parentId).toBe('c')
     expect(await env.childIds('c')).toEqual(['b', 'd'])
@@ -675,7 +675,7 @@ describe('core.moveVertical', () => {
     // visible at the same depth.
     await seedTwoSubtrees()
     await env.repo.mutate.setProperty({id: 'a', schema: isCollapsedProp, value: true})
-    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
+    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1, scopeRootId: 'root'})
     expect(moved).toBe(true)
     expect(env.read('d')!.parentId).toBe('a')
     expect(await env.childIds('a')).toEqual(['b', 'd'])
@@ -687,7 +687,7 @@ describe('core.moveVertical', () => {
     // is revealed.
     await seedTwoSubtrees()
     await env.repo.mutate.setProperty({id: 'c', schema: isCollapsedProp, value: true})
-    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1})
+    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1, scopeRootId: 'root'})
     expect(moved).toBe(true)
     expect(env.read('b')!.parentId).toBe('c')
     expect(await env.childIds('c')).toEqual(['b', 'd'])
@@ -708,6 +708,24 @@ describe('core.moveVertical', () => {
     const moved = await env.repo.mutate.moveVertical({id: 'b', direction: -1, scopeRootId: 'a'})
     expect(moved).toBe(false)
     expect(env.read('b')!.parentId).toBe('a')
+  })
+
+  it('without a scopeRootId, the sibling-list edge is a no-op (no unbounded cross-parent)', async () => {
+    // a/b, c/d → move d up with NO scope (e.g. a bridge run-action). d is
+    // c's first child, so a cross-parent move would need a visible
+    // boundary; without one it stays put rather than reparenting.
+    await seedTwoSubtrees()
+    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
+    expect(moved).toBe(false)
+    expect(env.read('d')!.parentId).toBe('c')
+  })
+
+  it('still swaps same-parent siblings without a scopeRootId', async () => {
+    // Same-parent reorder doesn't need a scope boundary.
+    await seedABC()
+    const moved = await env.repo.mutate.moveVertical({id: 'B', direction: -1})
+    expect(moved).toBe(true)
+    expect(await env.childIds('root')).toEqual(['B', 'A', 'C'])
   })
 })
 

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -581,6 +581,86 @@ describe('core.outdent', () => {
   })
 })
 
+// ──── moveVertical ────
+
+describe('core.moveVertical', () => {
+  // Shapes the user-facing example:
+  //   a / b      (a with child b)
+  //   c / d      (c with child d)
+  const seedTwoSubtrees = async () => {
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'a'})
+    await env.repo.mutate.createChild({parentId: 'a', id: 'b'})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'c'})
+    await env.repo.mutate.createChild({parentId: 'c', id: 'd'})
+  }
+
+  it('swaps with the previous sibling (same parent) when one exists', async () => {
+    await seedABC()
+    const moved = await env.repo.mutate.moveVertical({id: 'B', direction: -1})
+    expect(moved).toBe(true)
+    expect(await env.childIds('root')).toEqual(['B', 'A', 'C'])
+  })
+
+  it('swaps with the next sibling (same parent) when one exists', async () => {
+    await seedABC()
+    const moved = await env.repo.mutate.moveVertical({id: 'B', direction: 1})
+    expect(moved).toBe(true)
+    expect(await env.childIds('root')).toEqual(['A', 'C', 'B'])
+  })
+
+  it('moves a first child up into the previous sibling subtree (cross-parent)', async () => {
+    // a/b, c/d → move d up → d becomes a's last child, c emptied.
+    await seedTwoSubtrees()
+    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
+    expect(moved).toBe(true)
+    expect(env.read('d')!.parentId).toBe('a')
+    expect(await env.childIds('a')).toEqual(['b', 'd'])
+    expect(await env.childIds('c')).toEqual([])
+  })
+
+  it('moves a last child down into the next sibling subtree (cross-parent)', async () => {
+    // a/b, c/d → move b down → b becomes c's first child, a emptied.
+    await seedTwoSubtrees()
+    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1})
+    expect(moved).toBe(true)
+    expect(env.read('b')!.parentId).toBe('c')
+    expect(await env.childIds('c')).toEqual(['b', 'd'])
+    expect(await env.childIds('a')).toEqual([])
+  })
+
+  it('pops a first child out above its parent when the parent is itself first', async () => {
+    // root: P/(s); move s up → s lands above P under root.
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'P'})
+    await env.repo.mutate.createChild({parentId: 'P', id: 's'})
+    const moved = await env.repo.mutate.moveVertical({id: 's', direction: -1})
+    expect(moved).toBe(true)
+    expect(env.read('s')!.parentId).toBe('root')
+    expect(await env.childIds('root')).toEqual(['s', 'P'])
+  })
+
+  it('does not move the scope root itself', async () => {
+    await seedTwoSubtrees()
+    const moved = await env.repo.mutate.moveVertical({id: 'a', direction: 1, scopeRootId: 'a'})
+    expect(moved).toBe(false)
+    expect(await env.childIds('root')).toEqual(['a', 'c'])
+  })
+
+  it('does not cross a first direct child of the scope root out of scope', async () => {
+    // scopeRootId=root-like 'a': 'b' is a's only child; moving it up
+    // would escape 'a', so it no-ops.
+    await seedTwoSubtrees()
+    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: -1, scopeRootId: 'a'})
+    expect(moved).toBe(false)
+    expect(env.read('b')!.parentId).toBe('a')
+  })
+})
+
 // ──── split ────
 
 describe('core.split', () => {

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -644,6 +644,40 @@ describe('core.moveVertical', () => {
     expect(await env.childIds('root')).toEqual(['s', 'P'])
   })
 
+  it('does not bury a block in a COLLAPSED previous-sibling subtree (up)', async () => {
+    // a (collapsed, hides b), c/d → move d up. a's subtree is hidden,
+    // so d must land adjacent to its parent c (between a and c), not as
+    // a's last child where it would vanish.
+    await seedTwoSubtrees()
+    await env.repo.mutate.setProperty({id: 'a', schema: isCollapsedProp, value: true})
+    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
+    expect(moved).toBe(true)
+    expect(env.read('d')!.parentId).toBe('root')
+    expect(await env.childIds('root')).toEqual(['a', 'd', 'c'])
+    expect(await env.childIds('a')).toEqual(['b'])
+  })
+
+  it('does not bury a block in a COLLAPSED next-sibling subtree (down)', async () => {
+    // a/b, c (collapsed, hides d) → move b down. c's subtree is hidden,
+    // so b lands adjacent to parent a (between a and c), not inside c.
+    await seedTwoSubtrees()
+    await env.repo.mutate.setProperty({id: 'c', schema: isCollapsedProp, value: true})
+    const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1})
+    expect(moved).toBe(true)
+    expect(env.read('b')!.parentId).toBe('root')
+    expect(await env.childIds('root')).toEqual(['a', 'b', 'c'])
+    expect(await env.childIds('c')).toEqual(['d'])
+  })
+
+  it('still descends into an EXPANDED previous-sibling subtree (up)', async () => {
+    // Sanity: with a expanded, d becomes a's last child (the base case).
+    await seedTwoSubtrees()
+    await env.repo.mutate.setProperty({id: 'a', schema: isCollapsedProp, value: false})
+    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
+    expect(moved).toBe(true)
+    expect(await env.childIds('a')).toEqual(['b', 'd'])
+  })
+
   it('does not move the scope root itself', async () => {
     await seedTwoSubtrees()
     const moved = await env.repo.mutate.moveVertical({id: 'a', direction: 1, scopeRootId: 'a'})

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -611,14 +611,24 @@ describe('core.moveVertical', () => {
     expect(await env.childIds('root')).toEqual(['A', 'C', 'B'])
   })
 
-  it('moves a first child up into the previous sibling subtree (cross-parent)', async () => {
-    // a/b, c/d → move d up → d becomes a's last child, c emptied.
-    await seedTwoSubtrees()
-    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
+  it('moves a first child up into the previous sibling subtree at the same depth', async () => {
+    // a/b/c, d/e → move e up → e becomes a's last child (depth 1, like
+    // it was under d); b keeps its own child c; d is emptied.
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'a'})
+    await env.repo.mutate.createChild({parentId: 'a', id: 'b'})
+    await env.repo.mutate.createChild({parentId: 'b', id: 'c'})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'd'})
+    await env.repo.mutate.createChild({parentId: 'd', id: 'e'})
+
+    const moved = await env.repo.mutate.moveVertical({id: 'e', direction: -1})
     expect(moved).toBe(true)
-    expect(env.read('d')!.parentId).toBe('a')
-    expect(await env.childIds('a')).toEqual(['b', 'd'])
-    expect(await env.childIds('c')).toEqual([])
+    expect(env.read('e')!.parentId).toBe('a')
+    expect(await env.childIds('a')).toEqual(['b', 'e'])
+    expect(await env.childIds('b')).toEqual(['c'])
+    expect(await env.childIds('d')).toEqual([])
   })
 
   it('moves a last child down into the next sibling subtree (cross-parent)', async () => {
@@ -631,51 +641,43 @@ describe('core.moveVertical', () => {
     expect(await env.childIds('a')).toEqual([])
   })
 
-  it('pops a first child out above its parent when the parent is itself first', async () => {
-    // root: P/(s); move s up → s lands above P under root.
+  it('is a no-op when the parent is itself the first child (would need to outdent)', async () => {
+    // root: P/(s); moving s up has no same-depth slot above it without
+    // outdenting, so moveVertical leaves it put (indentation invariant).
     await env.repo.tx(async tx => {
       await tx.create({id: 'root', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'})
     }, {scope: ChangeScope.BlockDefault})
     await env.repo.mutate.createChild({parentId: 'root', id: 'P'})
     await env.repo.mutate.createChild({parentId: 'P', id: 's'})
     const moved = await env.repo.mutate.moveVertical({id: 's', direction: -1})
-    expect(moved).toBe(true)
-    expect(env.read('s')!.parentId).toBe('root')
-    expect(await env.childIds('root')).toEqual(['s', 'P'])
+    expect(moved).toBe(false)
+    expect(env.read('s')!.parentId).toBe('P')
+    expect(await env.childIds('root')).toEqual(['P'])
   })
 
-  it('does not bury a block in a COLLAPSED previous-sibling subtree (up)', async () => {
-    // a (collapsed, hides b), c/d → move d up. a's subtree is hidden,
-    // so d must land adjacent to its parent c (between a and c), not as
-    // a's last child where it would vanish.
+  it('descends into AND expands a collapsed previous-sibling subtree (up)', async () => {
+    // a (collapsed), c/d → move d up → d becomes a's last child and a is
+    // revealed (like indenting under a collapsed bullet), so d stays
+    // visible at the same depth.
     await seedTwoSubtrees()
     await env.repo.mutate.setProperty({id: 'a', schema: isCollapsedProp, value: true})
     const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
     expect(moved).toBe(true)
-    expect(env.read('d')!.parentId).toBe('root')
-    expect(await env.childIds('root')).toEqual(['a', 'd', 'c'])
-    expect(await env.childIds('a')).toEqual(['b'])
+    expect(env.read('d')!.parentId).toBe('a')
+    expect(await env.childIds('a')).toEqual(['b', 'd'])
+    expect(env.read('a')!.properties[isCollapsedProp.name]).toBe(false)
   })
 
-  it('does not bury a block in a COLLAPSED next-sibling subtree (down)', async () => {
-    // a/b, c (collapsed, hides d) → move b down. c's subtree is hidden,
-    // so b lands adjacent to parent a (between a and c), not inside c.
+  it('descends into AND expands a collapsed next-sibling subtree (down)', async () => {
+    // a/b, c (collapsed) → move b down → b becomes c's first child and c
+    // is revealed.
     await seedTwoSubtrees()
     await env.repo.mutate.setProperty({id: 'c', schema: isCollapsedProp, value: true})
     const moved = await env.repo.mutate.moveVertical({id: 'b', direction: 1})
     expect(moved).toBe(true)
-    expect(env.read('b')!.parentId).toBe('root')
-    expect(await env.childIds('root')).toEqual(['a', 'b', 'c'])
-    expect(await env.childIds('c')).toEqual(['d'])
-  })
-
-  it('still descends into an EXPANDED previous-sibling subtree (up)', async () => {
-    // Sanity: with a expanded, d becomes a's last child (the base case).
-    await seedTwoSubtrees()
-    await env.repo.mutate.setProperty({id: 'a', schema: isCollapsedProp, value: false})
-    const moved = await env.repo.mutate.moveVertical({id: 'd', direction: -1})
-    expect(moved).toBe(true)
-    expect(await env.childIds('a')).toEqual(['b', 'd'])
+    expect(env.read('b')!.parentId).toBe('c')
+    expect(await env.childIds('c')).toEqual(['b', 'd'])
+    expect(env.read('c')!.properties[isCollapsedProp.name]).toBe(false)
   })
 
   it('does not move the scope root itself', async () => {

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -116,6 +116,18 @@ const relocateBlock = async (
   await tx.move(block.id, {parentId, orderKey})
 }
 
+/** Reveal a block's children by clearing a collapsed flag. Structural
+ *  placements that put a block *as a child of* `id` call this so the
+ *  inserted/moved block can't land inside a closed subtree and vanish.
+ *  The shared invariant behind indent (reparent under previous sibling),
+ *  moveVertical (descend into a neighbour), and child-first create-below
+ *  (vim `o` / Enter on a collapsed scope root). No-op when not collapsed. */
+const revealChildren = async (tx: Tx, id: string): Promise<void> => {
+  if (await tx.getProperty(id, isCollapsedProp)) {
+    await tx.setProperty(id, isCollapsedProp, false)
+  }
+}
+
 // ──── setContent ────
 
 export const setContent = defineMutator<{id: string; content: string}, void>({
@@ -206,6 +218,11 @@ interface CreateChildArgs {
   /** Optional explicit id (deterministic-id callers). Engine assigns
    *  a UUID when absent. */
   id?: string
+  /** Reveal the parent if it's collapsed, so the new child is visible.
+   *  User-initiated "create child and focus it" paths (vim `o`, Enter
+   *  on a collapsed scope root) set this; programmatic child creation
+   *  leaves it off to avoid force-expanding. */
+  revealParent?: boolean
 }
 
 const createChildSchema = z.object({
@@ -215,6 +232,7 @@ const createChildSchema = z.object({
   references: z.array(z.object({id: z.string(), alias: z.string()})).optional(),
   position: positionSchema.optional(),
   id: z.string().optional(),
+  revealParent: z.boolean().optional(),
 })
 
 export const createChild = defineMutator<CreateChildArgs, string>({
@@ -226,6 +244,7 @@ export const createChild = defineMutator<CreateChildArgs, string>({
   apply: async (tx, args) => {
     const parent = await requireBlock(tx, args.parentId)
     const orderKey = await orderKeyForInsert(tx, args.parentId, parent.workspaceId, args.position ?? {kind: 'last'})
+    if (args.revealParent) await revealChildren(tx, args.parentId)
     return tx.create({
       id: args.id,
       workspaceId: parent.workspaceId,
@@ -432,9 +451,7 @@ export const indent = defineMutator<{id: string}, void>({
     const newParentChildren = await tx.childrenOf(newParent.id)
     const orderKey = keyAtEnd(newParentChildren.at(-1)?.orderKey ?? null)
     await tx.move(id, {parentId: newParent.id, orderKey})
-    if (await tx.getProperty(newParent.id, isCollapsedProp)) {
-      await tx.setProperty(newParent.id, isCollapsedProp, false)
-    }
+    await revealChildren(tx, newParent.id)
   },
 })
 
@@ -588,12 +605,9 @@ export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
 
     if (!target) return false
     // Moving INTO a neighbouring subtree (target parent ≠ current parent)
-    // reveals it if collapsed, so the block stays visible — same as
-    // `indent` does when reparenting under a collapsed new parent.
+    // reveals it if collapsed, so the block stays visible.
     if (target.parentId !== null && target.parentId !== self.parentId) {
-      if (await tx.getProperty(target.parentId, isCollapsedProp)) {
-        await tx.setProperty(target.parentId, isCollapsedProp, false)
-      }
+      await revealChildren(tx, target.parentId)
     }
     await relocateBlock(tx, self, target.parentId, target.position)
     return true

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -425,30 +425,32 @@ export const indent = defineMutator<{id: string}, void>({
 
 interface OutdentArgs {
   id: string
-  /** Optional view boundary. If `self.parentId === topLevelBlockId`,
-   *  outdent is a no-op — the block is a direct child of the current
-   *  view's root and outdenting would move it outside the visible
-   *  zoom scope (or to the workspace root for root-level views).
-   *  Returns `false` in that case so callers can fall back. */
-  topLevelBlockId?: string
+  /** Optional surface boundary — the root of the visible subtree the
+   *  caller renders (the panel's zoom root on the main outline, a
+   *  backlink entry's shown block, …). If `self.parentId === scopeRootId`,
+   *  outdent is a no-op — the block is a direct child of the surface's
+   *  root and outdenting would move it outside the visible scope (or to
+   *  the workspace root for root-level views). Returns `false` in that
+   *  case so callers can fall back. */
+  scopeRootId?: string
 }
 
 export const outdent = defineMutator<OutdentArgs, boolean>({
   name: 'core.outdent',
   argsSchema: z.object({
     id: z.string(),
-    topLevelBlockId: z.string().optional(),
+    scopeRootId: z.string().optional(),
   }),
   resultSchema: z.boolean(),
   scope: ChangeScope.BlockDefault,
   describe: ({id}) => `outdent ${id}`,
-  apply: async (tx, {id, topLevelBlockId}) => {
+  apply: async (tx, {id, scopeRootId}) => {
     const self = await requireBlock(tx, id)
     if (self.parentId === null) return false  // already at root
-    // Refuse to outdent past the current view boundary — a direct
-    // child of `topLevelBlockId` would otherwise pop out to the
-    // grandparent (or workspace root), exiting the user's zoom scope.
-    if (topLevelBlockId !== undefined && self.parentId === topLevelBlockId) return false
+    // Refuse to outdent past the surface boundary — a direct child of
+    // `scopeRootId` would otherwise pop out to the grandparent (or
+    // workspace root), exiting the visible scope.
+    if (scopeRootId !== undefined && self.parentId === scopeRootId) return false
     const parent = await requireBlock(tx, self.parentId)
     // Move under grandparent, positioned right after current parent.
     // tx.childrenOf(null) enumerates root-level siblings of the pinned

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -50,6 +50,14 @@ const orderKeyBeforeSibling = async (tx: Tx, sibling: BlockData): Promise<string
   return keyBetween(previous?.orderKey ?? null, sibling.orderKey)
 }
 
+/** Placement of a block within a parent's child list — an explicit
+ *  position used by the insert/move mutators. */
+type InsertPosition =
+  | { kind: 'first' }
+  | { kind: 'last' }
+  | { kind: 'after'; siblingId: string }
+  | { kind: 'before'; siblingId: string }
+
 /** Compute the order_key for inserting under `parentId` at a given
  *  `position`. Reads sibling list from SQL (tx.childrenOf is sorted by
  *  (order_key, id) per §11.4). `parentId === null` enumerates
@@ -61,11 +69,7 @@ const orderKeyForInsert = async (
   tx: Tx,
   parentId: string | null,
   workspaceId: string,
-  position:
-    | { kind: 'first' }
-    | { kind: 'last' }
-    | { kind: 'after'; siblingId: string }
-    | { kind: 'before'; siblingId: string },
+  position: InsertPosition,
 ): Promise<string> => {
   const siblings = await tx.childrenOf(parentId, workspaceId)
 
@@ -97,6 +101,20 @@ const positionSchema = z.discriminatedUnion('kind', [
   z.object({kind: z.literal('after'), siblingId: z.string()}),
   z.object({kind: z.literal('before'), siblingId: z.string()}),
 ])
+
+/** Re-home `block` under `parentId` at `position`, computing the order
+ *  key. The shared core of `core.move` (explicit placement) and
+ *  `moveVertical` (which computes a target then places the block) — both
+ *  funnel their final write through here. */
+const relocateBlock = async (
+  tx: Tx,
+  block: BlockData,
+  parentId: string | null,
+  position: InsertPosition,
+): Promise<void> => {
+  const orderKey = await orderKeyForInsert(tx, parentId, block.workspaceId, position)
+  await tx.move(block.id, {parentId, orderKey})
+}
 
 // ──── setContent ────
 
@@ -377,8 +395,7 @@ export const move = defineMutator<MoveArgs, void>({
     // workspace_id is immutable (server-side trigger enforces it), so
     // it's also the destination workspace.
     const self = await requireBlock(tx, args.id)
-    const orderKey = await orderKeyForInsert(tx, args.parentId, self.workspaceId, args.position)
-    await tx.move(args.id, {parentId: args.parentId, orderKey})
+    await relocateBlock(tx, self, args.parentId, args.position)
   },
 })
 
@@ -475,12 +492,6 @@ export const outdent = defineMutator<OutdentArgs, boolean>({
 })
 
 // ──── moveVertical ────
-
-type InsertPosition =
-  | { kind: 'first' }
-  | { kind: 'last' }
-  | { kind: 'after'; siblingId: string }
-  | { kind: 'before'; siblingId: string }
 
 interface MoveVerticalArgs {
   id: string
@@ -584,8 +595,7 @@ export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
         await tx.setProperty(target.parentId, isCollapsedProp, false)
       }
     }
-    const orderKey = await orderKeyForInsert(tx, target.parentId, self.workspaceId, target.position)
-    await tx.move(id, {parentId: target.parentId, orderKey})
+    await relocateBlock(tx, self, target.parentId, target.position)
     return true
   },
 })

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -591,7 +591,12 @@ export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
       // slot would be a shallower level, which would change indentation,
       // so it's a no-op.
       return (async () => {
-        if (self.parentId === scopeRootId) return null
+        // Cross-parent moves are bounded by the visible surface, so they
+        // need a scope root. Without one (e.g. a bridge run-action with no
+        // UI context) keep the move same-parent only — the edge is a
+        // no-op, matching the previous reorder behaviour — rather than
+        // reparenting into an unbounded neighbour/page.
+        if (scopeRootId === undefined || self.parentId === scopeRootId) return null
         const parent = await requireBlock(tx, self.parentId!)
         const parentSiblings = await tx.childrenOf(parent.parentId, self.workspaceId)
         const pIdx = parentSiblings.findIndex(s => s.id === parent.id)

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -494,33 +494,35 @@ interface MoveVerticalArgs {
 }
 
 /**
- * Move a block one step up or down in the *visible* outline, crossing
- * parent boundaries the way Roam does. Within a sibling list it swaps
- * with the adjacent sibling; at the edge of a sibling list it descends
- * into the neighbouring subtree:
+ * Move a block one step up or down in the visible outline, WITHOUT ever
+ * changing its indentation. Within a sibling list it swaps with the
+ * adjacent sibling; when it is the first/last child of its parent it
+ * moves into the neighbouring sibling subtree at the SAME depth it
+ * already had:
  *
  *     a            a
  *       b            b
- *     c     ──▶      d   (move d up → last child of c's previous sibling a)
- *       d          c
+ *         c            c
+ *     d     ──▶      e   (move e up → a's last child; e stays depth 1)
+ *       e          d
  *
  * Rules (up; down mirrors):
  *  - has a previous sibling          → swap before it (same parent);
- *  - first child, parent has an
- *    EXPANDED previous sibling Q     → become Q's last child;
  *  - first child, parent has a
- *    COLLAPSED previous sibling, or
- *    parent is itself the first      → move just above the parent
- *    child                            (under the grandparent).
+ *    previous sibling Q              → become Q's last child — same depth
+ *                                      the block already had. Q is
+ *                                      revealed if collapsed, mirroring
+ *                                      how `indent` reveals a collapsed
+ *                                      new parent;
+ *  - first child, parent is itself   → no-op. The only one-step-up slot
+ *    the first child                   would be a shallower level, and
+ *                                      moveVertical never outdents.
  *
- * "Visible" is the key word: a collapsed block is one opaque row, so we
- * never descend into a collapsed neighbour's hidden subtree (the block
- * would vanish). In that case the block lands adjacent to its parent
- * instead — still exactly one visible step.
- *
- * Bounded by `scopeRootId`: the scope root itself never moves, and a
- * first/last direct child of the scope root won't cross out of it.
- * Returns whether anything moved so callers can no-op cleanly.
+ * Indentation is invariant: every move keeps the block at its original
+ * depth, so it never pops out to / into a shallower or deeper level.
+ * Bounded by `scopeRootId`: the scope root never moves, and a first/last
+ * direct child of it won't cross out. Returns whether anything moved so
+ * callers can no-op cleanly.
  */
 export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
   name: 'core.moveVertical',
@@ -554,41 +556,34 @@ export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
             : {kind: 'after', siblingId: adjacent.id},
         })
       }
-      // Edge of the sibling list — cross into the neighbouring subtree,
-      // unless that would escape the scope.
+      // Edge of the sibling list — move into the neighbouring sibling
+      // subtree at the same depth. If the parent has no neighbouring
+      // sibling (it's itself the first/last child), the only one-step
+      // slot would be a shallower level, which would change indentation,
+      // so it's a no-op.
       return (async () => {
         if (self.parentId === scopeRootId) return null
         const parent = await requireBlock(tx, self.parentId!)
         const parentSiblings = await tx.childrenOf(parent.parentId, self.workspaceId)
         const pIdx = parentSiblings.findIndex(s => s.id === parent.id)
         const neighbourParent = up ? parentSiblings[pIdx - 1] : parentSiblings[pIdx + 1]
-        // Only descend into the neighbour when it's expanded — descending
-        // into a collapsed subtree would hide the block. A collapsed
-        // neighbour is treated as opaque, so we fall through to the
-        // adjacent-to-parent placement below (one visible step, stays
-        // visible).
-        const neighbourExpanded = neighbourParent
-          ? !((await tx.getProperty(neighbourParent.id, isCollapsedProp)) ?? false)
-          : false
-        if (neighbourParent && neighbourExpanded) {
-          return {
-            parentId: neighbourParent.id,
-            position: up ? {kind: 'last' as const} : {kind: 'first' as const},
-          }
-        }
-        // No neighbour subtree to descend into (parent is itself the
-        // first/last child) or the neighbour is collapsed: pop the block
-        // out just above/below the parent under the grandparent.
+        if (!neighbourParent) return null
         return {
-          parentId: parent.parentId,
-          position: up
-            ? {kind: 'before' as const, siblingId: parent.id}
-            : {kind: 'after' as const, siblingId: parent.id},
+          parentId: neighbourParent.id,
+          position: up ? {kind: 'last' as const} : {kind: 'first' as const},
         }
       })()
     })()
 
     if (!target) return false
+    // Moving INTO a neighbouring subtree (target parent ≠ current parent)
+    // reveals it if collapsed, so the block stays visible — same as
+    // `indent` does when reparenting under a collapsed new parent.
+    if (target.parentId !== null && target.parentId !== self.parentId) {
+      if (await tx.getProperty(target.parentId, isCollapsedProp)) {
+        await tx.setProperty(target.parentId, isCollapsedProp, false)
+      }
+    }
     const orderKey = await orderKeyForInsert(tx, target.parentId, self.workspaceId, target.position)
     await tx.move(id, {parentId: target.parentId, orderKey})
     return true

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -474,6 +474,111 @@ export const outdent = defineMutator<OutdentArgs, boolean>({
   },
 })
 
+// ──── moveVertical ────
+
+type InsertPosition =
+  | { kind: 'first' }
+  | { kind: 'last' }
+  | { kind: 'after'; siblingId: string }
+  | { kind: 'before'; siblingId: string }
+
+interface MoveVerticalArgs {
+  id: string
+  /** -1 = up (toward the top of the visible list), +1 = down. */
+  direction: -1 | 1
+  /** Surface boundary — the root of the visible subtree (see the
+   *  `outdent` mutator and `BlockContextType.scopeRootId`). The block
+   *  never moves above/below this root, and a direct child of it won't
+   *  cross out of the scope. */
+  scopeRootId?: string
+}
+
+/**
+ * Move a block one step up or down in the visible outline, crossing
+ * parent boundaries the way Roam / org-mode do. Within a sibling list
+ * it swaps with the adjacent sibling; at the edge of a sibling list it
+ * descends into the neighbouring subtree:
+ *
+ *     a            a
+ *       b            b
+ *     c     ──▶      d   (move d up → last child of c's previous sibling a)
+ *       d          c
+ *
+ * Rules (up; down mirrors):
+ *  - has a previous sibling          → swap before it (same parent);
+ *  - first child, parent has a
+ *    previous sibling Q              → become Q's last child;
+ *  - first child, parent is first    → move just above the parent
+ *    child                            (under the grandparent).
+ *
+ * Bounded by `scopeRootId`: the scope root itself never moves, and a
+ * first/last direct child of the scope root won't cross out of it.
+ * Returns whether anything moved so callers can no-op cleanly.
+ */
+export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
+  name: 'core.moveVertical',
+  argsSchema: z.object({
+    id: z.string(),
+    direction: z.union([z.literal(-1), z.literal(1)]),
+    scopeRootId: z.string().optional(),
+  }),
+  resultSchema: z.boolean(),
+  scope: ChangeScope.BlockDefault,
+  describe: ({id, direction}) => `move ${id} ${direction === -1 ? 'up' : 'down'}`,
+  apply: async (tx, {id, direction, scopeRootId}) => {
+    const self = await requireBlock(tx, id)
+    if (self.parentId === null) return false
+    // The scope root anchors the view; it can't move within itself.
+    if (scopeRootId !== undefined && id === scopeRootId) return false
+
+    const siblings = await tx.childrenOf(self.parentId)
+    const idx = siblings.findIndex(s => s.id === id)
+    if (idx === -1) return false
+
+    const target = await ((): Promise<{parentId: string | null; position: InsertPosition} | null> => {
+      const up = direction === -1
+      const hasAdjacentSibling = up ? idx > 0 : idx < siblings.length - 1
+      if (hasAdjacentSibling) {
+        const adjacent = siblings[up ? idx - 1 : idx + 1]
+        return Promise.resolve({
+          parentId: self.parentId,
+          position: up
+            ? {kind: 'before', siblingId: adjacent.id}
+            : {kind: 'after', siblingId: adjacent.id},
+        })
+      }
+      // Edge of the sibling list — cross into the neighbouring subtree,
+      // unless that would escape the scope.
+      return (async () => {
+        if (self.parentId === scopeRootId) return null
+        const parent = await requireBlock(tx, self.parentId!)
+        const parentSiblings = await tx.childrenOf(parent.parentId, self.workspaceId)
+        const pIdx = parentSiblings.findIndex(s => s.id === parent.id)
+        const neighbourParent = up ? parentSiblings[pIdx - 1] : parentSiblings[pIdx + 1]
+        if (neighbourParent) {
+          return {
+            parentId: neighbourParent.id,
+            position: up ? {kind: 'last' as const} : {kind: 'first' as const},
+          }
+        }
+        // Parent is itself the first/last child: pop the block out just
+        // above/below the parent under the grandparent.
+        return {
+          parentId: parent.parentId,
+          position: up
+            ? {kind: 'before' as const, siblingId: parent.id}
+            : {kind: 'after' as const, siblingId: parent.id},
+        }
+      })()
+    })()
+
+    if (!target) return false
+    const orderKey = await orderKeyForInsert(tx, target.parentId, self.workspaceId, target.position)
+    await tx.move(id, {parentId: target.parentId, orderKey})
+    return true
+  },
+})
+
 // ──── split ────
 
 interface SplitArgs {
@@ -619,6 +724,7 @@ export const KERNEL_MUTATORS: ReadonlyArray<AnyMutator> = [
   setOrderKey,
   indent,
   outdent,
+  moveVertical,
   split,
   merge,
 ]
@@ -642,6 +748,7 @@ declare module '@/data/api' {
     'core.setOrderKey': typeof setOrderKey
     'core.indent': typeof indent
     'core.outdent': typeof outdent
+    'core.moveVertical': typeof moveVertical
     'core.split': typeof split
     'core.merge': typeof merge
   }

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -120,9 +120,10 @@ const relocateBlock = async (
  *  placements that put a block *as a child of* `id` call this so the
  *  inserted/moved block can't land inside a closed subtree and vanish.
  *  The shared invariant behind indent (reparent under previous sibling),
- *  moveVertical (descend into a neighbour), and child-first create-below
- *  (vim `o` / Enter on a collapsed scope root). No-op when not collapsed. */
-const revealChildren = async (tx: Tx, id: string): Promise<void> => {
+ *  moveVertical (descend into a neighbour), child-first create-below
+ *  (vim `o` / Enter on a collapsed scope root), and paste-as-child.
+ *  No-op when not collapsed. */
+export const revealChildren = async (tx: Tx, id: string): Promise<void> => {
   if (await tx.getProperty(id, isCollapsedProp)) {
     await tx.setProperty(id, isCollapsedProp, false)
   }

--- a/src/data/internals/kernelMutators.ts
+++ b/src/data/internals/kernelMutators.ts
@@ -494,10 +494,10 @@ interface MoveVerticalArgs {
 }
 
 /**
- * Move a block one step up or down in the visible outline, crossing
- * parent boundaries the way Roam / org-mode do. Within a sibling list
- * it swaps with the adjacent sibling; at the edge of a sibling list it
- * descends into the neighbouring subtree:
+ * Move a block one step up or down in the *visible* outline, crossing
+ * parent boundaries the way Roam does. Within a sibling list it swaps
+ * with the adjacent sibling; at the edge of a sibling list it descends
+ * into the neighbouring subtree:
  *
  *     a            a
  *       b            b
@@ -506,10 +506,17 @@ interface MoveVerticalArgs {
  *
  * Rules (up; down mirrors):
  *  - has a previous sibling          → swap before it (same parent);
+ *  - first child, parent has an
+ *    EXPANDED previous sibling Q     → become Q's last child;
  *  - first child, parent has a
- *    previous sibling Q              → become Q's last child;
- *  - first child, parent is first    → move just above the parent
+ *    COLLAPSED previous sibling, or
+ *    parent is itself the first      → move just above the parent
  *    child                            (under the grandparent).
+ *
+ * "Visible" is the key word: a collapsed block is one opaque row, so we
+ * never descend into a collapsed neighbour's hidden subtree (the block
+ * would vanish). In that case the block lands adjacent to its parent
+ * instead — still exactly one visible step.
  *
  * Bounded by `scopeRootId`: the scope root itself never moves, and a
  * first/last direct child of the scope root won't cross out of it.
@@ -555,14 +562,23 @@ export const moveVertical = defineMutator<MoveVerticalArgs, boolean>({
         const parentSiblings = await tx.childrenOf(parent.parentId, self.workspaceId)
         const pIdx = parentSiblings.findIndex(s => s.id === parent.id)
         const neighbourParent = up ? parentSiblings[pIdx - 1] : parentSiblings[pIdx + 1]
-        if (neighbourParent) {
+        // Only descend into the neighbour when it's expanded — descending
+        // into a collapsed subtree would hide the block. A collapsed
+        // neighbour is treated as opaque, so we fall through to the
+        // adjacent-to-parent placement below (one visible step, stays
+        // visible).
+        const neighbourExpanded = neighbourParent
+          ? !((await tx.getProperty(neighbourParent.id, isCollapsedProp)) ?? false)
+          : false
+        if (neighbourParent && neighbourExpanded) {
           return {
             parentId: neighbourParent.id,
             position: up ? {kind: 'last' as const} : {kind: 'first' as const},
           }
         }
-        // Parent is itself the first/last child: pop the block out just
-        // above/below the parent under the grandparent.
+        // No neighbour subtree to descend into (parent is itself the
+        // first/last child) or the neighbour is collapsed: pop the block
+        // out just above/below the parent under the grandparent.
         return {
           parentId: parent.parentId,
           position: up

--- a/src/data/structuralEditPolicy.ts
+++ b/src/data/structuralEditPolicy.ts
@@ -1,0 +1,97 @@
+import { Block } from './block'
+import { isCollapsedProp } from './properties.js'
+
+/**
+ * Where a "new block below" gesture (vim `o`, Enter-at-end-of-line)
+ * must place the created block so it lands somewhere the user can see.
+ *  - `child-first`: insert as the block's first child.
+ *  - `sibling-below`: insert as the next sibling.
+ */
+export type CreateBelowPlacement = 'child-first' | 'sibling-below'
+
+export interface StructuralEditPolicyInput {
+  /** Block the structural edit targets. */
+  blockId: string
+  /** Its data-tree parent (null at the workspace root). */
+  parentId: string | null
+  /** True when the block has children that are currently shown
+   *  (i.e. it has at least one child AND is not collapsed). */
+  hasUncollapsedChildren: boolean
+  /** Root of the visible subtree this block is rendered within — the
+   *  panel's zoom root for the main outline, the shown block for a
+   *  backlink entry, the embedded block for an embed, etc. `undefined`
+   *  when no scope is known (treated as "no scope root", so nothing is
+   *  considered the scope root). */
+  scopeRootId: string | undefined
+}
+
+/**
+ * Scope-relative structural-edit policy for one block. Answers the
+ * questions every structural mutation needs ("am I at the visible
+ * boundary, and what may I do here?") from a single rule set, instead
+ * of each call site re-deriving them from the panel's `topLevelBlockId`.
+ *
+ * The decisions hinge on whether the block is the *scope root* — the
+ * top of the bounded subtree the current surface renders. A scope root
+ * has no visible parent or siblings within the surface, so:
+ *  - "new block below" must descend into a child (a sibling would land
+ *    outside the surface, the classic "invisible sibling" bug);
+ *  - indent / outdent / merge-into-previous are no-ops (they would
+ *    restructure across the surface boundary).
+ *
+ * The main outline reaches the same answers it always did, because
+ * there the scope root simply *is* `topLevelBlockId`. Nested surfaces
+ * (backlinks, embeds) now get correct behaviour for free by declaring
+ * their own scope root.
+ */
+export interface StructuralEditPolicy {
+  /** Is this block the root of its render scope? */
+  isScopeRoot: boolean
+  /** Placement for vim `o` / Enter-at-end. */
+  createBelowPlacement: CreateBelowPlacement
+  /** May Tab indent this block within the surface? */
+  canIndent: boolean
+  /** May Shift+Tab outdent this block within the surface? The
+   *  fine-grained "already at the boundary" check still lives in the
+   *  `core.outdent` mutator (it returns `false` and the caller falls
+   *  back); this only gates the scope-root case the mutator can't see. */
+  canOutdent: boolean
+  /** May Backspace-at-start merge this block into the previous visible
+   *  block? False at the scope root, where the previous visible block
+   *  is outside the surface. */
+  canMergeUp: boolean
+}
+
+export const resolveStructuralEditPolicy = (
+  {blockId, parentId, hasUncollapsedChildren, scopeRootId}: StructuralEditPolicyInput,
+): StructuralEditPolicy => {
+  const isScopeRoot = scopeRootId !== undefined && blockId === scopeRootId
+  return {
+    isScopeRoot,
+    createBelowPlacement:
+      isScopeRoot || hasUncollapsedChildren ? 'child-first' : 'sibling-below',
+    canIndent: !isScopeRoot,
+    canOutdent: !isScopeRoot && parentId !== scopeRootId,
+    canMergeUp: !isScopeRoot,
+  }
+}
+
+/**
+ * Convenience resolver that reads the inputs `resolveStructuralEditPolicy`
+ * needs from a live `Block`, centralizing the load idiom the structural
+ * action handlers used to repeat (`load` + `childIds` + `isCollapsed`).
+ */
+export const structuralEditPolicyForBlock = async (
+  block: Block,
+  scopeRootId: string | undefined,
+): Promise<StructuralEditPolicy> => {
+  const data = block.peek() ?? await block.load()
+  const childIds = await block.childIds.load()
+  const isCollapsed = block.peekProperty(isCollapsedProp) ?? false
+  return resolveStructuralEditPolicy({
+    blockId: block.id,
+    parentId: data?.parentId ?? null,
+    hasUncollapsedChildren: childIds.length > 0 && !isCollapsed,
+    scopeRootId,
+  })
+}

--- a/src/data/test/structuralEditPolicy.test.ts
+++ b/src/data/test/structuralEditPolicy.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { resolveStructuralEditPolicy } from '../structuralEditPolicy.ts'
+
+const policy = (over: Partial<Parameters<typeof resolveStructuralEditPolicy>[0]> = {}) =>
+  resolveStructuralEditPolicy({
+    blockId: 'b',
+    parentId: 'p',
+    hasUncollapsedChildren: false,
+    scopeRootId: 'root',
+    ...over,
+  })
+
+describe('resolveStructuralEditPolicy', () => {
+  describe('non-scope-root block', () => {
+    it('creates a sibling below when it has no visible children', () => {
+      expect(policy().createBelowPlacement).toBe('sibling-below')
+    })
+
+    it('creates a first child when it has visible children', () => {
+      expect(policy({hasUncollapsedChildren: true}).createBelowPlacement).toBe('child-first')
+    })
+
+    it('allows indent / outdent / merge-up', () => {
+      const p = policy({parentId: 'somewhere-else'})
+      expect(p).toMatchObject({canIndent: true, canOutdent: true, canMergeUp: true, isScopeRoot: false})
+    })
+
+    it('refuses to outdent past the scope boundary (direct child of root)', () => {
+      expect(policy({parentId: 'root'}).canOutdent).toBe(false)
+    })
+  })
+
+  describe('scope-root block', () => {
+    const root = (over: Partial<Parameters<typeof resolveStructuralEditPolicy>[0]> = {}) =>
+      policy({blockId: 'root', parentId: 'real-parent', ...over})
+
+    it('always creates a first child so the new block stays visible', () => {
+      expect(root().createBelowPlacement).toBe('child-first')
+      expect(root({hasUncollapsedChildren: true}).createBelowPlacement).toBe('child-first')
+    })
+
+    it('is a no-op for indent / outdent / merge-up', () => {
+      expect(root()).toMatchObject({
+        isScopeRoot: true,
+        canIndent: false,
+        canOutdent: false,
+        canMergeUp: false,
+      })
+    })
+  })
+
+  it('treats nothing as a scope root when scopeRootId is undefined', () => {
+    const p = policy({scopeRootId: undefined})
+    expect(p.isScopeRoot).toBe(false)
+    expect(p.canIndent).toBe(true)
+  })
+})

--- a/src/extensions/blockInteraction.ts
+++ b/src/extensions/blockInteraction.ts
@@ -518,7 +518,7 @@ export const handleBlockSelectionClick = async (
         : null,
     })
   } else if (event.shiftKey) {
-    await extendSelection(block.id, uiStateBlock, repo, context.scopeRootId)
+    await extendSelection(block.id, uiStateBlock, repo, context.scopeRootId, !context.blockContext?.isNestedSurface)
   } else {
     await resetBlockSelection(uiStateBlock)
   }

--- a/src/extensions/blockInteraction.ts
+++ b/src/extensions/blockInteraction.ts
@@ -57,6 +57,12 @@ export interface BlockResolveContext {
   uiStateBlock: Block
   types: readonly string[]
   topLevelBlockId?: string
+  /** Root of the visible subtree this mount renders (see
+   *  `BlockContextType.scopeRootId`). Equals `topLevelBlockId` on the
+   *  main outline; differs in nested surfaces (a backlink entry's shown
+   *  block, an embedded block). Structural-edit and navigation handlers
+   *  consume this as the surface boundary. */
+  scopeRootId?: string
   /** Focal-on-document — `block.id === topLevelBlockId` AND the current
    *  mount is the document surface (not an embed, backlink entry, or
    *  breadcrumb preview). Populated by `useIsFocalRender(block)`; the
@@ -512,7 +518,7 @@ export const handleBlockSelectionClick = async (
         : null,
     })
   } else if (event.shiftKey) {
-    await extendSelection(block.id, uiStateBlock, repo)
+    await extendSelection(block.id, uiStateBlock, repo, context.scopeRootId)
   } else {
     await resetBlockSelection(uiStateBlock)
   }

--- a/src/extensions/useShortcutSurfaceActivations.ts
+++ b/src/extensions/useShortcutSurfaceActivations.ts
@@ -68,14 +68,12 @@ export function useShortcutSurfaceActivations(
   const inEditMode = useInEditMode(block.id)
   const isSelected = useIsSelected(block.id)
 
-  // Root of this surface's visible subtree. Set by every surface that
-  // mounts a block as a bounded view (panel, backlink entry, embed,
-  // breadcrumb); falls back to the panel's zoom root for the main
-  // outline. This — not topLevelBlockId — is the boundary structural
-  // and navigation handlers operate against.
-  const scopeRootId = typeof blockContext.scopeRootId === 'string'
-    ? blockContext.scopeRootId
-    : topLevelBlockId
+  // Root of this surface's visible subtree — declared by every surface
+  // that mounts a block (panel/top-level = its rendered root, backlink
+  // entry = shown block, embed = embedded block, breadcrumb = segment).
+  // This, not topLevelBlockId, is the boundary structural and navigation
+  // handlers operate against.
+  const scopeRootId = blockContext.scopeRootId
 
   const runtime = useAppRuntime()
   const resolveShortcutActivations = runtime.read(shortcutSurfaceActivationsFacet)

--- a/src/extensions/useShortcutSurfaceActivations.ts
+++ b/src/extensions/useShortcutSurfaceActivations.ts
@@ -68,6 +68,15 @@ export function useShortcutSurfaceActivations(
   const inEditMode = useInEditMode(block.id)
   const isSelected = useIsSelected(block.id)
 
+  // Root of this surface's visible subtree. Set by every surface that
+  // mounts a block as a bounded view (panel, backlink entry, embed,
+  // breadcrumb); falls back to the panel's zoom root for the main
+  // outline. This — not topLevelBlockId — is the boundary structural
+  // and navigation handlers operate against.
+  const scopeRootId = typeof blockContext.scopeRootId === 'string'
+    ? blockContext.scopeRootId
+    : topLevelBlockId
+
   const runtime = useAppRuntime()
   const resolveShortcutActivations = runtime.read(shortcutSurfaceActivationsFacet)
 
@@ -78,6 +87,7 @@ export function useShortcutSurfaceActivations(
       uiStateBlock,
       types,
       topLevelBlockId,
+      scopeRootId,
       isTopLevel: block.id === topLevelBlockId && !blockContext.isNestedSurface,
       blockContext,
       inFocus,
@@ -85,13 +95,21 @@ export function useShortcutSurfaceActivations(
       isSelected,
       ...options,
       surface,
-    }),
+    // Inject the surface scope root into every activation's
+    // dependencies so handlers receive it uniformly, without each
+    // activation contribution (vim, codemirror, backlinks, plugins)
+    // having to forward it by hand.
+    }).map(activation => ({
+      ...activation,
+      dependencies: {...(activation.dependencies ?? {}), scopeRootId},
+    })),
     [
       block,
       repo,
       uiStateBlock,
       types,
       topLevelBlockId,
+      scopeRootId,
       blockContext,
       inFocus,
       inEditMode,

--- a/src/extensions/useShortcutSurfaceActivations.ts
+++ b/src/extensions/useShortcutSurfaceActivations.ts
@@ -74,6 +74,11 @@ export function useShortcutSurfaceActivations(
   // This, not topLevelBlockId, is the boundary structural and navigation
   // handlers operate against.
   const scopeRootId = blockContext.scopeRootId
+  // Focal panel/top-level surfaces force-open their scope root; nested
+  // surfaces (backlink/embed) honour its collapse flag. Navigation uses
+  // this so it won't descend into a collapsed nested root's hidden
+  // children.
+  const scopeRootForcesOpen = !blockContext.isNestedSurface
 
   const runtime = useAppRuntime()
   const resolveShortcutActivations = runtime.read(shortcutSurfaceActivationsFacet)
@@ -99,7 +104,7 @@ export function useShortcutSurfaceActivations(
     // having to forward it by hand.
     }).map(activation => ({
       ...activation,
-      dependencies: {...(activation.dependencies ?? {}), scopeRootId},
+      dependencies: {...(activation.dependencies ?? {}), scopeRootId, scopeRootForcesOpen},
     })),
     [
       block,
@@ -108,6 +113,7 @@ export function useShortcutSurfaceActivations(
       types,
       topLevelBlockId,
       scopeRootId,
+      scopeRootForcesOpen,
       blockContext,
       inFocus,
       inEditMode,

--- a/src/plugins/agent-runtime/commands.ts
+++ b/src/plugins/agent-runtime/commands.ts
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import type { Repo } from '@/data/repo'
 import type { Block } from '@/data/block'
 import { ChangeScope, type BlockData, type BlockReference } from '@/data/api'
-import { aliasesProp, extensionDescriptionProp, extensionNameProp } from '@/data/properties.js'
+import { aliasesProp, extensionDescriptionProp, extensionNameProp, topLevelBlockIdProp } from '@/data/properties.js'
 import { EXTENSION_TYPE, PAGE_TYPE } from '@/data/blockTypes'
 import { keyAtEnd } from '@/data/orderKey.js'
 import {
@@ -581,6 +581,14 @@ const runRuntimeAction = async (
   const selectedBlocks = selectedBlockIds.map(id => context.repo.block(id))
   const anchorBlock = runtimeBlock(context.repo, dependencies.anchorBlockId)
 
+  // Imperative runner (no React context), so scopeRootId isn't injected
+  // by useShortcutSurfaceActivations. Forward a caller-supplied one, else
+  // derive the panel scope from the ui-state block — the boundary the
+  // structural handlers (delete/outdent/move) expect.
+  const scopeRootId = isString(dependencies.scopeRootId)
+    ? dependencies.scopeRootId
+    : uiStateBlock.peekProperty(topLevelBlockIdProp)
+
   let returned: unknown
   try {
     returned = await action.handler({
@@ -588,6 +596,7 @@ const runRuntimeAction = async (
       block,
       selectedBlocks,
       anchorBlock,
+      scopeRootId,
     }, new CustomEvent('agent-runtime:run-action', {detail: {actionId}}))
   } catch (handlerError) {
     // Bubble up with action context so the CLI shows "which action

--- a/src/plugins/agent-runtime/commands.ts
+++ b/src/plugins/agent-runtime/commands.ts
@@ -562,9 +562,9 @@ const runRuntimeAction = async (
   }
 
   const dependencies = command.dependencies ?? {}
-  const uiStateBlock = runtimeBlock(context.repo, dependencies.uiStateBlockId)
+  const realUiStateBlock = runtimeBlock(context.repo, dependencies.uiStateBlockId)
     ?? runtimeBlock(context.repo, command.uiStateBlockId)
-    ?? fakeUiStateBlock(context.repo)
+  const uiStateBlock = realUiStateBlock ?? fakeUiStateBlock(context.repo)
   const block = runtimeBlock(context.repo, dependencies.blockId)
     ?? runtimeBlock(context.repo, command.blockId)
     ?? uiStateBlock
@@ -583,11 +583,11 @@ const runRuntimeAction = async (
 
   // Imperative runner (no React context), so scopeRootId isn't injected
   // by useShortcutSurfaceActivations. Forward a caller-supplied one, else
-  // derive the panel scope from the ui-state block — the boundary the
-  // structural handlers (delete/outdent/move) expect.
+  // derive the panel scope — but only from a REAL ui-state block;
+  // `fakeUiStateBlock` is a bare {repo} with no peekProperty.
   const scopeRootId = isString(dependencies.scopeRootId)
     ? dependencies.scopeRootId
-    : uiStateBlock.peekProperty(topLevelBlockIdProp)
+    : realUiStateBlock?.peekProperty(topLevelBlockIdProp)
 
   let returned: unknown
   try {

--- a/src/plugins/backlinks/BacklinkEntry.tsx
+++ b/src/plugins/backlinks/BacklinkEntry.tsx
@@ -98,8 +98,13 @@ const BacklinkItemContent = ({
   const bodyOverrides = useMemo(() => ({
     ...NESTED_OVERRIDES,
     renderScopeId,
+    // The shown block is the root of this entry's visible subtree, so
+    // structural edits (o / Enter / Tab) and bounded navigation treat
+    // it like a panel's top-level block instead of restructuring the
+    // real tree around it (which lives outside the entry).
+    scopeRootId: shownBlock.id,
     ...backlinkEntryShortcutContextOverrides(shortcutController),
-  }), [renderScopeId, shortcutController])
+  }), [renderScopeId, shownBlock.id, shortcutController])
 
   return (
     <>

--- a/src/plugins/breadcrumbs/BreadcrumbList.tsx
+++ b/src/plugins/breadcrumbs/BreadcrumbList.tsx
@@ -75,6 +75,7 @@ export const BreadcrumbList = ({
               <NestedBlockContextProvider
                 overrides={{
                   ...overrides,
+                  scopeRootId: parent.id,
                   renderScopeId: breadcrumbRenderScopeId(
                     parentRenderScopeId,
                     parent.id,

--- a/src/plugins/spatial-navigation/test/actions.test.ts
+++ b/src/plugins/spatial-navigation/test/actions.test.ts
@@ -131,7 +131,7 @@ describe('spatial navigation selection actions', () => {
       context: ActionContextTypes.NORMAL_MODE,
       handler: async deps => {
         fallback()
-        await extendSelectionDown(deps.uiStateBlock, env.repo)
+        await extendSelectionDown(deps.uiStateBlock, env.repo, deps.scopeRootId)
       },
     })
 
@@ -170,7 +170,7 @@ describe('spatial navigation selection actions', () => {
       context: ActionContextTypes.MULTI_SELECT_MODE,
       handler: async deps => {
         fallback()
-        await extendSelectionDown(deps.uiStateBlock, env.repo)
+        await extendSelectionDown(deps.uiStateBlock, env.repo, deps.scopeRootId)
       },
     })
 
@@ -206,7 +206,7 @@ describe('spatial navigation selection actions', () => {
       context: ActionContextTypes.MULTI_SELECT_MODE,
       handler: async deps => {
         fallback()
-        await extendSelectionDown(deps.uiStateBlock, env.repo)
+        await extendSelectionDown(deps.uiStateBlock, env.repo, deps.scopeRootId)
       },
     })
 

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -347,14 +347,19 @@ export const SwipeActionMenu = () => {
     if (!action) return false
 
     const block = repo.block(blockId)
-    const deps = {block, uiStateBlock, ...(renderScopeId ? {renderScopeId} : {})}
+    // Swipe runs actions imperatively (outside a block's React context),
+    // so scopeRootId isn't injected by useShortcutSurfaceActivations.
+    // The menu is panel-scoped and operates on the main outline, so the
+    // panel's top-level block is the scope root — the same value the
+    // structural handlers need (delete/indent/move).
+    const deps = {block, uiStateBlock, scopeRootId: topLevelBlockId, ...(renderScopeId ? {renderScopeId} : {})}
     if (action.canRun && !action.canRun(deps)) return false
 
     void Promise.resolve(action.handler(deps, trigger)).catch(error => {
       console.error(`[swipe-quick-actions] Action "${actionId}" failed`, error)
     })
     return true
-  }, [allActions, repo, uiStateBlock])
+  }, [allActions, repo, uiStateBlock, topLevelBlockId])
   const actionItems = runtime.read(quickActionItemsFacet)
   // Filter via the referenced action's `canRun` (the swipe surface is
   // presentational — semantic availability lives on the action). The
@@ -369,7 +374,7 @@ export const SwipeActionMenu = () => {
     if (!blockId) return actionItems
     const block = repo.block(blockId)
     if (!block.peek()) return actionItems
-    const deps = {block, uiStateBlock, ...(renderScopeId ? {renderScopeId} : {})}
+    const deps = {block, uiStateBlock, scopeRootId: topLevelBlockId, ...(renderScopeId ? {renderScopeId} : {})}
     return actionItems.filter(item => {
       const action = allActions.find(a => a.id === item.actionId)
       if (!action) return true
@@ -380,7 +385,7 @@ export const SwipeActionMenu = () => {
     actionItems, allActions,
     activeBlockId, activeRenderScopeId,
     previewBlockId, previewRenderScopeId,
-    repo, uiStateBlock,
+    repo, uiStateBlock, topLevelBlockId,
   ])
   const [primaryRows, overflowItems] = useMemo(() => {
     const rows = new Map<number, QuickActionItem[]>()

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -2,7 +2,6 @@ import { Repo } from '../../data/repo'
 import {
   focusBlock,
   isCollapsedProp,
-  topLevelBlockIdProp,
   selectionStateProp,
 } from '@/data/properties.js'
 import {
@@ -10,6 +9,7 @@ import {
   nextVisibleBlock,
   previousVisibleBlock,
 } from '@/utils/selection.js'
+import { structuralEditPolicyForBlock } from '@/data/structuralEditPolicy.js'
 import { actionsFacet } from '@/extensions/core.js'
 import { AppExtension } from '@/extensions/facet.js'
 import { pasteFromClipboard } from '@/utils/paste.js'
@@ -30,7 +30,7 @@ const JUMP_BLOCK_COUNT = 8
 
 const jumpVisibleBlocks = async (
   startBlock: BlockShortcutDependencies['block'],
-  topLevelBlockId: string,
+  scopeRootId: string,
   count: number,
   direction: 'up' | 'down',
 ) => {
@@ -38,7 +38,7 @@ const jumpVisibleBlocks = async (
   let current = startBlock
   let last = startBlock
   for (let i = 0; i < count; i++) {
-    const next = await step(current, topLevelBlockId)
+    const next = await step(current, scopeRootId)
     if (!next) break
     current = next
     last = next
@@ -92,13 +92,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
       id: 'move_down',
       description: 'Move to next block',
       handler: async (deps: BlockShortcutDependencies) => {
-        const {block, uiStateBlock} = deps
-        if (!block || !uiStateBlock) return
+        const {block, uiStateBlock, scopeRootId} = deps
+        if (!block || !uiStateBlock || !scopeRootId) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
-
-        const next = await nextVisibleBlock(block, topLevelBlockId)
+        const next = await nextVisibleBlock(block, scopeRootId)
         if (next) void focusBlock(uiStateBlock, next.id, {renderScopeId: deps.renderScopeId})
       },
       defaultBinding: {
@@ -109,13 +106,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
       id: 'move_up',
       description: 'Move to previous block',
       handler: async (deps: BlockShortcutDependencies) => {
-        const {block, uiStateBlock} = deps
-        if (!block || !uiStateBlock) return
+        const {block, uiStateBlock, scopeRootId} = deps
+        if (!block || !uiStateBlock || !scopeRootId) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
-
-        const prev = await previousVisibleBlock(block, topLevelBlockId)
+        const prev = await previousVisibleBlock(block, scopeRootId)
         if (prev) void focusBlock(uiStateBlock, prev.id, {renderScopeId: deps.renderScopeId})
       },
       defaultBinding: {
@@ -148,19 +142,14 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
       id: 'create_block_below_and_edit',
       description: 'Create block below (or as child) and enter edit mode',
       handler: async (deps: BlockShortcutDependencies) => {
-        const {block, uiStateBlock} = deps
-        if (!block || !uiStateBlock) return
+        const {block, uiStateBlock, scopeRootId} = deps
+        if (!block || !uiStateBlock || !scopeRootId) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
-        await block.load()
-        const childIds = await block.childIds.load()
-        const isCollapsed = block.peekProperty(isCollapsedProp) ?? false
-        const hasChildren = childIds.length > 0
-        const isTopLevel = block.id === topLevelBlockId
-
-        const hasUncollapsedChildren = hasChildren && !isCollapsed
-        const newId = hasUncollapsedChildren || isTopLevel
+        // child-first when the block shows children OR is the scope root
+        // (where a sibling would be created outside the visible surface —
+        // the "invisible block" bug). Otherwise a sibling below.
+        const {createBelowPlacement} = await structuralEditPolicyForBlock(block, scopeRootId)
+        const newId = createBelowPlacement === 'child-first'
           ? await repo.mutate.createChild({parentId: block.id, position: {kind: 'first'}})
           : await repo.mutate.createSiblingBelow({siblingId: block.id})
         if (newId) await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId: deps.renderScopeId})
@@ -192,12 +181,11 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_to_first_visible_block',
       description: 'Jump to first visible block',
-      handler: async ({uiStateBlock}: BlockShortcutDependencies) => {
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+      handler: async ({uiStateBlock, scopeRootId, renderScopeId}: BlockShortcutDependencies) => {
+        if (!scopeRootId) return
 
-        void focusBlock(uiStateBlock, topLevelBlockId, {
-          renderScopeId: outlineRenderScopeId(topLevelBlockId),
+        void focusBlock(uiStateBlock, scopeRootId, {
+          renderScopeId: renderScopeId ?? outlineRenderScopeId(scopeRootId),
         })
       },
       defaultBinding: {
@@ -211,15 +199,14 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_to_last_visible_block',
       description: 'Jump to last visible block',
-      handler: async ({uiStateBlock}: BlockShortcutDependencies) => {
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+      handler: async ({uiStateBlock, scopeRootId, renderScopeId}: BlockShortcutDependencies) => {
+        if (!scopeRootId) return
 
-        const lastBlock = await getLastVisibleDescendant(repo.block(topLevelBlockId), topLevelBlockId)
+        const lastBlock = await getLastVisibleDescendant(repo.block(scopeRootId), scopeRootId)
         if (!lastBlock) return
 
         void focusBlock(uiStateBlock, lastBlock.id, {
-          renderScopeId: outlineRenderScopeId(topLevelBlockId),
+          renderScopeId: renderScopeId ?? outlineRenderScopeId(scopeRootId),
         })
       },
       defaultBinding: {
@@ -229,11 +216,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_many_down',
       description: 'Jump down several blocks',
-      handler: async ({block, uiStateBlock, renderScopeId}: BlockShortcutDependencies) => {
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
+        if (!scopeRootId) return
 
-        const target = await jumpVisibleBlocks(block, topLevelBlockId, JUMP_BLOCK_COUNT, 'down')
+        const target = await jumpVisibleBlocks(block, scopeRootId, JUMP_BLOCK_COUNT, 'down')
         if (target) void focusBlock(uiStateBlock, target.id, {renderScopeId})
       },
       defaultBinding: {
@@ -243,11 +229,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_many_up',
       description: 'Jump up several blocks',
-      handler: async ({block, uiStateBlock, renderScopeId}: BlockShortcutDependencies) => {
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
+        if (!scopeRootId) return
 
-        const target = await jumpVisibleBlocks(block, topLevelBlockId, JUMP_BLOCK_COUNT, 'up')
+        const target = await jumpVisibleBlocks(block, scopeRootId, JUMP_BLOCK_COUNT, 'up')
         if (target) void focusBlock(uiStateBlock, target.id, {renderScopeId})
       },
       defaultBinding: {
@@ -269,10 +254,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'paste_after',
       description: 'Paste from clipboard after current block',
-      handler: async ({block, uiStateBlock, renderScopeId}: BlockShortcutDependencies) => {
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
         const pasted = await pasteFromClipboard(block, repo, {
           position: 'after',
-          topLevelBlockId: uiStateBlock.peekProperty(topLevelBlockIdProp),
+          scopeRootId,
         })
         if (pasted[0]) void focusBlock(uiStateBlock, pasted[0].id, {renderScopeId})
       },
@@ -283,10 +268,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'paste_before',
       description: 'Paste from clipboard before current block',
-      handler: async ({block, uiStateBlock, renderScopeId}: BlockShortcutDependencies) => {
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
         const pasted = await pasteFromClipboard(block, repo, {
           position: 'before',
-          topLevelBlockId: uiStateBlock.peekProperty(topLevelBlockIdProp),
+          scopeRootId,
         })
         if (pasted[0]) void focusBlock(uiStateBlock, pasted[0].id, {renderScopeId})
       },
@@ -313,13 +298,12 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'collapse_into_parent',
       description: 'Collapse current block into its parent and focus parent',
-      handler: async ({block, uiStateBlock, renderScopeId}: BlockShortcutDependencies) => {
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId || block.id === topLevelBlockId) return
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
+        if (!scopeRootId || block.id === scopeRootId) return
 
         await repo.load(block.id, {ancestors: true})
         const parent = block.parent
-        if (!parent || parent.id === topLevelBlockId) return
+        if (!parent || parent.id === scopeRootId) return
 
         await parent.set(isCollapsedProp, true)
         void focusBlock(uiStateBlock, parent.id, {renderScopeId})

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -35,11 +35,12 @@ const jumpVisibleBlocks = async (
   direction: 'up' | 'down',
   scopeRootForcesOpen = true,
 ) => {
-  const step = direction === 'up' ? previousVisibleBlock : nextVisibleBlock
   let current = startBlock
   let last = startBlock
   for (let i = 0; i < count; i++) {
-    const next = await step(current, scopeRootId, scopeRootForcesOpen)
+    const next = direction === 'up'
+      ? await previousVisibleBlock(current, scopeRootId)
+      : await nextVisibleBlock(current, scopeRootId, scopeRootForcesOpen)
     if (!next) break
     current = next
     last = next

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -150,7 +150,7 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
         // the "invisible block" bug). Otherwise a sibling below.
         const {createBelowPlacement} = await structuralEditPolicyForBlock(block, scopeRootId)
         const newId = createBelowPlacement === 'child-first'
-          ? await repo.mutate.createChild({parentId: block.id, position: {kind: 'first'}})
+          ? await repo.mutate.createChild({parentId: block.id, position: {kind: 'first'}, revealParent: true})
           : await repo.mutate.createSiblingBelow({siblingId: block.id})
         if (newId) await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId: deps.renderScopeId})
       },

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -33,12 +33,13 @@ const jumpVisibleBlocks = async (
   scopeRootId: string,
   count: number,
   direction: 'up' | 'down',
+  scopeRootForcesOpen = true,
 ) => {
   const step = direction === 'up' ? previousVisibleBlock : nextVisibleBlock
   let current = startBlock
   let last = startBlock
   for (let i = 0; i < count; i++) {
-    const next = await step(current, scopeRootId)
+    const next = await step(current, scopeRootId, scopeRootForcesOpen)
     if (!next) break
     current = next
     last = next
@@ -95,7 +96,7 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
         const {block, uiStateBlock, scopeRootId} = deps
         if (!block || !uiStateBlock || !scopeRootId) return
 
-        const next = await nextVisibleBlock(block, scopeRootId)
+        const next = await nextVisibleBlock(block, scopeRootId, deps.scopeRootForcesOpen)
         if (next) void focusBlock(uiStateBlock, next.id, {renderScopeId: deps.renderScopeId})
       },
       defaultBinding: {
@@ -199,10 +200,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_to_last_visible_block',
       description: 'Jump to last visible block',
-      handler: async ({uiStateBlock, scopeRootId, renderScopeId}: BlockShortcutDependencies) => {
+      handler: async ({uiStateBlock, scopeRootId, renderScopeId, scopeRootForcesOpen}: BlockShortcutDependencies) => {
         if (!scopeRootId) return
 
-        const lastBlock = await getLastVisibleDescendant(repo.block(scopeRootId), scopeRootId)
+        const lastBlock = await getLastVisibleDescendant(repo.block(scopeRootId), scopeRootId, scopeRootForcesOpen)
         if (!lastBlock) return
 
         void focusBlock(uiStateBlock, lastBlock.id, {
@@ -216,10 +217,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_many_down',
       description: 'Jump down several blocks',
-      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId, scopeRootForcesOpen}: BlockShortcutDependencies) => {
         if (!scopeRootId) return
 
-        const target = await jumpVisibleBlocks(block, scopeRootId, JUMP_BLOCK_COUNT, 'down')
+        const target = await jumpVisibleBlocks(block, scopeRootId, JUMP_BLOCK_COUNT, 'down', scopeRootForcesOpen)
         if (target) void focusBlock(uiStateBlock, target.id, {renderScopeId})
       },
       defaultBinding: {
@@ -229,10 +230,10 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     bindNormal({
       id: 'jump_many_up',
       description: 'Jump up several blocks',
-      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId}: BlockShortcutDependencies) => {
+      handler: async ({block, uiStateBlock, renderScopeId, scopeRootId, scopeRootForcesOpen}: BlockShortcutDependencies) => {
         if (!scopeRootId) return
 
-        const target = await jumpVisibleBlocks(block, scopeRootId, JUMP_BLOCK_COUNT, 'up')
+        const target = await jumpVisibleBlocks(block, scopeRootId, JUMP_BLOCK_COUNT, 'up', scopeRootForcesOpen)
         if (target) void focusBlock(uiStateBlock, target.id, {renderScopeId})
       },
       defaultBinding: {

--- a/src/shortcuts/blockActions.ts
+++ b/src/shortcuts/blockActions.ts
@@ -229,8 +229,10 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
       const {block, uiStateBlock, scopeRootId} = deps
       if (!block || !uiStateBlock) return
 
-      if (!scopeRootId) return
-
+      // `scopeRootId` only locates the post-delete focus target; the
+      // delete itself doesn't need it. Don't gate the delete on it, so
+      // non-React runners that can't inject a scope (the agent-runtime
+      // bridge) still delete — they just skip focus recovery.
       // Same-depth next sibling is the natural shift-up target. When
       // `block` has descendants those vanish too, so we can't use
       // `nextVisibleBlock` (which would descend into the doomed
@@ -239,7 +241,7 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
       // sibling → parent. This mirrors what the proactive
       // `PanelFocusRecovery` does on the DOM side, so manual deletes
       // and surprise disappearances both land on the same target.
-      const next = await blockAfterSubtreeRemoval(block, scopeRootId)
+      const next = scopeRootId ? await blockAfterSubtreeRemoval(block, scopeRootId) : null
       await withMoveTransition(async () => {
         await block.delete()
       })

--- a/src/shortcuts/blockActions.ts
+++ b/src/shortcuts/blockActions.ts
@@ -77,32 +77,17 @@ const writeToClipboard = (text: string): void => {
   void navigator.clipboard.writeText(text)
 }
 
-/** Move `block` up (-1) or down (+1) among its siblings. Computes a
- *  new orderKey that lands between the appropriate neighbor pair so
- *  the block's position changes deterministically. No-op if the
- *  block is already at the relevant edge or if it has no parent. */
-const reorderBlock = async (repo: Repo, block: Block, direction: -1 | 1): Promise<void> => {
-  const data = block.peek() ?? await block.load()
-  if (!data || data.parentId === null) return
-
-  const siblingIds = await repo.query.childIds({id: data.parentId}).load()
-  const idx = siblingIds.indexOf(block.id)
-  if (idx === -1) return
-
-  const target = idx + direction
-  if (target < 0 || target >= siblingIds.length) return
-
-  // Target sibling we want to land before/after. For direction=-1
-  // (move up), we want to land BEFORE siblingIds[target]. For
-  // direction=+1, we want to land AFTER siblingIds[target].
-  const targetSiblingId = siblingIds[target]
-  await repo.mutate.move({
-    id: block.id,
-    parentId: data.parentId,
-    position: direction === -1
-      ? {kind: 'before', siblingId: targetSiblingId}
-      : {kind: 'after', siblingId: targetSiblingId},
-  })
+/** Move `block` one step up (-1) or down (+1) in the visible outline,
+ *  crossing parent boundaries Roam/org-style and bounded by the
+ *  surface's scope root. Delegates the tree logic to the
+ *  `core.moveVertical` mutator (one transaction, undoable as a unit). */
+const reorderBlock = async (
+  repo: Repo,
+  block: Block,
+  direction: -1 | 1,
+  scopeRootId: string | undefined,
+): Promise<void> => {
+  await repo.mutate.moveVertical({id: block.id, direction, scopeRootId})
 }
 
 export const requestEditorFocusIfEditing = (uiStateBlock: Block) => {
@@ -206,9 +191,9 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'move_block_up',
     description: 'Move block up',
     handler: async (deps: BlockShortcutDependencies) => {
-      const {block, uiStateBlock} = deps
+      const {block, uiStateBlock, scopeRootId} = deps
       if (!block) return
-      await reorderBlock(repo, block, -1)
+      await reorderBlock(repo, block, -1, scopeRootId)
       requestEditorFocusIfEditing(uiStateBlock)
     },
     defaultBinding: {
@@ -223,9 +208,9 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'move_block_down',
     description: 'Move block down',
     handler: async (deps: BlockShortcutDependencies) => {
-      const {block, uiStateBlock} = deps
+      const {block, uiStateBlock, scopeRootId} = deps
       if (!block) return
-      await reorderBlock(repo, block, 1)
+      await reorderBlock(repo, block, 1, scopeRootId)
       requestEditorFocusIfEditing(uiStateBlock)
     },
     defaultBinding: {

--- a/src/shortcuts/blockActions.ts
+++ b/src/shortcuts/blockActions.ts
@@ -13,9 +13,9 @@ import {
   requestEditorFocus,
   setIsEditing,
   showPropertiesProp,
-  topLevelBlockIdProp,
   type EditorSelectionState,
 } from '@/data/properties.js'
+import { structuralEditPolicyForBlock } from '@/data/structuralEditPolicy.js'
 import {
   ActionConfig,
   ActionContextType,
@@ -124,30 +124,28 @@ export const enterEditMode = (uiStateBlock: Block, selection?: EditorSelectionSt
   requestEditorFocus(uiStateBlock)
 }
 
-export const extendSelectionDown = async (uiStateBlock: Block, repo: Repo) => {
-  const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-  if (!topLevelBlockId) return
+export const extendSelectionDown = async (uiStateBlock: Block, repo: Repo, scopeRootId: string | undefined) => {
+  if (!scopeRootId) return
 
   const focusedId = peekFocusedBlockLocation(uiStateBlock)?.blockId
   if (!focusedId) return
 
-  const nextBlock = await nextVisibleBlock(repo.block(focusedId), topLevelBlockId)
+  const nextBlock = await nextVisibleBlock(repo.block(focusedId), scopeRootId)
   if (!nextBlock) return
 
-  await extendSelection(nextBlock.id, uiStateBlock, repo)
+  await extendSelection(nextBlock.id, uiStateBlock, repo, scopeRootId)
 }
 
-export const extendSelectionUp = async (uiStateBlock: Block, repo: Repo) => {
-  const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-  if (!topLevelBlockId) return
+export const extendSelectionUp = async (uiStateBlock: Block, repo: Repo, scopeRootId: string | undefined) => {
+  if (!scopeRootId) return
 
   const focusedId = peekFocusedBlockLocation(uiStateBlock)?.blockId
   if (!focusedId) return
 
-  const prevBlock = await previousVisibleBlock(repo.block(focusedId), topLevelBlockId)
+  const prevBlock = await previousVisibleBlock(repo.block(focusedId), scopeRootId)
   if (!prevBlock) return
 
-  await extendSelection(prevBlock.id, uiStateBlock, repo)
+  await extendSelection(prevBlock.id, uiStateBlock, repo, scopeRootId)
 }
 
 export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockActions => {
@@ -166,6 +164,11 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'indent_block',
     description: 'Indent block',
     handler: async (deps: BlockShortcutDependencies) => {
+      // No-op on a scope root: indenting it would reparent the visible
+      // root under a sibling that lives outside the surface. The
+      // mutator separately no-ops when there's no previous sibling.
+      const {canIndent} = await structuralEditPolicyForBlock(deps.block, deps.scopeRootId)
+      if (!canIndent) return
       await repo.mutate.indent({id: deps.block.id})
       requestEditorFocusIfEditing(deps.uiStateBlock)
     },
@@ -180,11 +183,16 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
   const outdentBlock: BlockAction = {
     id: 'outdent_block',
     description: 'Outdent block',
-    handler: async ({block, uiStateBlock}: BlockShortcutDependencies) => {
-      const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-      if (!topLevelBlockId) return
+    handler: async ({block, uiStateBlock, scopeRootId}: BlockShortcutDependencies) => {
+      if (!scopeRootId) return
 
-      await repo.mutate.outdent({id: block.id, topLevelBlockId})
+      // Don't outdent the scope root itself; the mutator additionally
+      // refuses when the block is a direct child of the scope root
+      // (outdenting would escape the visible subtree).
+      const {canOutdent} = await structuralEditPolicyForBlock(block, scopeRootId)
+      if (!canOutdent) return
+
+      await repo.mutate.outdent({id: block.id, scopeRootId})
       requestEditorFocusIfEditing(uiStateBlock)
     },
     defaultBinding: {
@@ -233,11 +241,10 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     description: 'Delete block',
     icon: Trash2,
     handler: async (deps: BlockShortcutDependencies) => {
-      const {block, uiStateBlock} = deps
+      const {block, uiStateBlock, scopeRootId} = deps
       if (!block || !uiStateBlock) return
 
-      const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-      if (!topLevelBlockId) return
+      if (!scopeRootId) return
 
       // Same-depth next sibling is the natural shift-up target. When
       // `block` has descendants those vanish too, so we can't use
@@ -247,7 +254,7 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
       // sibling → parent. This mirrors what the proactive
       // `PanelFocusRecovery` does on the DOM side, so manual deletes
       // and surprise disappearances both land on the same target.
-      const next = await blockAfterSubtreeRemoval(block, topLevelBlockId)
+      const next = await blockAfterSubtreeRemoval(block, scopeRootId)
       await withMoveTransition(async () => {
         await block.delete()
       })
@@ -342,7 +349,7 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'extend_selection_up',
     description: 'Extend selection up',
     handler: async (deps: BlockShortcutDependencies) =>
-      await extendSelectionUp(deps.uiStateBlock, repo),
+      await extendSelectionUp(deps.uiStateBlock, repo, deps.scopeRootId),
     defaultBinding: {
       keys: 'Shift+ArrowUp',
       eventOptions: {
@@ -355,7 +362,7 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'extend_selection_down',
     description: 'Extend selection down',
     handler: async (deps: BlockShortcutDependencies) =>
-      await extendSelectionDown(deps.uiStateBlock, repo),
+      await extendSelectionDown(deps.uiStateBlock, repo, deps.scopeRootId),
     defaultBinding: {
       keys: 'Shift+ArrowDown',
       eventOptions: {

--- a/src/shortcuts/blockActions.ts
+++ b/src/shortcuts/blockActions.ts
@@ -109,19 +109,29 @@ export const enterEditMode = (uiStateBlock: Block, selection?: EditorSelectionSt
   requestEditorFocus(uiStateBlock)
 }
 
-export const extendSelectionDown = async (uiStateBlock: Block, repo: Repo, scopeRootId: string | undefined) => {
+export const extendSelectionDown = async (
+  uiStateBlock: Block,
+  repo: Repo,
+  scopeRootId: string | undefined,
+  scopeRootForcesOpen = true,
+) => {
   if (!scopeRootId) return
 
   const focusedId = peekFocusedBlockLocation(uiStateBlock)?.blockId
   if (!focusedId) return
 
-  const nextBlock = await nextVisibleBlock(repo.block(focusedId), scopeRootId)
+  const nextBlock = await nextVisibleBlock(repo.block(focusedId), scopeRootId, scopeRootForcesOpen)
   if (!nextBlock) return
 
-  await extendSelection(nextBlock.id, uiStateBlock, repo, scopeRootId)
+  await extendSelection(nextBlock.id, uiStateBlock, repo, scopeRootId, scopeRootForcesOpen)
 }
 
-export const extendSelectionUp = async (uiStateBlock: Block, repo: Repo, scopeRootId: string | undefined) => {
+export const extendSelectionUp = async (
+  uiStateBlock: Block,
+  repo: Repo,
+  scopeRootId: string | undefined,
+  scopeRootForcesOpen = true,
+) => {
   if (!scopeRootId) return
 
   const focusedId = peekFocusedBlockLocation(uiStateBlock)?.blockId
@@ -130,7 +140,7 @@ export const extendSelectionUp = async (uiStateBlock: Block, repo: Repo, scopeRo
   const prevBlock = await previousVisibleBlock(repo.block(focusedId), scopeRootId)
   if (!prevBlock) return
 
-  await extendSelection(prevBlock.id, uiStateBlock, repo, scopeRootId)
+  await extendSelection(prevBlock.id, uiStateBlock, repo, scopeRootId, scopeRootForcesOpen)
 }
 
 export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockActions => {
@@ -336,7 +346,7 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'extend_selection_up',
     description: 'Extend selection up',
     handler: async (deps: BlockShortcutDependencies) =>
-      await extendSelectionUp(deps.uiStateBlock, repo, deps.scopeRootId),
+      await extendSelectionUp(deps.uiStateBlock, repo, deps.scopeRootId, deps.scopeRootForcesOpen),
     defaultBinding: {
       keys: 'Shift+ArrowUp',
       eventOptions: {
@@ -349,7 +359,7 @@ export const createSharedBlockActions = ({repo}: { repo: Repo }): SharedBlockAct
     id: 'extend_selection_down',
     description: 'Extend selection down',
     handler: async (deps: BlockShortcutDependencies) =>
-      await extendSelectionDown(deps.uiStateBlock, repo, deps.scopeRootId),
+      await extendSelectionDown(deps.uiStateBlock, repo, deps.scopeRootId, deps.scopeRootForcesOpen),
     defaultBinding: {
       keys: 'Shift+ArrowDown',
       eventOptions: {

--- a/src/shortcuts/defaultShortcuts.test.ts
+++ b/src/shortcuts/defaultShortcuts.test.ts
@@ -11,6 +11,7 @@ import {
   editorSelection,
   focusBlock,
   focusedBlockLocationProp,
+  isCollapsedProp,
   isEditingProp,
   peekFocusedBlockLocation,
   topLevelBlockIdProp,
@@ -550,6 +551,37 @@ describe('default CodeMirror shortcuts', () => {
     // New block lands as a child of the scope root, not a sibling under root.
     expect(await childIds('root')).toEqual(['shown'])
     expect(await childIds('shown')).toHaveLength(1)
+  })
+
+  it('reveals a COLLAPSED scope-root block when Enter creates its first child', async () => {
+    // A nested scope root (backlink/embed) isn't isTopLevel, so a
+    // collapsed root would hide the new child inside a closed
+    // Collapsible. Enter must reveal the root so the inserted+focused
+    // block is visible.
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: WS, parentId: null, orderKey: 'a0'})
+      await tx.create({id: 'ui', workspaceId: WS, parentId: null, orderKey: 'z0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'shown', content: 'shown'})
+    await env.repo.mutate.createChild({parentId: 'shown', id: 'existing', content: 'existing'})
+    await env.repo.mutate.setProperty({id: 'shown', schema: isCollapsedProp, value: true})
+
+    const uiStateBlock = env.repo.block('ui')
+    await focusBlock(uiStateBlock, 'shown')
+
+    const action = findEditModeAction(env.repo, 'split_block_cm')
+    await action.handler({
+      block: env.repo.block('shown'),
+      editorView: codeMirrorEditorView('shown', 'shown'.length),
+      uiStateBlock,
+      scopeRootId: 'shown',
+    } satisfies CodeMirrorEditModeDependencies, {preventDefault: vi.fn()} as unknown as ActionTrigger)
+
+    // Root revealed, and the new block is its first child (above 'existing').
+    expect(env.repo.block('shown').peek()?.properties[isCollapsedProp.name]).toBe(false)
+    const children = await childIds('shown')
+    expect(children).toHaveLength(2)
+    expect(children[1]).toBe('existing')
   })
 
   it('makes Tab a no-op on a scope-root block', async () => {

--- a/src/shortcuts/defaultShortcuts.test.ts
+++ b/src/shortcuts/defaultShortcuts.test.ts
@@ -344,6 +344,7 @@ describe('default CodeMirror shortcuts', () => {
       block: env.repo.block('current'),
       editorView: codeMirrorEditorView('current', 'current'.length),
       uiStateBlock,
+      scopeRootId: 'root',
     } satisfies CodeMirrorEditModeDependencies, trigger)
 
     expect(trigger.preventDefault).toHaveBeenCalledTimes(1)
@@ -373,6 +374,7 @@ describe('default CodeMirror shortcuts', () => {
       block: env.repo.block('current'),
       editorView: codeMirrorEditorView('current', 0),
       uiStateBlock,
+      scopeRootId: 'root',
     } satisfies CodeMirrorEditModeDependencies, trigger)
 
     expect(trigger.preventDefault).toHaveBeenCalledTimes(1)
@@ -402,6 +404,7 @@ describe('default CodeMirror shortcuts', () => {
       block: env.repo.block('empty'),
       editorView: emptyEditorView(),
       uiStateBlock,
+      scopeRootId: 'root',
     } satisfies CodeMirrorEditModeDependencies, trigger)
 
     expect(trigger.preventDefault).toHaveBeenCalledTimes(1)
@@ -433,6 +436,7 @@ describe('default CodeMirror shortcuts', () => {
       block: env.repo.block('current'),
       editorView: codeMirrorEditorView('current', 0),
       uiStateBlock,
+      scopeRootId: 'root',
     } satisfies CodeMirrorEditModeDependencies, trigger)
 
     expect(trigger.preventDefault).toHaveBeenCalledTimes(1)
@@ -468,6 +472,7 @@ describe('default CodeMirror shortcuts', () => {
       block: env.repo.block('current'),
       editorView: codeMirrorEditorView('current', 0),
       uiStateBlock,
+      scopeRootId: 'root',
     } satisfies CodeMirrorEditModeDependencies, trigger)
 
     expect(trigger.preventDefault).not.toHaveBeenCalled()
@@ -496,6 +501,7 @@ describe('default CodeMirror shortcuts', () => {
       block: env.repo.block('current'),
       editorView,
       uiStateBlock,
+      scopeRootId: 'root',
     } satisfies CodeMirrorEditModeDependencies, {preventDefault: vi.fn()} as unknown as ActionTrigger)
 
     const rootChildren = await childIds('root')
@@ -513,5 +519,60 @@ describe('default CodeMirror shortcuts', () => {
       blockId: 'current',
       start: 0,
     })
+  })
+
+  // Scope-root behaviour: when the focused block is the root of the
+  // surface's visible subtree (e.g. a backlink entry's shown block,
+  // where scopeRootId === the block's own id) a "new block below" must
+  // land as a first child so it stays visible — a sibling would be
+  // created outside the surface. These mirror what happens for a
+  // panel's top-level block but now key off scopeRootId, so any nested
+  // surface gets the same behaviour.
+  it('creates a first child (not a sibling) when Enter is pressed at the end of a scope-root block', async () => {
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: WS, parentId: null, orderKey: 'a0'})
+      await tx.create({id: 'ui', workspaceId: WS, parentId: null, orderKey: 'z0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'shown', content: 'shown'})
+
+    const uiStateBlock = env.repo.block('ui')
+    await focusBlock(uiStateBlock, 'shown')
+
+    const action = findEditModeAction(env.repo, 'split_block_cm')
+    await action.handler({
+      block: env.repo.block('shown'),
+      editorView: codeMirrorEditorView('shown', 'shown'.length),
+      uiStateBlock,
+      // The shown block is its own scope root (no children yet).
+      scopeRootId: 'shown',
+    } satisfies CodeMirrorEditModeDependencies, {preventDefault: vi.fn()} as unknown as ActionTrigger)
+
+    // New block lands as a child of the scope root, not a sibling under root.
+    expect(await childIds('root')).toEqual(['shown'])
+    expect(await childIds('shown')).toHaveLength(1)
+  })
+
+  it('makes Tab a no-op on a scope-root block', async () => {
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: WS, parentId: null, orderKey: 'a0'})
+      await tx.create({id: 'ui', workspaceId: WS, parentId: null, orderKey: 'z0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'first', content: 'first'})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'shown', content: 'shown'})
+
+    const uiStateBlock = env.repo.block('ui')
+    const action = findEditModeAction(env.repo, 'edit.cm.indent_block')
+    await action.handler({
+      block: env.repo.block('shown'),
+      editorView: codeMirrorEditorView('shown', 0),
+      uiStateBlock,
+      // 'shown' is the scope root even though it has a previous sibling
+      // ('first') in the real tree — indenting would escape the surface.
+      scopeRootId: 'shown',
+    } satisfies CodeMirrorEditModeDependencies, {preventDefault: vi.fn()} as unknown as ActionTrigger)
+
+    // Unchanged: still a direct child of root, not reparented under 'first'.
+    expect(await childIds('root')).toEqual(['first', 'shown'])
+    expect(await childIds('first')).toEqual([])
   })
 })

--- a/src/shortcuts/defaultShortcuts.test.ts
+++ b/src/shortcuts/defaultShortcuts.test.ts
@@ -40,6 +40,7 @@ import {
   type BlockShortcutDependencies,
   type CodeMirrorEditModeDependencies,
 } from '@/shortcuts/types'
+import { createSharedBlockActions } from '@/shortcuts/blockActions'
 
 const WS = 'ws-1'
 const USER: User = {id: 'user-1'}
@@ -606,5 +607,24 @@ describe('default CodeMirror shortcuts', () => {
     // Unchanged: still a direct child of root, not reparented under 'first'.
     expect(await childIds('root')).toEqual(['first', 'shown'])
     expect(await childIds('first')).toEqual([])
+  })
+
+  it('deletes a block even without a scopeRootId (non-React action runners)', async () => {
+    // scopeRootId only locates the post-delete focus target; imperative
+    // runners (agent-runtime bridge) may not supply one, but the delete
+    // itself must still happen.
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: WS, parentId: null, orderKey: 'a0'})
+      await tx.create({id: 'ui', workspaceId: WS, parentId: null, orderKey: 'z0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'victim', content: 'x'})
+
+    const {deleteBlock} = createSharedBlockActions({repo: env.repo})
+    await deleteBlock.handler(
+      {block: env.repo.block('victim'), uiStateBlock: env.repo.block('ui')},
+      {preventDefault: vi.fn()} as unknown as ActionTrigger,
+    )
+
+    expect(env.repo.block('victim').peek()?.deleted).toBe(true)
   })
 })

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -502,7 +502,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
     handler: async (deps: CodeMirrorEditModeDependencies) => {
       if (cursorIsAtStart(deps.editorView)) {
         setIsEditing(deps.uiStateBlock, false)
-        await extendSelectionUp(deps.uiStateBlock, repo, deps.scopeRootId)
+        await extendSelectionUp(deps.uiStateBlock, repo, deps.scopeRootId, deps.scopeRootForcesOpen)
       }
     },
   }
@@ -511,7 +511,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
     handler: async (deps: CodeMirrorEditModeDependencies) => {
       if (cursorIsAtEnd(deps.editorView)) {
         setIsEditing(deps.uiStateBlock, false)
-        await extendSelectionDown(deps.uiStateBlock, repo, deps.scopeRootId)
+        await extendSelectionDown(deps.uiStateBlock, repo, deps.scopeRootId, deps.scopeRootForcesOpen)
       }
     },
   }
@@ -663,7 +663,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           return
         }
 
-        const nextVisible = await nextVisibleBlock(block, scopeRootId)
+        const nextVisible = await nextVisibleBlock(block, scopeRootId, deps.scopeRootForcesOpen)
         if (!nextVisible) return
 
         await uiStateBlock.set(editorSelection, {
@@ -722,7 +722,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
 
         trigger.preventDefault()
 
-        const nextVisible = await nextVisibleBlock(block, scopeRootId)
+        const nextVisible = await nextVisibleBlock(block, scopeRootId, deps.scopeRootForcesOpen)
         if (!nextVisible) return
 
         await uiStateBlock.set(editorSelection, {

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -23,11 +23,11 @@ import { withMoveTransition } from '@/utils/viewTransition.js'
 import {
   activePanelIdProp,
   focusBlock,
-  isCollapsedProp,
   topLevelBlockIdProp,
   editorSelection,
   setIsEditing,
 } from '@/data/properties.js'
+import { structuralEditPolicyForBlock } from '@/data/structuralEditPolicy.js'
 import { insertExampleExtensionsUnder } from '@/extensions/exampleExtensions.js'
 import { selectionStateProp } from '@/data/properties'
 import { applyToAllBlocksInSelection, makeMultiSelect } from './utils'
@@ -502,7 +502,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
     handler: async (deps: CodeMirrorEditModeDependencies) => {
       if (cursorIsAtStart(deps.editorView)) {
         setIsEditing(deps.uiStateBlock, false)
-        await extendSelectionUp(deps.uiStateBlock, repo)
+        await extendSelectionUp(deps.uiStateBlock, repo, deps.scopeRootId)
       }
     },
   }
@@ -511,7 +511,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
     handler: async (deps: CodeMirrorEditModeDependencies) => {
       if (cursorIsAtEnd(deps.editorView)) {
         setIsEditing(deps.uiStateBlock, false)
-        await extendSelectionDown(deps.uiStateBlock, repo)
+        await extendSelectionDown(deps.uiStateBlock, repo, deps.scopeRootId)
       }
     },
   }
@@ -531,15 +531,11 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       description: 'Split block at cursor',
       context: ActionContextTypes.EDIT_MODE_CM,
       handler: async (deps: CodeMirrorEditModeDependencies) => {
-        const {block, editorView, uiStateBlock} = deps
+        const {block, editorView, uiStateBlock, scopeRootId} = deps
         if (!block || !editorView || !uiStateBlock) return
+        if (!scopeRootId) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
-        await block.load()
-        const childIds = await block.childIds.load()
-        const isCollapsed = block.peekProperty(isCollapsedProp) ?? false
-        const isTopLevel = block.id === topLevelBlockId
+        const policy = await structuralEditPolicyForBlock(block, scopeRootId)
 
         const selection = editorView.state.selection.main
         const doc = editorView.state.doc
@@ -550,8 +546,6 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           if (newId) await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId: deps.renderScopeId})
         }
 
-        const blockHasChildren = childIds.length > 0
-
         // Case 1: Cursor is in middle of text
         if (cursorPos < doc.length) {
           const blockInFocus = await splitCodeMirrorBlockAtCursor(block, editorView)
@@ -561,9 +555,10 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           })
           await focusBlock(uiStateBlock, blockInFocus.id, {edit: true, renderScopeId: deps.renderScopeId})
         }
-        // Case 2: Cursor is at end of text and block has children
-        else if (cursorPos === doc.length &&
-          (blockHasChildren && !isCollapsed || isTopLevel)) {
+        // Case 2: Cursor at end and the new block belongs as a first
+        // child — either the block shows children, or it's the scope
+        // root (where a sibling would land outside the surface).
+        else if (cursorPos === doc.length && policy.createBelowPlacement === 'child-first') {
           const newId = await repo.mutate.createChild({
             parentId: block.id,
             position: {kind: 'first'},
@@ -571,14 +566,15 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           if (newId) await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId: deps.renderScopeId})
         }
         // Repeated empty blocks creation - outdents the new block.
-        // outdent returns false if the block is at the view boundary
-        // (parent === topLevelBlockId) or already at workspace root —
-        // fall back to creating a sibling below.
+        // outdent returns false if the block is at the surface boundary
+        // (parent === scopeRootId) or already at workspace root — fall
+        // back to creating a sibling below. The scope root itself can't
+        // outdent (canOutdent false), so it falls back too.
         // Unwrapped (see indent/outdent in blockActions): the
         // root-level crossfade ghosts the shifting siblings, which
         // reads as blur. The unwrapped shift is cleaner.
         else if (editorView.state.doc.length === 0) {
-          const moved = await repo.mutate.outdent({id: block.id, topLevelBlockId})
+          const moved = policy.canOutdent && await repo.mutate.outdent({id: block.id, scopeRootId})
           if (!moved) await createSiblingBelow()
         }
         // Cursor at end, no children or they are collapsed
@@ -598,11 +594,10 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       description: 'Move to previous block when cursor is at start of CodeMirror',
       context: ActionContextTypes.EDIT_MODE_CM,
       handler: async (deps: CodeMirrorEditModeDependencies, trigger: ActionTrigger) => {
-        const {block, editorView, uiStateBlock} = deps
+        const {block, editorView, uiStateBlock, scopeRootId} = deps
         if (!block || !editorView || !uiStateBlock) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId || !isOnFirstVisualLine(editorView)) return
+        if (!scopeRootId || !isOnFirstVisualLine(editorView)) return
 
         // Capture caret x and call preventDefault BEFORE the async hop. The
         // hotkeys-js handler runs during the bubble phase but the browser's
@@ -619,7 +614,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
         const caretX = getCaretRect(editorView)?.left
         trigger.preventDefault()
 
-        const prevVisible = await previousVisibleBlock(block, topLevelBlockId)
+        const prevVisible = await previousVisibleBlock(block, scopeRootId)
         if (!prevVisible) return
         const data = block.peek() ?? await block.load()
         if (data?.parentId === prevVisible.id && focusPropertyRow(prevVisible.id, 'last')) {
@@ -647,11 +642,10 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       description: 'Move to next block when cursor is at end of CodeMirror',
       context: ActionContextTypes.EDIT_MODE_CM,
       handler: async (deps: CodeMirrorEditModeDependencies, trigger: ActionTrigger) => {
-        const {block, editorView, uiStateBlock} = deps
+        const {block, editorView, uiStateBlock, scopeRootId} = deps
         if (!block || !editorView || !uiStateBlock) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId || !isOnLastVisualLine(editorView)) return
+        if (!scopeRootId || !isOnLastVisualLine(editorView)) return
 
         // Capture caret x and call preventDefault BEFORE the async hop —
         // see move_up_from_cm_start for the full rationale. Without this,
@@ -668,7 +662,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           return
         }
 
-        const nextVisible = await nextVisibleBlock(block, topLevelBlockId)
+        const nextVisible = await nextVisibleBlock(block, scopeRootId)
         if (!nextVisible) return
 
         await uiStateBlock.set(editorSelection, {
@@ -687,18 +681,17 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       description: 'Move to previous block when cursor is at start of CodeMirror',
       context: ActionContextTypes.EDIT_MODE_CM,
       handler: async (deps: CodeMirrorEditModeDependencies, trigger: ActionTrigger) => {
-        const {block, editorView, uiStateBlock} = deps
+        const {block, editorView, uiStateBlock, scopeRootId} = deps
         if (!block || !editorView || !uiStateBlock) return
 
         const selection = editorView.state.selection.main
         if (!(selection.empty && selection.head === 0)) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+        if (!scopeRootId) return
 
         trigger.preventDefault()
 
-        const prevVisible = await previousVisibleBlock(block, topLevelBlockId)
+        const prevVisible = await previousVisibleBlock(block, scopeRootId)
         if (!prevVisible) return
 
         const prevData = await prevVisible.load()
@@ -718,18 +711,17 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       description: 'Move to next block when cursor is at end of CodeMirror',
       context: ActionContextTypes.EDIT_MODE_CM,
       handler: async (deps: CodeMirrorEditModeDependencies, trigger: ActionTrigger) => {
-        const {block, editorView, uiStateBlock} = deps
+        const {block, editorView, uiStateBlock, scopeRootId} = deps
         if (!block || !editorView || !uiStateBlock) return
 
         const selection = editorView.state.selection.main
         if (!(selection.empty && selection.head === editorView.state.doc.length)) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+        if (!scopeRootId) return
 
         trigger.preventDefault()
 
-        const nextVisible = await nextVisibleBlock(block, topLevelBlockId)
+        const nextVisible = await nextVisibleBlock(block, scopeRootId)
         if (!nextVisible) return
 
         await uiStateBlock.set(editorSelection, {
@@ -748,7 +740,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
       description: 'Backspace at block start: delete empty / merge into previous (CodeMirror)',
       context: ActionContextTypes.EDIT_MODE_CM,
       handler: async (deps: CodeMirrorEditModeDependencies, trigger: ActionTrigger) => {
-        const {block, editorView, uiStateBlock} = deps
+        const {block, editorView, uiStateBlock, scopeRootId} = deps
         if (!block || !uiStateBlock || !editorView) return
 
         // Only act when the cursor is at position 0 with no selection;
@@ -756,8 +748,11 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
         const sel = editorView.state.selection.main
         if (!(sel.empty && sel.from === 0)) return
 
-        const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
-        if (!topLevelBlockId) return
+        if (!scopeRootId) return
+
+        // Don't merge the scope root into a block outside the surface —
+        // there's no visible previous block to merge into here.
+        const {canMergeUp} = await structuralEditPolicyForBlock(block, scopeRootId)
 
         // Live content from the editor — SQL may lag (pushChange is debounced).
         const liveContent = editorView.state.doc.toString()
@@ -765,7 +760,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
         // Empty block: delete it and move focus up.
         if (liveContent === '') {
           trigger.preventDefault()
-          const prevVisible = await previousVisibleBlock(block, topLevelBlockId)
+          const prevVisible = await previousVisibleBlock(block, scopeRootId)
           if (prevVisible) {
             const prevData = await prevVisible.load()
             await uiStateBlock.set(editorSelection, {
@@ -781,8 +776,12 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
         // Non-empty block: merge into the previous visible block (Roam-style).
         // Refuse if there is none, or if the previous visible block is the
         // panel's top-level block (don't merge into the page/view header).
-        const prevVisible = await previousVisibleBlock(block, topLevelBlockId)
-        if (!prevVisible || prevVisible.id === topLevelBlockId) return
+        // Refuse to merge the scope root upward — its previous visible
+        // block lives outside the surface.
+        if (!canMergeUp) return
+
+        const prevVisible = await previousVisibleBlock(block, scopeRootId)
+        if (!prevVisible || prevVisible.id === scopeRootId) return
 
         // Roam rule: refuse when both blocks have independent children — the
         // children would have to be reconciled in a way the user didn't ask
@@ -922,7 +921,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           pasted = await pasteFromClipboard(target, repo, {
             position: 'after',
             placement: 'sibling',
-            topLevelBlockId: uiStateBlock.peekProperty(topLevelBlockIdProp),
+            scopeRootId: deps.scopeRootId,
           })
         })
         if (pasted[0]) {
@@ -948,7 +947,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           pasted = await pasteFromClipboard(target, repo, {
             position: 'before',
             placement: 'sibling',
-            topLevelBlockId: uiStateBlock.peekProperty(topLevelBlockIdProp),
+            scopeRootId: deps.scopeRootId,
           })
         })
         if (pasted[0]) {

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -562,6 +562,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           const newId = await repo.mutate.createChild({
             parentId: block.id,
             position: {kind: 'first'},
+            revealParent: true,
           })
           if (newId) await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId: deps.renderScopeId})
         }

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -65,6 +65,14 @@ export const ActionContextTypes = {
 
 export interface BaseShortcutDependencies {
   uiStateBlock: Block;
+  /** Root of the visible subtree the action runs within (see
+   *  `BlockContextType.scopeRootId`). Structural and navigation
+   *  handlers use this as the surface boundary instead of reading the
+   *  panel's `topLevelBlockId`, so they behave correctly inside nested
+   *  surfaces (backlinks, embeds). Injected centrally for block
+   *  surfaces by `useShortcutSurfaceActivations`; defaults to the
+   *  panel's zoom root for the main outline. */
+  scopeRootId?: string;
 }
 
 export interface BlockShortcutDependencies  extends BaseShortcutDependencies {

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -73,6 +73,12 @@ export interface BaseShortcutDependencies {
    *  surfaces by `useShortcutSurfaceActivations`; defaults to the
    *  panel's zoom root for the main outline. */
   scopeRootId?: string;
+  /** Whether the surface force-opens its scope root regardless of the
+   *  root's own collapse flag (true for focal panel/top-level roots,
+   *  false for nested surface roots that honour collapse). Navigation
+   *  primitives use it so they don't descend into a collapsed nested
+   *  root whose children aren't rendered. Defaults to true (focal). */
+  scopeRootForcesOpen?: boolean;
 }
 
 export interface BlockShortcutDependencies  extends BaseShortcutDependencies {

--- a/src/shortcuts/utils.ts
+++ b/src/shortcuts/utils.ts
@@ -114,7 +114,7 @@ export const applyToAllBlocksInSelection = <T extends ActionContextType>(
   // dropping all but the last block's animation). The per-action
   // wraps inside the inner handlers are reentrancy-suppressed.
   const multiSelectHandler = async (multiSelectDeps: MultiSelectModeDependencies, trigger: ActionTrigger) => {
-    const {selectedBlocks, uiStateBlock} = multiSelectDeps
+    const {selectedBlocks, uiStateBlock, scopeRootId} = multiSelectDeps
     const blocks = applyInReverseOrder ? selectedBlocks.toReversed() : selectedBlocks
     console.log(`[makeMultiSelect] Running action for ${blocks.length} blocks`)
 
@@ -129,6 +129,7 @@ export const applyToAllBlocksInSelection = <T extends ActionContextType>(
         const originalDeps = {
           block,
           uiStateBlock,
+          scopeRootId,
         } as ShortcutDependenciesMap[T]
 
         await actionConfig.handler(originalDeps, trigger)

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,17 @@ export interface BlockContextType {
      *  one rendered occurrence of that block, even when the same block is
      *  visible in the main outline and one or more embeds/backlink rows. */
     renderScopeId?: string
+    /** Id of the block rendered as the root of this surface's visible
+     *  subtree: the panel's zoom root for the main outline, the shown
+     *  block for a backlink entry, the embedded block for an embed, a
+     *  single segment for a breadcrumb. Structural edits (create-below,
+     *  indent/outdent, merge-up) and bounded navigation read this — NOT
+     *  the panel's `topLevelBlockId` — so a block rendered as a root in
+     *  a nested surface behaves like one. Every surface that mounts a
+     *  block as a bounded view declares it; absent only at the very top
+     *  layout boundary, before a panel sets it. See
+     *  `resolveStructuralEditPolicy`. */
+    scopeRootId?: string
     /** Single visible panel mode: widen the panel's scroll target to the
      *  whole layout surface while constraining its document content inside
      *  the panel renderer. */

--- a/src/utils/paste.ts
+++ b/src/utils/paste.ts
@@ -2,6 +2,7 @@ import { ChangeScope, type BlockData, type Tx } from '@/data/api'
 import { Block } from '../data/block'
 import type { Repo } from '../data/repo'
 import { isCollapsedProp } from '@/data/properties.js'
+import { revealChildren } from '@/data/internals/kernelMutators.js'
 import { parseMarkdownToBlocks, type ParsedBlock } from '@/utils/markdownParser.js'
 import { keysBetween } from '../data/orderKey.ts'
 
@@ -113,6 +114,12 @@ const resolveRootDestination = async (
     (placement === 'visible' && position === 'after' && targetHasVisibleChildren)
   const rootParentId = rootsAsChildren ? target.id : target.parentId
   if (!rootParentId) throw new Error(`paste target ${target.id} has no visible insertion parent`)
+
+  // Placing the pasted roots as children of `target` — reveal it if
+  // collapsed so the focused paste isn't hidden inside a closed subtree
+  // (same invariant as indent / moveVertical / create-child). No-op when
+  // target is already expanded.
+  if (rootsAsChildren) await revealChildren(tx, target.id)
 
   const rootInsertion = rootsAsChildren
     ? insertionForFirstChild(targetChildren[0]?.orderKey)

--- a/src/utils/paste.ts
+++ b/src/utils/paste.ts
@@ -10,9 +10,10 @@ type PastePlacement = 'visible' | 'sibling'
 
 interface PasteOptions {
   position?: PastePosition
-  /** The currently rendered outline root. Paste uses this to avoid
-   *  creating siblings outside a zoomed panel's visible subtree. */
-  topLevelBlockId?: string
+  /** Root of the surface's visible subtree (see
+   *  `BlockContextType.scopeRootId`). Paste uses this to avoid creating
+   *  siblings outside the visible scope. */
+  scopeRootId?: string
   /** `visible` follows outline navigation semantics; `sibling` keeps
    *  range paste before/after the selected range unless that would
    *  leave the visible subtree. */
@@ -100,14 +101,14 @@ const resolveRootDestination = async (
   target: BlockData,
   {
     position,
-    topLevelBlockId,
+    scopeRootId,
     placement,
-  }: Required<Pick<PasteOptions, 'position' | 'placement'>> & Pick<PasteOptions, 'topLevelBlockId'>,
+  }: Required<Pick<PasteOptions, 'position' | 'placement'>> & Pick<PasteOptions, 'scopeRootId'>,
 ): Promise<RootDestination> => {
   const targetChildren = await tx.childrenOf(target.id, target.workspaceId)
-  const targetIsTopLevel = topLevelBlockId === target.id
+  const targetIsScopeRoot = scopeRootId === target.id
   const targetHasVisibleChildren = targetChildren.length > 0 && !isCollapsed(target.properties)
-  const rootsAsChildren = targetIsTopLevel ||
+  const rootsAsChildren = targetIsScopeRoot ||
     target.parentId === null ||
     (placement === 'visible' && position === 'after' && targetHasVisibleChildren)
   const rootParentId = rootsAsChildren ? target.id : target.parentId
@@ -172,7 +173,7 @@ export async function pasteMultilineText(
   repo: Repo,
   {
     position = 'after',
-    topLevelBlockId,
+    scopeRootId,
     placement = 'visible',
   }: PasteOptions = {},
 ): Promise<Block[]> {
@@ -191,7 +192,7 @@ export async function pasteMultilineText(
 
     const {rootParentId, rootInsertion, targetChildren} = await resolveRootDestination(tx, target, {
       position,
-      topLevelBlockId,
+      scopeRootId,
       placement,
     })
 
@@ -251,7 +252,7 @@ export async function pasteEditModeMultilineText(
   plan: EditModeMultilinePastePlan,
   pasteTarget: Block,
   repo: Repo,
-  options: Pick<PasteOptions, 'topLevelBlockId'> = {},
+  options: Pick<PasteOptions, 'scopeRootId'> = {},
 ): Promise<EditModeMultilinePasteResult | null> {
   const rootBlocks: Block[] = []
   let focusBlock = pasteTarget
@@ -263,7 +264,7 @@ export async function pasteEditModeMultilineText(
 
     const {rootParentId, rootInsertion, targetChildren} = await resolveRootDestination(tx, target, {
       position: 'after',
-      topLevelBlockId: options.topLevelBlockId,
+      scopeRootId: options.scopeRootId,
       placement: 'sibling',
     })
 

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -12,12 +12,15 @@ import {
 import { outlineRenderScopeId } from '@/utils/renderScope'
 import { ChangeScope } from '@/data/api'
 
-/** True if `block` is collapsed *and* the caller cares (i.e. it isn't
- *  the surface's scope root — the root always exposes children even
- *  if its own collapsed flag is set). Reads the property synchronously
- *  from cache; assumes the row has been loaded. */
-const isExpanded = (block: Block, scopeRootId: string): boolean => {
-  if (block.id === scopeRootId) return true
+/** True if `block` is collapsed *and* the caller cares. The scope root
+ *  is treated as always-expanded ONLY when its surface force-opens it
+ *  (`scopeRootForcesOpen`) — true for a focal panel/top-level root
+ *  (rendered `open` regardless of its own collapse flag), false for a
+ *  nested surface root (backlink/embed), which honours its collapse flag
+ *  in both render and navigation. Reads the property synchronously from
+ *  cache; assumes the row has been loaded. */
+const isExpanded = (block: Block, scopeRootId: string, scopeRootForcesOpen: boolean): boolean => {
+  if (block.id === scopeRootId && scopeRootForcesOpen) return true
   return !(block.peekProperty(isCollapsedProp) ?? false)
 }
 
@@ -36,12 +39,13 @@ const isExpanded = (block: Block, scopeRootId: string): boolean => {
 export const nextVisibleBlock = async (
   current: Block,
   scopeRootId: string,
+  scopeRootForcesOpen = true,
 ): Promise<Block | null> => {
   const repo = current.repo
   await current.load()
 
   // Step into the first child if expanded.
-  if (isExpanded(current, scopeRootId)) {
+  if (isExpanded(current, scopeRootId, scopeRootForcesOpen)) {
     const childIds = await current.childIds.load()
     if (childIds.length > 0) return repo.block(childIds[0])
   }
@@ -72,6 +76,10 @@ export const nextVisibleBlock = async (
 export const previousVisibleBlock = async (
   current: Block,
   scopeRootId: string,
+  // Accepted for signature parity with `nextVisibleBlock` (so callers can
+  // treat them interchangeably). Unused: climbing toward the scope root
+  // never re-enters it, so its force-open state is irrelevant here.
+  _scopeRootForcesOpen = true,
 ): Promise<Block | null> => {
   if (current.id === scopeRootId) return null
   const repo = current.repo
@@ -141,23 +149,26 @@ export const blockAfterSubtreeRemoval = async (
  *  the bottom of an expanded subtree. Returns the input block if it
  *  is collapsed or has no children.
  *
- *  When `scopeRootId` is supplied and equals the block's id, its own
- *  `isCollapsedProp` is ignored — matches `isExpanded`'s "scope root
- *  always exposes children" rule. Necessary so vim `Shift+G` (jump to
- *  last visible block) still descends from a scope root whose own flag
- *  happens to carry a stale collapsed flag from when it was viewed as a
- *  child. Mid-walk collapsed blocks still terminate the descent so
- *  `previousVisibleBlock`'s contract (don't dive into a collapsed
- *  sibling) is preserved. */
+ *  When `scopeRootId` is supplied, equals the block's id, AND the
+ *  surface force-opens it (`scopeRootForcesOpen`), its own
+ *  `isCollapsedProp` is ignored — matches `isExpanded`'s rule. Necessary
+ *  so vim `Shift+G` (jump to last visible block) still descends from a
+ *  focal panel root whose own flag carries a stale collapsed flag from
+ *  when it was viewed as a child. A nested scope root that honours its
+ *  collapse flag (`scopeRootForcesOpen === false`) terminates the
+ *  descent instead. Mid-walk collapsed blocks still terminate the
+ *  descent so `previousVisibleBlock`'s contract (don't dive into a
+ *  collapsed sibling) is preserved. */
 export const getLastVisibleDescendant = async (
   block: Block,
   scopeRootId?: string,
+  scopeRootForcesOpen = true,
 ): Promise<Block> => {
   const repo = block.repo
   await block.load()
   let current = block
   while (true) {
-    const isScopeRoot = current.id === scopeRootId
+    const isScopeRoot = current.id === scopeRootId && scopeRootForcesOpen
     const collapsed = current.peekProperty(isCollapsedProp) ?? false
     if (collapsed && !isScopeRoot) return current
     const childIds = await current.childIds.load()
@@ -353,6 +364,7 @@ export async function getBlocksInRange(
   endBlockId: string,
   scopeRootId: string,
   repo: Repo,
+  scopeRootForcesOpen = true,
 ): Promise<string[]> {
   if (startBlockId === endBlockId) {
     return validateSelectionHierarchy([startBlockId], repo)
@@ -365,7 +377,7 @@ export async function getBlocksInRange(
     const ids: string[] = [startBlockId]
     let walker: Block | null = start
     while (walker) {
-      walker = await nextVisibleBlock(walker, scopeRootId)
+      walker = await nextVisibleBlock(walker, scopeRootId, scopeRootForcesOpen)
       if (!walker) return null
       ids.push(walker.id)
       if (walker.id === endBlockId) return ids
@@ -412,6 +424,7 @@ export async function extendSelection(
   uiStateBlock: Block,
   repo: Repo,
   scopeRootId: string | undefined,
+  scopeRootForcesOpen = true,
 ): Promise<void> {
   const currentState = uiStateBlock.peekProperty(selectionStateProp)
   const focusedId = peekFocusedBlockLocation(uiStateBlock)?.blockId
@@ -421,7 +434,7 @@ export async function extendSelection(
   const currentAnchor = currentState?.anchorBlockId || focusedId
   if (!currentAnchor) return
 
-  const rangeIds = await getBlocksInRange(currentAnchor, targetBlockId, scopeRootId, repo)
+  const rangeIds = await getBlocksInRange(currentAnchor, targetBlockId, scopeRootId, repo, scopeRootForcesOpen)
 
   const currentLocation = peekFocusedBlockLocation(uiStateBlock)
   await commitSelectionRange({

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -8,47 +8,47 @@ import {
   peekFocusedBlockLocation,
   sameFocusedBlockLocation,
   selectionStateProp,
-  topLevelBlockIdProp,
 } from '@/data/properties'
 import { outlineRenderScopeId } from '@/utils/renderScope'
 import { ChangeScope } from '@/data/api'
 
 /** True if `block` is collapsed *and* the caller cares (i.e. it isn't
- *  the panel's top-level block — the top always exposes children even
+ *  the surface's scope root — the root always exposes children even
  *  if its own collapsed flag is set). Reads the property synchronously
  *  from cache; assumes the row has been loaded. */
-const isExpanded = (block: Block, topLevelBlockId: string): boolean => {
-  if (block.id === topLevelBlockId) return true
+const isExpanded = (block: Block, scopeRootId: string): boolean => {
+  if (block.id === scopeRootId) return true
   return !(block.peekProperty(isCollapsedProp) ?? false)
 }
 
 /** Returns the next visible block in document order under
- *  `topLevelBlockId`, walking *relatively* — descend into the first
- *  child if `current` is expanded and has children, otherwise climb
- *  ancestors looking for a next sibling. Stops at the panel boundary
- *  (`topLevelBlockId`); returns null when `current` is the last
- *  visible block.
+ *  `scopeRootId` (the surface's visible-subtree root — the panel's zoom
+ *  root on the main outline, the shown block in a backlink entry, …),
+ *  walking *relatively* — descend into the first child if `current` is
+ *  expanded and has children, otherwise climb ancestors looking for a
+ *  next sibling. Stops at the scope boundary (`scopeRootId`); returns
+ *  null when `current` is the last visible block.
  *
  *  Touches O(depth) blocks (one SQL per parent's child list, all small
- *  + handle-cached) instead of materializing the panel's full
- *  visible-id list. Works correctly inside panels with arbitrary
- *  topLevelBlockId because no global "active panel" state is consulted. */
+ *  + handle-cached) instead of materializing the surface's full
+ *  visible-id list. Works correctly inside any surface with an arbitrary
+ *  scope root because no global "active panel" state is consulted. */
 export const nextVisibleBlock = async (
   current: Block,
-  topLevelBlockId: string,
+  scopeRootId: string,
 ): Promise<Block | null> => {
   const repo = current.repo
   await current.load()
 
   // Step into the first child if expanded.
-  if (isExpanded(current, topLevelBlockId)) {
+  if (isExpanded(current, scopeRootId)) {
     const childIds = await current.childIds.load()
     if (childIds.length > 0) return repo.block(childIds[0])
   }
 
-  // Climb ancestors looking for a next sibling. Stop at top-level.
+  // Climb ancestors looking for a next sibling. Stop at the scope root.
   let walker: Block = current
-  while (walker.id !== topLevelBlockId) {
+  while (walker.id !== scopeRootId) {
     const data = walker.peek()
     if (!data || data.parentId === null) return null
     const parentId = data.parentId
@@ -65,15 +65,15 @@ export const nextVisibleBlock = async (
 }
 
 /** Returns the previous visible block in document order under
- *  `topLevelBlockId`. Mirror of `nextVisibleBlock`: if `current` has a
+ *  `scopeRootId`. Mirror of `nextVisibleBlock`: if `current` has a
  *  previous sibling, descend into that sibling's last visible
- *  descendant; otherwise return the parent. Stops at `topLevelBlockId`
- *  (returns null when `current` is the panel's top-level block). */
+ *  descendant; otherwise return the parent. Stops at `scopeRootId`
+ *  (returns null when `current` is the surface's scope root). */
 export const previousVisibleBlock = async (
   current: Block,
-  topLevelBlockId: string,
+  scopeRootId: string,
 ): Promise<Block | null> => {
-  if (current.id === topLevelBlockId) return null
+  if (current.id === scopeRootId) return null
   const repo = current.repo
   await current.load()
 
@@ -90,11 +90,9 @@ export const previousVisibleBlock = async (
     // Descend into the previous sibling's last visible descendant.
     return getLastVisibleDescendant(repo.block(siblingIds[idx - 1]))
   }
-  // No previous sibling — the parent is the previous visible block,
-  // unless the parent is *above* topLevelBlockId (which we never
-  // returned next-into anyway). When current is a direct child of
-  // topLevelBlockId, parent === topLevelBlockId, which is itself the
-  // first visible block in the panel.
+  // No previous sibling — the parent is the previous visible block.
+  // When current is a direct child of scopeRootId, parent === scopeRootId,
+  // which is itself the first visible block in the surface.
   return parent
 }
 
@@ -110,8 +108,8 @@ export const previousVisibleBlock = async (
  *       removal the parent is now empty, and it's the natural place
  *       to land.
  *
- *  Returns null when `current` is the panel's `topLevelBlockId` (no
- *  meaningful target, the panel is about to be empty), or when the
+ *  Returns null when `current` is the surface's `scopeRootId` (no
+ *  meaningful target, the surface is about to be empty), or when the
  *  block is detached from the tree.
  *
  *  Mirrors `walker.findRecoveryAnchor`'s sibling-then-ancestor order
@@ -119,9 +117,9 @@ export const previousVisibleBlock = async (
  *  recovery's choice for the disappear-from-DOM case. */
 export const blockAfterSubtreeRemoval = async (
   current: Block,
-  topLevelBlockId: string,
+  scopeRootId: string,
 ): Promise<Block | null> => {
-  if (current.id === topLevelBlockId) return null
+  if (current.id === scopeRootId) return null
   const repo = current.repo
   await current.load()
   const data = current.peek()
@@ -143,25 +141,25 @@ export const blockAfterSubtreeRemoval = async (
  *  the bottom of an expanded subtree. Returns the input block if it
  *  is collapsed or has no children.
  *
- *  When `topLevelBlockId` is supplied and equals the block's id, its own
- *  `isCollapsedProp` is ignored — matches `isExpanded`'s "panel root
+ *  When `scopeRootId` is supplied and equals the block's id, its own
+ *  `isCollapsedProp` is ignored — matches `isExpanded`'s "scope root
  *  always exposes children" rule. Necessary so vim `Shift+G` (jump to
- *  last visible block) still descends from a panel whose root happens to
- *  carry a stale collapsed flag from when it was viewed as a child. Mid-
- *  walk collapsed blocks still terminate the descent so
+ *  last visible block) still descends from a scope root whose own flag
+ *  happens to carry a stale collapsed flag from when it was viewed as a
+ *  child. Mid-walk collapsed blocks still terminate the descent so
  *  `previousVisibleBlock`'s contract (don't dive into a collapsed
  *  sibling) is preserved. */
 export const getLastVisibleDescendant = async (
   block: Block,
-  topLevelBlockId?: string,
+  scopeRootId?: string,
 ): Promise<Block> => {
   const repo = block.repo
   await block.load()
   let current = block
   while (true) {
-    const isPanelRoot = current.id === topLevelBlockId
+    const isScopeRoot = current.id === scopeRootId
     const collapsed = current.peekProperty(isCollapsedProp) ?? false
-    if (collapsed && !isPanelRoot) return current
+    if (collapsed && !isScopeRoot) return current
     const childIds = await current.childIds.load()
     if (childIds.length === 0) return current
     current = repo.block(childIds[childIds.length - 1])
@@ -353,7 +351,7 @@ export async function commitSelectionRange(
 export async function getBlocksInRange(
   startBlockId: string,
   endBlockId: string,
-  topLevelBlockId: string,
+  scopeRootId: string,
   repo: Repo,
 ): Promise<string[]> {
   if (startBlockId === endBlockId) {
@@ -367,7 +365,7 @@ export async function getBlocksInRange(
     const ids: string[] = [startBlockId]
     let walker: Block | null = start
     while (walker) {
-      walker = await nextVisibleBlock(walker, topLevelBlockId)
+      walker = await nextVisibleBlock(walker, scopeRootId)
       if (!walker) return null
       ids.push(walker.id)
       if (walker.id === endBlockId) return ids
@@ -379,7 +377,7 @@ export async function getBlocksInRange(
     const ids: string[] = [startBlockId]
     let walker: Block | null = start
     while (walker) {
-      walker = await previousVisibleBlock(walker, topLevelBlockId)
+      walker = await previousVisibleBlock(walker, scopeRootId)
       if (!walker) return null
       ids.unshift(walker.id)
       if (walker.id === endBlockId) return ids
@@ -391,12 +389,12 @@ export async function getBlocksInRange(
   const range = forward ?? await collectBackward()
   if (range) return validateSelectionHierarchy(range, repo)
 
-  // Either endpoint isn't reachable from the other under the current
-  // panel; preserve the legacy fallback of returning whichever
+  // Either endpoint isn't reachable from the other within the current
+  // scope; preserve the legacy fallback of returning whichever
   // endpoints we know exist.
   console.warn(
     '[getBlocksInRange] endpoints not connected via visible navigation.',
-    {startBlockId, endBlockId, topLevelBlockId},
+    {startBlockId, endBlockId, scopeRootId},
   )
   const fallback: string[] = []
   if (start.peek()) fallback.push(startBlockId)
@@ -407,23 +405,23 @@ export async function getBlocksInRange(
 /** Extends selection to include blocks in range between current
  *  anchor and target block. Reads selection state + focus from the
  *  UI-state block (sync), computes the range against the visible
- *  document order under the active panel's top-level block, then
- *  writes the new selection state. */
+ *  document order within the surface's scope root, then writes the
+ *  new selection state. */
 export async function extendSelection(
   targetBlockId: string,
   uiStateBlock: Block,
   repo: Repo,
+  scopeRootId: string | undefined,
 ): Promise<void> {
   const currentState = uiStateBlock.peekProperty(selectionStateProp)
   const focusedId = peekFocusedBlockLocation(uiStateBlock)?.blockId
-  const topLevelBlockId = uiStateBlock.peekProperty(topLevelBlockIdProp)
 
-  if (!topLevelBlockId) return
+  if (!scopeRootId) return
 
   const currentAnchor = currentState?.anchorBlockId || focusedId
   if (!currentAnchor) return
 
-  const rangeIds = await getBlocksInRange(currentAnchor, targetBlockId, topLevelBlockId, repo)
+  const rangeIds = await getBlocksInRange(currentAnchor, targetBlockId, scopeRootId, repo)
 
   const currentLocation = peekFocusedBlockLocation(uiStateBlock)
   await commitSelectionRange({
@@ -431,7 +429,7 @@ export async function extendSelection(
     anchorBlockId: currentAnchor,
     targetLocation: {
       blockId: targetBlockId,
-      renderScopeId: currentLocation?.renderScopeId ?? outlineRenderScopeId(topLevelBlockId),
+      renderScopeId: currentLocation?.renderScopeId ?? outlineRenderScopeId(scopeRootId),
     },
     selectedBlockIds: rangeIds,
   })

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -76,10 +76,6 @@ export const nextVisibleBlock = async (
 export const previousVisibleBlock = async (
   current: Block,
   scopeRootId: string,
-  // Accepted for signature parity with `nextVisibleBlock` (so callers can
-  // treat them interchangeably). Unused: climbing toward the scope root
-  // never re-enters it, so its force-open state is irrelevant here.
-  _scopeRootForcesOpen = true,
 ): Promise<Block | null> => {
   if (current.id === scopeRootId) return null
   const repo = current.repo

--- a/src/utils/test/paste.test.ts
+++ b/src/utils/test/paste.test.ts
@@ -93,6 +93,21 @@ describe('pasteMultilineText', () => {
     expect(await childContents('root')).toEqual(['Parent', 'Sibling'])
   })
 
+  it('reveals a collapsed scope-root target when pasting as its children', async () => {
+    // Pasting onto a nested scope root (scopeRootId === target.id) inserts
+    // the roots as its children; if it's collapsed they'd be hidden, so the
+    // paste must reveal it (same invariant as create-child / move).
+    await createBlock('root', 'Root', null, 'a0')
+    await createBlock('sr', 'Scope root', 'root', 'a0')
+    await createBlock('existing', 'Existing', 'sr', 'a0')
+    await env.repo.mutate.setProperty({id: 'sr', schema: isCollapsedProp, value: true})
+
+    await pasteMultilineText('Alpha\nBeta', env.repo.block('sr'), env.repo, {scopeRootId: 'sr'})
+
+    expect(env.repo.block('sr').peek()?.properties[isCollapsedProp.name]).toBe(false)
+    expect(await childContents('sr')).toEqual(['Alpha', 'Beta', 'Existing'])
+  })
+
   it('pastes after a collapsed target as a visible sibling', async () => {
     await createBlock('root', 'Root', null, 'a0')
     await createBlock('parent', 'Parent', 'root', 'a0')

--- a/src/utils/test/paste.test.ts
+++ b/src/utils/test/paste.test.ts
@@ -67,7 +67,7 @@ describe('pasteMultilineText', () => {
       '- Alpha\n  - Detail\n- Beta',
       env.repo.block('empty'),
       env.repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
 
     expect(pasted[0]?.id).toBe('empty')
@@ -86,7 +86,7 @@ describe('pasteMultilineText', () => {
       'Pasted\nSecond',
       env.repo.block('parent'),
       env.repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
 
     expect(await childContents('parent')).toEqual(['Pasted', 'Second', 'Old child'])
@@ -104,7 +104,7 @@ describe('pasteMultilineText', () => {
       'Pasted',
       env.repo.block('parent'),
       env.repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
 
     expect(await childContents('root')).toEqual(['Parent', 'Pasted', 'Sibling'])
@@ -120,7 +120,7 @@ describe('pasteMultilineText', () => {
       'Pasted',
       env.repo.block('page'),
       env.repo,
-      {topLevelBlockId: 'page'},
+      {scopeRootId: 'page'},
     )
 
     expect(await childContents('workspace-root')).toEqual(['Page'])
@@ -135,7 +135,7 @@ describe('pasteMultilineText', () => {
       'Pasted',
       env.repo.block('root'),
       env.repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
 
     expect(await childContents('root')).toEqual(['Pasted', 'Existing'])
@@ -151,7 +151,7 @@ describe('pasteMultilineText', () => {
       'Pasted',
       env.repo.block('parent'),
       env.repo,
-      {placement: 'sibling', topLevelBlockId: 'root'},
+      {placement: 'sibling', scopeRootId: 'root'},
     )
 
     expect(await childContents('root')).toEqual(['Parent', 'Pasted', 'Sibling'])
@@ -175,7 +175,7 @@ describe('pasteEditModeMultilineText', () => {
       plan!,
       env.repo.block('target'),
       env.repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
 
     expect(env.repo.block('target').peek()?.content).toBe('hello alpha')
@@ -198,7 +198,7 @@ describe('pasteEditModeMultilineText', () => {
       plan!,
       env.repo.block('target'),
       env.repo,
-      {topLevelBlockId: 'root'},
+      {scopeRootId: 'root'},
     )
 
     expect(env.repo.block('target').peek()?.content).toBe('prefix Parent')
@@ -221,7 +221,7 @@ describe('pasteEditModeMultilineText', () => {
       plan!,
       env.repo.block('page'),
       env.repo,
-      {topLevelBlockId: 'page'},
+      {scopeRootId: 'page'},
     )
 
     expect(await childContents('workspace-root')).toEqual(['Page title'])

--- a/src/utils/test/selection.test.ts
+++ b/src/utils/test/selection.test.ts
@@ -195,6 +195,20 @@ describe('getLastVisibleDescendant', () => {
     expect(result.id).toBe('b')
   })
 
+  it('honors a collapsed scope root when the surface does NOT force it open', async () => {
+    // A nested scope root (backlink/embed) renders its collapse flag, so
+    // navigation must not descend into its hidden children — returns the
+    // root itself rather than a child that isn't rendered.
+    await seedOutline(env.repo, [
+      {id: 'top', parentId: null, orderKey: 'a'},
+      {id: 'a', parentId: 'top', orderKey: 'b'},
+      {id: 'b', parentId: 'top', orderKey: 'c'},
+    ])
+    await env.repo.mutate.setProperty({id: 'top', schema: isCollapsedProp, value: true})
+    const result = await getLastVisibleDescendant(env.repo.block('top'), 'top', false)
+    expect(result.id).toBe('top')
+  })
+
   it('still honors the collapsed flag on entry when the id does not match topLevelBlockId', async () => {
     // Confirms the exemption is narrowly scoped to the panel root — a
     // collapsed sibling encountered mid-walk still terminates the descent.


### PR DESCRIPTION
Block-structural gestures (vim `o`, Enter-at-end, Tab/Shift+Tab,
Backspace-merge) each re-derived "am I at the visible boundary?" from the
panel's topLevelBlockId. Nested surfaces that render a block as their own
root — backlink entries, embeds, breadcrumbs — were invisible to that
check, so on a backlink entry `o`/Enter created a sibling outside the
entry ("invisible block"), Tab indented it in the real tree, etc.

Introduce a single source of truth:

- `scopeRootId` on BlockContextType: the root of a surface's visible
  subtree. Declared by every surface that mounts a block as a bounded
  view (panel = topLevelBlockId, backlink entry = shown block, embed =
  embedded block, breadcrumb = segment). New surfaces get correct
  behaviour by declaring it — no action changes (tier-A extensibility).

- `resolveStructuralEditPolicy` (data/structuralEditPolicy.ts): derives
  createBelowPlacement / canIndent / canOutdent / canMergeUp from the
  block's position relative to its scope root. All four gestures route
  through it instead of comparing to topLevelBlockId.

- scopeRootId is injected into every block-surface shortcut dependency
  centrally in useShortcutSurfaceActivations, so handlers (and plugins)
  receive it uniformly.

Migrate edit + navigation off direct topLevelBlockId reads: selection
nav primitives, extendSelection, paste boundary, the outdent mutator's
boundary arg, and the bounded-navigation follow-on (j/k, arrows, gg/G,
jumps now stay within the surface scope). topLevelBlockId remains the
panel's persisted zoom anchor; the remaining direct readers (PanelRenderer,
panel history/layout, zoom in/out, focal-render affordances) are all
genuinely panel-scoped.