### PR TITLE
Show display name instead of user id for "Changed by"

### DIFF
--- a/src/components/BlockProperties.component.test.tsx
+++ b/src/components/BlockProperties.component.test.tsx
@@ -52,8 +52,9 @@ vi.mock('@/data/globalState.ts', () => ({
     return uiStateBlockRef.current
   },
   // Attribution name resolution is exercised in globalState's own tests;
-  // here it's identity so the metadata row stays deterministic.
-  useUserName: (userId: string) => userId,
+  // here it's identity (and reports no page) so the metadata row stays
+  // deterministic and renders as plain text.
+  useUserPage: (userId: string) => ({name: userId}),
 }))
 
 vi.mock('@/utils/navigation.ts', () => ({

--- a/src/components/BlockProperties.component.test.tsx
+++ b/src/components/BlockProperties.component.test.tsx
@@ -51,6 +51,9 @@ vi.mock('@/data/globalState.ts', () => ({
     if (!uiStateBlockRef.current) throw new Error('test UI state block not initialised')
     return uiStateBlockRef.current
   },
+  // Attribution name resolution is exercised in globalState's own tests;
+  // here it's identity so the metadata row stays deterministic.
+  useUserName: (userId: string) => userId,
 }))
 
 vi.mock('@/utils/navigation.ts', () => ({

--- a/src/components/BlockProperties.component.test.tsx
+++ b/src/components/BlockProperties.component.test.tsx
@@ -60,6 +60,10 @@ vi.mock('@/utils/navigation.ts', () => ({
   useNavigate: () => (input: unknown) => {
     navigateCallsRef.current.push(input)
   },
+  // MetadataRow's "Changed by" link uses this; record opens like navigate.
+  useOpenBlock: ({blockId}: {blockId: string}) => () => {
+    navigateCallsRef.current.push({blockId})
+  },
 }))
 
 const reviewStatusProp = defineProperty<string>('phase2:review-status', {

--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -9,8 +9,7 @@ import { Eye, EyeOff } from 'lucide-react'
 import { Block } from '../data/block'
 import { useBlockContext } from '@/context/block'
 import { useChildIds, useHandle } from '@/hooks/block.js'
-import { useUIStateBlock, useUserName } from '@/data/globalState.js'
-import { userPageBlockId } from '@/data/stateBlocks.js'
+import { useUIStateBlock, useUserPage } from '@/data/globalState.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { usePropertySchemas } from '@/hooks/propertySchemas.js'
 import { propertyEditorOverridesFacet, typesFacet, valuePresetsFacet } from '../data/facets.ts'
@@ -56,7 +55,6 @@ export function BlockProperties({block}: BlockPropertiesProps) {
     selector: data => data
       ? {
         id: data.id,
-        workspaceId: data.workspaceId,
         content: data.content,
         properties: data.properties,
         updatedAt: data.updatedAt,
@@ -65,7 +63,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
       : undefined,
   })
   const childIds = useChildIds(block)
-  const updatedByName = useUserName(blockData?.updatedBy ?? '')
+  const updatedByUser = useUserPage(blockData?.updatedBy ?? '')
   const uiStateBlock = useUIStateBlock()
   const runtime = useAppRuntime()
   const {panelId, scopeRootId, renderScopeId, isNestedSurface} = useBlockContext()
@@ -117,8 +115,8 @@ export function BlockProperties({block}: BlockPropertiesProps) {
     ? buildPropertyPanelModel({
       blockId: blockData.id,
       updatedAt: blockData.updatedAt,
-      updatedBy: updatedByName,
-      updatedByBlockId: userPageBlockId(blockData.workspaceId, blockData.updatedBy),
+      updatedBy: updatedByUser.name,
+      updatedByBlockId: updatedByUser.blockId,
       properties,
       schemas,
       uis,
@@ -127,7 +125,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
       syntheticRows,
     })
     : null,
-  [blockData, presets, properties, schemas, syntheticRows, typesRegistry, uis, updatedByName])
+  [blockData, presets, properties, schemas, syntheticRows, typesRegistry, uis, updatedByUser])
 
   if (!blockData || !model) return null
 

--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -10,6 +10,7 @@ import { Block } from '../data/block'
 import { useBlockContext } from '@/context/block'
 import { useChildIds, useHandle } from '@/hooks/block.js'
 import { useUIStateBlock, useUserName } from '@/data/globalState.js'
+import { userPageBlockId } from '@/data/stateBlocks.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { usePropertySchemas } from '@/hooks/propertySchemas.js'
 import { propertyEditorOverridesFacet, typesFacet, valuePresetsFacet } from '../data/facets.ts'
@@ -55,6 +56,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
     selector: data => data
       ? {
         id: data.id,
+        workspaceId: data.workspaceId,
         content: data.content,
         properties: data.properties,
         updatedAt: data.updatedAt,
@@ -116,6 +118,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
       blockId: blockData.id,
       updatedAt: blockData.updatedAt,
       updatedBy: updatedByName,
+      updatedByBlockId: userPageBlockId(blockData.workspaceId, blockData.updatedBy),
       properties,
       schemas,
       uis,

--- a/src/components/BlockProperties.tsx
+++ b/src/components/BlockProperties.tsx
@@ -9,7 +9,7 @@ import { Eye, EyeOff } from 'lucide-react'
 import { Block } from '../data/block'
 import { useBlockContext } from '@/context/block'
 import { useChildIds, useHandle } from '@/hooks/block.js'
-import { useUIStateBlock } from '@/data/globalState.js'
+import { useUIStateBlock, useUserName } from '@/data/globalState.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { usePropertySchemas } from '@/hooks/propertySchemas.js'
 import { propertyEditorOverridesFacet, typesFacet, valuePresetsFacet } from '../data/facets.ts'
@@ -63,6 +63,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
       : undefined,
   })
   const childIds = useChildIds(block)
+  const updatedByName = useUserName(blockData?.updatedBy ?? '')
   const uiStateBlock = useUIStateBlock()
   const runtime = useAppRuntime()
   const {panelId, scopeRootId, renderScopeId, isNestedSurface} = useBlockContext()
@@ -114,7 +115,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
     ? buildPropertyPanelModel({
       blockId: blockData.id,
       updatedAt: blockData.updatedAt,
-      updatedBy: blockData.updatedBy,
+      updatedBy: updatedByName,
       properties,
       schemas,
       uis,
@@ -123,7 +124,7 @@ export function BlockProperties({block}: BlockPropertiesProps) {
       syntheticRows,
     })
     : null,
-  [blockData, presets, properties, schemas, syntheticRows, typesRegistry, uis])
+  [blockData, presets, properties, schemas, syntheticRows, typesRegistry, uis, updatedByName])
 
   if (!blockData || !model) return null
 

--- a/src/components/propertyPanel/Rows.tsx
+++ b/src/components/propertyPanel/Rows.tsx
@@ -1,5 +1,8 @@
 import { Settings2 } from 'lucide-react'
 import { Input } from '@/components/ui/input'
+import { useRepo } from '@/context/repo.js'
+import { useOpenBlock } from '@/utils/navigation.js'
+import { buildAppHash } from '@/utils/routing.js'
 import { METADATA_ROW_GRID_STYLE, PROPERTY_ROW_GRID_STYLE } from './layout'
 import type { PropertyPanelMetadataRow, PropertyPanelModelSection } from './model'
 
@@ -22,6 +25,13 @@ export function PropertySectionLabel({section}: {section: PropertyPanelModelSect
 }
 
 export function MetadataRow({row}: {row: PropertyPanelMetadataRow}) {
+  const repo = useRepo()
+  const workspaceId = repo.activeWorkspaceId ?? undefined
+  // Hooks must be unconditional; the opener is only wired up for rows
+  // that actually carry a link target (currently just "Changed by").
+  const openBlock = useOpenBlock({blockId: row.linkToBlockId ?? '', workspaceId})
+  const showLink = Boolean(row.linkToBlockId) && Boolean(workspaceId)
+
   return (
     <div
       className="grid items-center gap-2 py-0.5 text-sm"
@@ -29,7 +39,18 @@ export function MetadataRow({row}: {row: PropertyPanelMetadataRow}) {
     >
       <Settings2 className="h-3.5 w-3.5 text-muted-foreground" />
       <div className="truncate text-muted-foreground" title={row.label}>{row.label}</div>
-      <Input value={row.value} disabled className="h-7 min-w-0 bg-muted/30 text-sm" />
+      {showLink ? (
+        <a
+          href={buildAppHash(workspaceId!, row.linkToBlockId!)}
+          onClick={openBlock}
+          title={row.value}
+          className="inline-flex h-7 min-w-0 items-center rounded-sm px-2 text-sm text-foreground no-underline hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <span className="min-w-0 truncate">{row.value}</span>
+        </a>
+      ) : (
+        <Input value={row.value} disabled className="h-7 min-w-0 bg-muted/30 text-sm" />
+      )}
     </div>
   )
 }

--- a/src/components/propertyPanel/model.ts
+++ b/src/components/propertyPanel/model.ts
@@ -20,6 +20,9 @@ const EMPTY_BLOCK_TYPES: readonly string[] = []
 export interface PropertyPanelMetadataRow {
   readonly label: string
   readonly value: string
+  /** When set, the value renders as a link opening this block (e.g.
+   *  "Changed by" → the editing user's page). */
+  readonly linkToBlockId?: string
 }
 
 export interface PropertyPanelModelRow {
@@ -178,6 +181,8 @@ export const buildPropertyPanelModel = (args: {
   blockId: string
   updatedAt: number
   updatedBy: string
+  /** User page block id for `updatedBy`, so "Changed by" can link to it. */
+  updatedByBlockId?: string
   properties: Record<string, unknown>
   schemas: ReadonlyMap<string, AnyPropertySchema>
   uis: ReadonlyMap<string, AnyPropertyEditorOverride>
@@ -245,7 +250,7 @@ export const buildPropertyPanelModel = (args: {
   const metadataRows = [
     {label: 'ID', value: args.blockId},
     {label: 'Last changed', value: new Date(args.updatedAt).toLocaleString()},
-    {label: 'Changed by', value: args.updatedBy},
+    {label: 'Changed by', value: args.updatedBy, linkToBlockId: args.updatedByBlockId},
   ]
 
   return {

--- a/src/data/blockTypes.ts
+++ b/src/data/blockTypes.ts
@@ -9,6 +9,7 @@ import {
   presetConfigProp,
   presetIdProp,
   propertyNameProp,
+  userIdProp,
 } from '@/data/properties'
 
 export const EXTENSION_TYPE = 'extension'
@@ -32,6 +33,11 @@ export const TYPES_PAGE_TYPE = 'panel:types'
 /** Marker type for the singleton Recents page — a Tana-style view of
  *  recently-edited blocks in the workspace. */
 export const RECENTS_PAGE_TYPE = 'panel:recents'
+/** Per-user "user page" type. Tagged alongside `PAGE_TYPE` (so the page
+ *  stays navigable) and carries the user's opaque id as a property,
+ *  letting `block_types`-indexed lookups enumerate users and attribution
+ *  surfaces resolve an id to its page/name. Kernel-owned. */
+export const USER_TYPE = 'user'
 
 export const KERNEL_TYPE_CONTRIBUTIONS: readonly TypeContribution[] = [
   defineBlockType({
@@ -70,5 +76,12 @@ export const KERNEL_TYPE_CONTRIBUTIONS: readonly TypeContribution[] = [
     id: RECENTS_PAGE_TYPE,
     label: 'Recents page',
     properties: [aliasesProp],
+  }),
+  defineBlockType({
+    id: USER_TYPE,
+    label: 'User',
+    // Lift aliases + id so the property panel surfaces them and the id
+    // auto-materialises when `addType('user')` runs.
+    properties: [aliasesProp, userIdProp],
   }),
 ]

--- a/src/data/globalState.ts
+++ b/src/data/globalState.ts
@@ -39,6 +39,7 @@ import {
   getUserBlock,
   requireSchemaScope,
   requireWorkspaceId,
+  userPageBlockId,
 } from '@/data/stateBlocks.js'
 export { USER_PREFS_PATH_PART } from '@/data/userPrefs.js'
 
@@ -74,6 +75,22 @@ export function useUserBlock(): Block {
   const workspaceId = requireWorkspaceId(repo, 'useUserBlock')
 
   return use(getUserBlock(repo, workspaceId, user))
+}
+
+/** Resolve a `userId` (as stored in `created_by` / `updated_by`) to that
+ *  user's display name for attribution surfaces ("Changed by", update
+ *  tooltips, …). Reads the user-page block's content — which the page's
+ *  owning client keeps in sync with their name — via its deterministic
+ *  id, so it works for any user whose page has synced into this
+ *  workspace, not just the current one. Falls back to the raw id while
+ *  the page is loading or absent (e.g. a peer who hasn't synced yet),
+ *  which is exactly the prior behaviour, so the worst case degrades
+ *  gracefully rather than rendering blank. */
+export function useUserName(userId: string): string {
+  const repo = useRepo()
+  const workspaceId = requireWorkspaceId(repo, 'useUserName')
+  const block = repo.block(userPageBlockId(workspaceId, userId))
+  return useHandle(block, {selector: doc => doc?.content || userId})
 }
 
 /** Hook to access and modify a UI-state property on the active UI-state

--- a/src/data/globalState.ts
+++ b/src/data/globalState.ts
@@ -77,20 +77,27 @@ export function useUserBlock(): Block {
   return use(getUserBlock(repo, workspaceId, user))
 }
 
-/** Resolve a `userId` (as stored in `created_by` / `updated_by`) to that
- *  user's display name for attribution surfaces ("Changed by", update
- *  tooltips, …). Reads the user-page block's content — which the page's
- *  owning client keeps in sync with their name — via its deterministic
- *  id, so it works for any user whose page has synced into this
- *  workspace, not just the current one. Falls back to the raw id while
- *  the page is loading or absent (e.g. a peer who hasn't synced yet),
- *  which is exactly the prior behaviour, so the worst case degrades
- *  gracefully rather than rendering blank. */
-export function useUserName(userId: string): string {
+/** Resolve a `userId` (as stored in `created_by` / `updated_by`) to its
+ *  user page: the display name plus — only when the page block actually
+ *  exists in this workspace — its block id, so callers can link to it.
+ *
+ *  Reads the user-page block's content (which the page's owning client
+ *  keeps in sync with their name) via its deterministic id, so it works
+ *  for any user whose page has synced here, not just the current one.
+ *  While the page is loading or absent (e.g. a peer who hasn't synced
+ *  yet) `name` falls back to the raw id and `blockId` is omitted — so
+ *  attribution degrades to the prior plain-text behaviour rather than
+ *  rendering a link to a block that doesn't exist. */
+export function useUserPage(userId: string): {name: string; blockId?: string} {
   const repo = useRepo()
-  const workspaceId = requireWorkspaceId(repo, 'useUserName')
-  const block = repo.block(userPageBlockId(workspaceId, userId))
-  return useHandle(block, {selector: doc => doc?.content || userId})
+  const workspaceId = requireWorkspaceId(repo, 'useUserPage')
+  const id = userPageBlockId(workspaceId, userId)
+  const block = repo.block(id)
+  return useHandle(block, {
+    selector: doc => doc
+      ? {name: doc.content || userId, blockId: id}
+      : {name: userId},
+  })
 }
 
 /** Hook to access and modify a UI-state property on the active UI-state

--- a/src/data/properties.ts
+++ b/src/data/properties.ts
@@ -219,6 +219,19 @@ export const blockTypePropertiesProp = defineProperty<readonly string[]>('block-
   changeScope: ChangeScope.BlockDefault,
 })
 
+// ──── user page kernel fields ────
+
+/** Opaque user id (the value stored in `created_by` / `updated_by`) on a
+ *  `'user'` user-page block. Gives the page a structured, queryable link
+ *  between the id and the display name (the block's content) alongside
+ *  the human-friendly alias — so attribution surfaces can resolve either
+ *  direction without parsing aliases. */
+export const userIdProp = defineProperty<string>('user:id', {
+  codec: codecs.string,
+  defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
 /** Re-export of the canonical alias schema (defined under
  *  `@/data/internals/coreProperties.ts` so the kernel parseReferences
  *  processor can reference it without circling back through this
@@ -410,4 +423,6 @@ export const KERNEL_PROPERTY_SCHEMAS: ReadonlyArray<PropertySchema<unknown>> = [
   blockTypeLabelProp,
   blockTypeDescriptionProp,
   blockTypePropertiesProp,
+  // user page fields
+  userIdProp,
 ] as ReadonlyArray<PropertySchema<unknown>>

--- a/src/data/stateBlocks.ts
+++ b/src/data/stateBlocks.ts
@@ -45,7 +45,12 @@ const USER_PAGE_NS = '99b1b4e5-6f58-4fd2-9089-dc3b358dd4df'
 // to the same block id across clients.
 const STATE_CHILD_NS = '8f6c2c84-1c12-4e4a-8b9e-9b0f87a7e1d2'
 
-const userPageBlockId = (workspaceId: string, userId: string): string =>
+/** Deterministic id of a user's "user page" block. Exported so display
+ *  surfaces can resolve an arbitrary `userId` (e.g. a row's `updatedBy`)
+ *  back to its page — and thus its display name — without knowing the
+ *  namespace. Two offline clients derive the same id, so a user's page
+ *  authored on one device resolves the same on every other. */
+export const userPageBlockId = (workspaceId: string, userId: string): string =>
   uuidv5(`${workspaceId}:${userId}`, USER_PAGE_NS)
 
 const stateChildBlockId = (parentId: string, content: string): string =>
@@ -186,10 +191,39 @@ const ensureUserPrefsChild = (repo: Repo, parent: Block): Promise<Block> =>
 
 // ──── Bootstrap blocks ────
 
+const dedupe = (values: readonly string[]): string[] => [...new Set(values)]
+
+/** Additively backfill the user-id alias onto an existing user page.
+ *  Pages created before the id became an alias (or restored by an older
+ *  client) only carry the display-name alias; this upgrades them in
+ *  place on first access. Idempotent and additive — never rewrites the
+ *  display-name alias or content, so a user who renamed their own page
+ *  keeps that. Runs at most once per memoized (repo, workspace, user)
+ *  since the caller is itself memoized; the peek skips the tx entirely
+ *  once the alias is present. Best-effort: an alias-collision rejection
+ *  (the id already claimed elsewhere — not expected for opaque ids) is
+ *  swallowed so it can't break user-page resolution. */
+const ensureUserIdAlias = async (repo: Repo, id: string, userId: string): Promise<void> => {
+  const current = repo.block(id).peekProperty(aliasesProp) ?? []
+  if (current.includes(userId)) return
+  try {
+    await repo.tx(async tx => {
+      const row = await tx.get(id)
+      if (!row || row.deleted) return
+      const aliases = await tx.getProperty(id, aliasesProp)
+      if (aliases.includes(userId)) return
+      await tx.setProperty(id, aliasesProp, [...aliases, userId])
+    }, {scope: ChangeScope.UserPrefs, description: 'user-page id-alias backfill'})
+  } catch (err) {
+    console.warn(`[stateBlocks] could not backfill id alias on user page ${id}:`, err)
+  }
+}
+
 /** Per-user "user page" block — created (or restored) on first access.
- *  The alias matches the user's display name so alias-based lookup
- *  surfaces can target it directly. Memoized per (repo, workspaceId,
- *  userId) — `use()` requires a stable promise per render.
+ *  The aliases match the user's display name *and* opaque id so
+ *  alias-based lookup surfaces can target it either way. Memoized per
+ *  (repo, workspaceId, userId) — `use()` requires a stable promise per
+ *  render.
  *
  *  The fast path uses `repo.load` to skip the tx entirely when the row
  *  is already live in cache or in SQL. Tombstone branch lives INSIDE
@@ -199,12 +233,20 @@ export const getUserBlock = memoize(
   async (repo: Repo, workspaceId: string, user: User): Promise<Block> => {
     const id = userPageBlockId(workspaceId, user.id)
     const live = await repo.load(id)
-    if (live && !live.deleted) return repo.block(id)
+    if (live && !live.deleted) {
+      await ensureUserIdAlias(repo, id, user.id)
+      return repo.block(id)
+    }
 
     // User.name is optional in the data-layer User shape; fall back
     // to the id so the user-page block always has *some* content
     // and an addressable alias.
     const displayName = user.name ?? user.id
+    // The id rides alongside the display name as an alias so the
+    // user-page is addressable both ways — by name (`[[Alice]]`) and by
+    // the opaque id stored in `created_by`/`updated_by`. Deduped for the
+    // no-name case where displayName === user.id.
+    const aliases = dedupe([displayName, user.id])
     const typeSnapshot = repo.snapshotTypeRegistries()
 
     await repo.tx(async tx => {
@@ -218,7 +260,7 @@ export const getUserBlock = memoize(
       if (existing && !existing.deleted) return
       if (existing && existing.deleted) {
         await tx.restore(id, {content: displayName})
-        await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: [displayName]}, typeSnapshot)
+        await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: aliases}, typeSnapshot)
         return
       }
       await tx.create({
@@ -228,7 +270,7 @@ export const getUserBlock = memoize(
         orderKey: 'a0',
         content: displayName,
       })
-      await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: [displayName]}, typeSnapshot)
+      await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: aliases}, typeSnapshot)
     }, {scope: ChangeScope.UserPrefs})
 
     return repo.block(id)

--- a/src/data/stateBlocks.ts
+++ b/src/data/stateBlocks.ts
@@ -28,10 +28,11 @@ import {
   hasBlockType,
   selectionStateProp,
   showPropertiesProp,
+  userIdProp,
   type BlockSelectionState,
 } from '@/data/properties'
 import { USER_PREFS_PATH_PART } from '@/data/userPrefs.js'
-import { PAGE_TYPE } from '@/data/blockTypes.js'
+import { PAGE_TYPE, USER_TYPE } from '@/data/blockTypes.js'
 
 // ──── Deterministic-id namespaces ────
 
@@ -193,29 +194,44 @@ const ensureUserPrefsChild = (repo: Repo, parent: Block): Promise<Block> =>
 
 const dedupe = (values: readonly string[]): string[] => [...new Set(values)]
 
-/** Additively backfill the user-id alias onto an existing user page.
- *  Pages created before the id became an alias (or restored by an older
- *  client) only carry the display-name alias; this upgrades them in
- *  place on first access. Idempotent and additive — never rewrites the
- *  display-name alias or content, so a user who renamed their own page
- *  keeps that. Runs at most once per memoized (repo, workspace, user)
- *  since the caller is itself memoized; the peek skips the tx entirely
- *  once the alias is present. Best-effort: an alias-collision rejection
- *  (the id already claimed elsewhere — not expected for opaque ids) is
- *  swallowed so it can't break user-page resolution. */
-const ensureUserIdAlias = async (repo: Repo, id: string, userId: string): Promise<void> => {
-  const current = repo.block(id).peekProperty(aliasesProp) ?? []
-  if (current.includes(userId)) return
+/** Repair an existing user page to the current shape: the user id as an
+ *  alias, the `USER_TYPE` marker, and the `user:id` property. Pages
+ *  created before any of these existed (or restored by an older client)
+ *  are upgraded in place on first access. Idempotent and additive —
+ *  never rewrites the display-name alias or content, so a user who
+ *  renamed their own page keeps that. Runs at most once per memoized
+ *  (repo, workspace, user) since the caller is itself memoized; the peek
+ *  skips the tx entirely once the page is up to date. Best-effort: an
+ *  alias-collision rejection (the id already claimed elsewhere — not
+ *  expected for opaque ids) is swallowed so it can't break user-page
+ *  resolution. */
+const reconcileUserPage = async (repo: Repo, id: string, userId: string): Promise<void> => {
+  const block = repo.block(id)
+  const data = block.peek()
+  if (!data) return
+  const aliases = block.peekProperty(aliasesProp) ?? []
+  const upToDate =
+    aliases.includes(userId) &&
+    hasBlockType(data, USER_TYPE) &&
+    (block.peekProperty(userIdProp) ?? '') === userId
+  if (upToDate) return
+
+  const typeSnapshot = repo.snapshotTypeRegistries()
   try {
     await repo.tx(async tx => {
       const row = await tx.get(id)
       if (!row || row.deleted) return
-      const aliases = await tx.getProperty(id, aliasesProp)
-      if (aliases.includes(userId)) return
-      await tx.setProperty(id, aliasesProp, [...aliases, userId])
-    }, {scope: ChangeScope.UserPrefs, description: 'user-page id-alias backfill'})
+      const txAliases = await tx.getProperty(id, aliasesProp)
+      if (!txAliases.includes(userId)) {
+        await tx.setProperty(id, aliasesProp, [...txAliases, userId])
+      }
+      if ((await tx.getProperty(id, userIdProp)) !== userId) {
+        await tx.setProperty(id, userIdProp, userId)
+      }
+      await repo.addTypeInTx(tx, id, USER_TYPE, {}, typeSnapshot)
+    }, {scope: ChangeScope.UserPrefs, description: 'user-page reconcile'})
   } catch (err) {
-    console.warn(`[stateBlocks] could not backfill id alias on user page ${id}:`, err)
+    console.warn(`[stateBlocks] could not reconcile user page ${id}:`, err)
   }
 }
 
@@ -234,7 +250,7 @@ export const getUserBlock = memoize(
     const id = userPageBlockId(workspaceId, user.id)
     const live = await repo.load(id)
     if (live && !live.deleted) {
-      await ensureUserIdAlias(repo, id, user.id)
+      await reconcileUserPage(repo, id, user.id)
       return repo.block(id)
     }
 
@@ -261,6 +277,7 @@ export const getUserBlock = memoize(
       if (existing && existing.deleted) {
         await tx.restore(id, {content: displayName})
         await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: aliases}, typeSnapshot)
+        await repo.addTypeInTx(tx, id, USER_TYPE, {[userIdProp.name]: user.id}, typeSnapshot)
         return
       }
       await tx.create({
@@ -271,6 +288,7 @@ export const getUserBlock = memoize(
         content: displayName,
       })
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: aliases}, typeSnapshot)
+      await repo.addTypeInTx(tx, id, USER_TYPE, {[userIdProp.name]: user.id}, typeSnapshot)
     }, {scope: ChangeScope.UserPrefs})
 
     return repo.block(id)

--- a/src/data/test/globalState.test.ts
+++ b/src/data/test/globalState.test.ts
@@ -8,7 +8,7 @@
  *
  * Coverage:
  *   - getUserBlock: creates a parent-less user page with the user's
- *     display name as content + alias; deterministic id per
+ *     display name as content + name/id aliases; deterministic id per
  *     (workspace, user); idempotent (memoized — second call returns
  *     same promise + Block); falls back to user.id when name is
  *     undefined; restores tombstoned user page
@@ -96,14 +96,16 @@ beforeEach(async () => { env = await setup() })
 afterEach(async () => { await env.h.cleanup() })
 
 describe('getUserBlock', () => {
-  it('creates a parent-less user page with content + alias from user.name', async () => {
+  it('creates a parent-less user page with content + name/id aliases from user.name', async () => {
     const userBlock = await getUserBlock(env.repo, WS, USER)
     const data = userBlock.peek()
 
     expect(data?.parentId).toBeNull()
     expect(data?.workspaceId).toBe(WS)
     expect(data?.content).toBe('Alice')
-    expect(userBlock.peekProperty(aliasesProp)).toEqual(['Alice'])
+    // Both the display name and the opaque id are aliases so the page is
+    // addressable either way (the id is what `updated_by` stores).
+    expect(userBlock.peekProperty(aliasesProp)).toEqual(['Alice', 'user-1'])
     expect(userBlock.peekProperty(typesProp)).toEqual([PAGE_TYPE])
 
     const events = await env.h.db.getAll<{scope: string; source: string}>(
@@ -145,7 +147,7 @@ describe('getUserBlock', () => {
       // Pull current data from SQL via the fresh repo's cache.
       await fresh.repo.load(restored.id)
       expect(restored.peek()?.deleted).toBe(false)
-      expect(restored.peekProperty(aliasesProp)).toEqual(['Alice'])
+      expect(restored.peekProperty(aliasesProp)).toEqual(['Alice', 'user-1'])
       expect(restored.peekProperty(typesProp)).toEqual([PAGE_TYPE])
     } finally {
       await fresh.h.cleanup()

--- a/src/data/test/globalState.test.ts
+++ b/src/data/test/globalState.test.ts
@@ -38,12 +38,13 @@ import { addedTypes } from '@/data/properties'
 import { createTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { Repo } from '../repo'
-import { PAGE_TYPE } from '@/data/blockTypes'
+import { PAGE_TYPE, USER_TYPE } from '@/data/blockTypes'
 import {
   aliasesProp,
   selectionStateProp,
   showPropertiesProp,
   typesProp,
+  userIdProp,
 } from '@/data/properties'
 import {
   getLayoutSessionBlock,
@@ -106,7 +107,9 @@ describe('getUserBlock', () => {
     // Both the display name and the opaque id are aliases so the page is
     // addressable either way (the id is what `updated_by` stores).
     expect(userBlock.peekProperty(aliasesProp)).toEqual(['Alice', 'user-1'])
-    expect(userBlock.peekProperty(typesProp)).toEqual([PAGE_TYPE])
+    // Navigable as a page, plus the USER_TYPE marker carrying the id.
+    expect(userBlock.peekProperty(typesProp)).toEqual([PAGE_TYPE, USER_TYPE])
+    expect(userBlock.peekProperty(userIdProp)).toBe('user-1')
 
     const events = await env.h.db.getAll<{scope: string; source: string}>(
       'SELECT scope, source FROM command_events ORDER BY created_at',
@@ -128,6 +131,7 @@ describe('getUserBlock', () => {
       const block = await getUserBlock(otherEnv.repo, WS, noNameUser)
       expect(block.peek()?.content).toBe('user-no-name')
       expect(block.peekProperty(aliasesProp)).toEqual(['user-no-name'])
+      expect(block.peekProperty(userIdProp)).toBe('user-no-name')
     } finally {
       await otherEnv.h.cleanup()
     }
@@ -148,7 +152,8 @@ describe('getUserBlock', () => {
       await fresh.repo.load(restored.id)
       expect(restored.peek()?.deleted).toBe(false)
       expect(restored.peekProperty(aliasesProp)).toEqual(['Alice', 'user-1'])
-      expect(restored.peekProperty(typesProp)).toEqual([PAGE_TYPE])
+      expect(restored.peekProperty(typesProp)).toEqual([PAGE_TYPE, USER_TYPE])
+      expect(restored.peekProperty(userIdProp)).toBe('user-1')
     } finally {
       await fresh.h.cleanup()
     }

--- a/src/plugins/update-indicator/UpdateIndicator.tsx
+++ b/src/plugins/update-indicator/UpdateIndicator.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Block } from '../../data/block'
-import { useInFocus, usePluginPrefsProperty, useUserName } from '@/data/globalState'
+import { useInFocus, usePluginPrefsProperty, useUserPage } from '@/data/globalState'
 import { useUpdateMetadata } from '@/hooks/block.js'
 import { previousLoadTimeProp, updateIndicatorPrefsType } from './loadTimes.ts'
 
@@ -8,7 +8,7 @@ export const UpdateIndicator = ({block}: { block: Block }) => {
   const inFocus = useInFocus(block.id)
   const [previousLoadTime] = usePluginPrefsProperty(updateIndicatorPrefsType, previousLoadTimeProp)
   const updateInfo = useUpdateMetadata(block)
-  const updatedByName = useUserName(updateInfo?.updatedBy ?? '')
+  const updatedByName = useUserPage(updateInfo?.updatedBy ?? '').name
   // `seen` is a sticky ratchet — once focus has touched this block
   // we don't show the indicator again. The "set state during render"
   // idiom (https://react.dev/reference/react/useState#storing-information-from-previous-renders)

--- a/src/plugins/update-indicator/UpdateIndicator.tsx
+++ b/src/plugins/update-indicator/UpdateIndicator.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Block } from '../../data/block'
-import { useInFocus, usePluginPrefsProperty } from '@/data/globalState'
+import { useInFocus, usePluginPrefsProperty, useUserName } from '@/data/globalState'
 import { useUpdateMetadata } from '@/hooks/block.js'
 import { previousLoadTimeProp, updateIndicatorPrefsType } from './loadTimes.ts'
 
@@ -8,6 +8,7 @@ export const UpdateIndicator = ({block}: { block: Block }) => {
   const inFocus = useInFocus(block.id)
   const [previousLoadTime] = usePluginPrefsProperty(updateIndicatorPrefsType, previousLoadTimeProp)
   const updateInfo = useUpdateMetadata(block)
+  const updatedByName = useUserName(updateInfo?.updatedBy ?? '')
   // `seen` is a sticky ratchet — once focus has touched this block
   // we don't show the indicator again. The "set state during render"
   // idiom (https://react.dev/reference/react/useState#storing-information-from-previous-renders)
@@ -27,7 +28,7 @@ export const UpdateIndicator = ({block}: { block: Block }) => {
   return (
     <div
       className="absolute right-1 top-1 h-2 w-2 rounded-full bg-blue-400"
-      title={`Updated by ${updateInfo.updatedBy} on ${new Date(updateInfo.updatedAt).toLocaleString()}`}
+      title={`Updated by ${updatedByName} on ${new Date(updateInfo.updatedAt).toLocaleString()}`}
     />
   )
 }


### PR DESCRIPTION
Attribution surfaces ("Changed by" in the property panel and the
update-indicator tooltip) rendered the raw opaque user id stored in
`updated_by`. Resolve it to the user's display name instead.

- Add `useUserName(userId)` which reads the owning user page's content
  (kept in sync with the user's name by that user's own client) via its
  deterministic id, falling back to the raw id while the page is
  loading or hasn't synced — so the worst case matches prior behaviour.
- Use it in BlockProperties and UpdateIndicator.
- Store the user id as an additional alias on the user page (alongside
  the display-name alias) so the page is addressable both by name and
  by the id that `created_by`/`updated_by` carry. Existing pages are
  backfilled additively on first access; new/restored pages get both
  aliases up front.

https://claude.ai/code/session_01UbcyXiWA7JNTPf7mK3V8bZ