### PR TITLE
Route scope-root block creation through the structural-edit policy

### DIFF
--- a/src/data/structuralEditPolicy.ts
+++ b/src/data/structuralEditPolicy.ts
@@ -9,6 +9,15 @@ import { isCollapsedProp } from './properties.js'
  */
 export type CreateBelowPlacement = 'child-first' | 'sibling-below'
 
+/**
+ * Where a "new block above" gesture (vim `O`) must place the created
+ * block so it lands somewhere the user can see.
+ *  - `child-first`: insert as the block's first child (used at the scope
+ *    root, where a sibling above would land outside the visible surface).
+ *  - `sibling-above`: insert as the previous sibling.
+ */
+export type CreateAbovePlacement = 'child-first' | 'sibling-above'
+
 export interface StructuralEditPolicyInput {
   /** Block the structural edit targets. */
   blockId: string
@@ -49,6 +58,11 @@ export interface StructuralEditPolicy {
   isScopeRoot: boolean
   /** Placement for vim `o` / Enter-at-end. */
   createBelowPlacement: CreateBelowPlacement
+  /** Placement for vim `O`. At the scope root a sibling above would land
+   *  outside the visible surface (the "invisible block" bug), so it
+   *  degenerates to a first child — the only insertion point relative to
+   *  the root the surface can actually render. */
+  createAbovePlacement: CreateAbovePlacement
   /** May Tab indent this block within the surface? */
   canIndent: boolean
   /** May Shift+Tab outdent this block within the surface? The
@@ -70,6 +84,7 @@ export const resolveStructuralEditPolicy = (
     isScopeRoot,
     createBelowPlacement:
       isScopeRoot || hasUncollapsedChildren ? 'child-first' : 'sibling-below',
+    createAbovePlacement: isScopeRoot ? 'child-first' : 'sibling-above',
     canIndent: !isScopeRoot,
     canOutdent: !isScopeRoot && parentId !== scopeRootId,
     canMergeUp: !isScopeRoot,

--- a/src/data/test/structuralEditPolicy.test.ts
+++ b/src/data/test/structuralEditPolicy.test.ts
@@ -63,5 +63,8 @@ describe('resolveStructuralEditPolicy', () => {
     const p = policy({scopeRootId: undefined})
     expect(p.isScopeRoot).toBe(false)
     expect(p.canIndent).toBe(true)
+    // Imperative/CLI dispatch (no surface): `O` falls back to a plain
+    // sibling-above rather than no-oping.
+    expect(p.createAbovePlacement).toBe('sibling-above')
   })
 })

--- a/src/data/test/structuralEditPolicy.test.ts
+++ b/src/data/test/structuralEditPolicy.test.ts
@@ -20,6 +20,11 @@ describe('resolveStructuralEditPolicy', () => {
       expect(policy({hasUncollapsedChildren: true}).createBelowPlacement).toBe('child-first')
     })
 
+    it('creates a sibling above regardless of children', () => {
+      expect(policy().createAbovePlacement).toBe('sibling-above')
+      expect(policy({hasUncollapsedChildren: true}).createAbovePlacement).toBe('sibling-above')
+    })
+
     it('allows indent / outdent / merge-up', () => {
       const p = policy({parentId: 'somewhere-else'})
       expect(p).toMatchObject({canIndent: true, canOutdent: true, canMergeUp: true, isScopeRoot: false})
@@ -37,6 +42,11 @@ describe('resolveStructuralEditPolicy', () => {
     it('always creates a first child so the new block stays visible', () => {
       expect(root().createBelowPlacement).toBe('child-first')
       expect(root({hasUncollapsedChildren: true}).createBelowPlacement).toBe('child-first')
+    })
+
+    it('creates a first child for `O` too, since a sibling above is outside the surface', () => {
+      expect(root().createAbovePlacement).toBe('child-first')
+      expect(root({hasUncollapsedChildren: true}).createAbovePlacement).toBe('child-first')
     })
 
     it('is a no-op for indent / outdent / merge-up', () => {

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -243,11 +243,21 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
     }),
     bindNormal({
       id: 'create_block_above_and_edit',
-      description: 'Create block above and enter edit mode',
-      handler: async ({block, uiStateBlock, renderScopeId}: BlockShortcutDependencies) => {
-        const newId = await repo.mutate.createSiblingAbove({siblingId: block.id})
+      description: 'Create block above (or as child) and enter edit mode',
+      handler: async (deps: BlockShortcutDependencies) => {
+        const {block, uiStateBlock, scopeRootId} = deps
+        if (!block || !uiStateBlock || !scopeRootId) return
+
+        // sibling-above normally, but at the scope root (e.g. a backlink
+        // entry) a sibling above would land outside the visible surface —
+        // the "invisible block" bug — so the policy falls back to a first
+        // child, the only insertion point the surface can render.
+        const {createAbovePlacement} = await structuralEditPolicyForBlock(block, scopeRootId)
+        const newId = createAbovePlacement === 'child-first'
+          ? await repo.mutate.createChild({parentId: block.id, position: {kind: 'first'}, revealParent: true})
+          : await repo.mutate.createSiblingAbove({siblingId: block.id})
         if (!newId) return
-        await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId})
+        await focusBlock(uiStateBlock, newId, {edit: true, renderScopeId: deps.renderScopeId})
       },
       defaultBinding: {
         keys: 'Shift+o',

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -246,12 +246,14 @@ export function getVimNormalModeActions({repo}: { repo: Repo }): ActionConfig<ty
       description: 'Create block above (or as child) and enter edit mode',
       handler: async (deps: BlockShortcutDependencies) => {
         const {block, uiStateBlock, scopeRootId} = deps
-        if (!block || !uiStateBlock || !scopeRootId) return
+        if (!block || !uiStateBlock) return
 
         // sibling-above normally, but at the scope root (e.g. a backlink
         // entry) a sibling above would land outside the visible surface —
         // the "invisible block" bug — so the policy falls back to a first
-        // child, the only insertion point the surface can render.
+        // child, the only insertion point the surface can render. With no
+        // scope root (imperative/CLI dispatch) the policy yields
+        // 'sibling-above', preserving the plain create-above behaviour.
         const {createAbovePlacement} = await structuralEditPolicyForBlock(block, scopeRootId)
         const newId = createAbovePlacement === 'child-first'
           ? await repo.mutate.createChild({parentId: block.id, position: {kind: 'first'}, revealParent: true})

--- a/src/shortcuts/defaultShortcuts.test.ts
+++ b/src/shortcuts/defaultShortcuts.test.ts
@@ -585,6 +585,45 @@ describe('default CodeMirror shortcuts', () => {
     expect(children[1]).toBe('existing')
   })
 
+  it('keeps the before-text in a scope-root block and pushes the suffix into a new first child on mid-text split', async () => {
+    // A normal mid-text split makes the before-text a preceding sibling;
+    // at the scope root that sibling is outside the surface, so the root
+    // keeps the before-text and the continuation becomes its first child.
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'root', workspaceId: WS, parentId: null, orderKey: 'a0'})
+      await tx.create({id: 'ui', workspaceId: WS, parentId: null, orderKey: 'z0'})
+    }, {scope: ChangeScope.BlockDefault})
+    await env.repo.mutate.createChild({parentId: 'root', id: 'shown', content: 'left right'})
+    await env.repo.mutate.createChild({parentId: 'shown', id: 'existing', content: 'existing'})
+
+    const uiStateBlock = env.repo.block('ui')
+    await focusBlock(uiStateBlock, 'shown')
+
+    const editorView = codeMirrorEditorView('left right', 'left '.length)
+    const action = findEditModeAction(env.repo, 'split_block_cm')
+    await action.handler({
+      block: env.repo.block('shown'),
+      editorView,
+      uiStateBlock,
+      scopeRootId: 'shown',
+    } satisfies CodeMirrorEditModeDependencies, {preventDefault: vi.fn()} as unknown as ActionTrigger)
+
+    // Root unchanged in the parent's children; before-text stays in it.
+    expect(await childIds('root')).toEqual(['shown'])
+    expect(env.repo.block('shown').peek()?.content).toBe('left ')
+
+    // Suffix lands as the new first child, ahead of the existing child.
+    const children = await childIds('shown')
+    const suffixId = children[0]
+    expect(children).toEqual([suffixId, 'existing'])
+    expect(env.repo.block(suffixId).peek()?.content).toBe('right')
+
+    // Editor and focus follow the suffix block.
+    expect(editorView.state.doc.toString()).toBe('left ')
+    expect(peekFocusedBlockLocation(uiStateBlock)?.blockId).toBe(suffixId)
+    expect(uiStateBlock.peekProperty(editorSelection)).toEqual({blockId: suffixId, start: 0})
+  })
+
   it('makes Tab a no-op on a scope-root block', async () => {
     await env.repo.tx(async tx => {
       await tx.create({id: 'root', workspaceId: WS, parentId: null, orderKey: 'a0'})

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -11,7 +11,11 @@ import {
 } from './types'
 import { Block } from '@/data/block'
 import { Repo } from '@/data/repo'
-import { merge as mergeMutator } from '@/data/internals/kernelMutators'
+import {
+  merge as mergeMutator,
+  setContent as setContentMutator,
+  createChild as createChildMutator,
+} from '@/data/internals/kernelMutators'
 import { ChangeScope } from '@/data/api'
 import {
   nextVisibleBlock,
@@ -109,6 +113,46 @@ const splitCodeMirrorBlockAtCursor = async (
     after: afterCursor,
   })
   return block
+}
+
+/**
+ * Mid-text split when the edited block is the *scope root* (a backlink
+ * entry, embed, or zoomed panel root). `core.split` would push the
+ * before-cursor text into a preceding sibling — which lives outside the
+ * visible surface, silently burying the first half (the same class as
+ * the "invisible block" bug for `o`/`O`). Instead the root keeps the
+ * before-text and the continuation becomes its first child, mirroring
+ * the reading order (root = first half, child = the rest).
+ *
+ * Returns the new child's id.
+ */
+const splitScopeRootIntoFirstChild = async (
+  block: Block,
+  editorView: EditorView,
+): Promise<string> => {
+  const doc = editorView.state.doc
+  const cursorPos = editorView.state.selection.main.head
+  const beforeCursor = doc.sliceString(0, cursorPos)
+  const afterCursor = doc.sliceString(cursorPos)
+  const repo = block.repo
+
+  // Re-arm the editor (and its debounced pushChange) with the prefix that
+  // stays in the root, so a later flush can't clobber the SQL we write
+  // below — same precaution as splitCodeMirrorBlockAtCursor.
+  editorView.dispatch({
+    changes: {from: 0, to: doc.length, insert: beforeCursor},
+    selection: EditorSelection.cursor(beforeCursor.length),
+  })
+
+  return repo.tx(async tx => {
+    await tx.run(setContentMutator, {id: block.id, content: beforeCursor})
+    return tx.run(createChildMutator, {
+      parentId: block.id,
+      content: afterCursor,
+      position: {kind: 'first'},
+      revealParent: true,
+    })
+  }, {scope: ChangeScope.BlockDefault, description: 'split scope root into first child'})
 }
 
 export const CREATE_NODE_IN_ACTIVE_PANEL_ACTION_ID = 'create_node_in_active_panel'
@@ -548,12 +592,21 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
 
         // Case 1: Cursor is in middle of text
         if (cursorPos < doc.length) {
-          const blockInFocus = await splitCodeMirrorBlockAtCursor(block, editorView)
-          await uiStateBlock.set(editorSelection, {
-            blockId: blockInFocus.id,
-            start: 0,
-          })
-          await focusBlock(uiStateBlock, blockInFocus.id, {edit: true, renderScopeId: deps.renderScopeId})
+          // At the scope root a normal split would bury the before-text in
+          // an invisible preceding sibling — keep it in the root and push
+          // the continuation into a new first child instead.
+          if (policy.isScopeRoot) {
+            const childId = await splitScopeRootIntoFirstChild(block, editorView)
+            await uiStateBlock.set(editorSelection, {blockId: childId, start: 0})
+            await focusBlock(uiStateBlock, childId, {edit: true, renderScopeId: deps.renderScopeId})
+          } else {
+            const blockInFocus = await splitCodeMirrorBlockAtCursor(block, editorView)
+            await uiStateBlock.set(editorSelection, {
+              blockId: blockInFocus.id,
+              start: 0,
+            })
+            await focusBlock(uiStateBlock, blockInFocus.id, {edit: true, renderScopeId: deps.renderScopeId})
+          }
         }
         // Case 2: Cursor at end and the new block belongs as a first
         // child — either the block shows children, or it's the scope


### PR DESCRIPTION
## Problem

Structural-edit gestures that act on a **scope root** (a backlink entry, embed, or zoomed panel root) can create blocks *outside* the visible surface — the "invisible block" bug. Most gestures (`o`, Enter-at-end, Tab, Shift+Tab, Backspace-merge, move up/down, delete, paste) were already routed through the scope-relative `resolveStructuralEditPolicy`, but two create-paths slipped through:

1. **`O` (create above)** still called `repo.mutate.createSiblingAbove(...)` directly. On a scope root the previous sibling lands outside the surface.
2. **Mid-text Enter** (`split_block_cm`, Case 1) called `core.split` unconditionally. `core.split` pushes the *before-cursor* text into a preceding sibling — at a scope root that silently buries the first half of the line in an invisible block.

So the policy wasn't "missing" these so much as these two paths never went through it.

## Fix

- Add a symmetric **`createAbovePlacement`** to `StructuralEditPolicy` (`sibling-above` normally, `child-first` at the scope root) and route the `O` handler through it, mirroring the `o` handler (incl. `revealParent` + `scopeRootId` guard).
- For **mid-text split at the scope root**, keep the before-text in the root and push the continuation into a new **first child** (revealing the root, focusing the child) — mirroring the reading order: root = first half, child = the rest. Non-scope-root splits are unchanged.

## Audit

Confirmed the remaining focused-block structural gestures are already policy-correct on a scope root: indent/outdent (`canIndent`/`canOutdent`), Backspace-merge (`canMergeUp`), move up/down (`moveVertical` is scope-aware), delete, and paste (passes `scopeRootId`). Other `createChild` call sites target an explicit known parent (not focused-block-relative), so the boundary doesn't apply.

## Test plan

- `tsc -b` — clean
- `eslint .` — 0 errors
- Full `vitest run` — 252 files / 2724 tests pass
- New tests: `createAbovePlacement` for ordinary vs. scope-root blocks; mid-text split on a scope root keeps before-text in the root and pushes the suffix into a focused first child.

https://claude.ai/code/session_015vMLq3RsQN15ezLpkWXxeK