### PR TITLE
Add deck-based spaced-repetition review mode

### DIFF
--- a/src/extensions/staticAppExtensions.ts
+++ b/src/extensions/staticAppExtensions.ts
@@ -40,6 +40,7 @@ import { appIntentsPlugin } from '@/plugins/app-intents'
 import { roamImportPlugin } from '@/plugins/roam-import'
 import { blockTaggingPlugin } from '@/plugins/block-tagging'
 import { srsReschedulingPlugin } from '@/plugins/srs-rescheduling'
+import { srsReviewPlugin } from '@/plugins/srs-review'
 import { todoPlugin } from '@/plugins/todo'
 import { syncStatusPlugin } from '@/plugins/sync-status'
 import { extensionsSettingsPlugin } from '@/plugins/extensions-settings'
@@ -116,6 +117,7 @@ export const staticAppExtensions = ({repo}: {repo: Repo}): AppExtension[] => [
   blockTaggingPlugin,
   extractTypePlugin,
   srsReschedulingPlugin,
+  srsReviewPlugin({repo}),
   syncStatusPlugin,
   updateIndicatorPlugin,
   agentRuntimePlugin,

--- a/src/plugins/srs-review/DeckPicker.tsx
+++ b/src/plugins/srs-review/DeckPicker.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react'
+import { Layers, Tag } from 'lucide-react'
+import type { Block } from '@/data/block'
+import { ChangeScope } from '@/data/api'
+import { useRepo } from '@/context/repo.js'
+import { usePluginPrefsProperty } from '@/data/globalState.js'
+import { cn } from '@/lib/utils.js'
+import {
+  blockTaggingPrefsType,
+  blockTagsConfigProp,
+  normalizeBlockTagsConfig,
+} from '@/plugins/block-tagging/config.js'
+import { useDueCards } from './useDueCards.ts'
+import { reviewDeckStartedProp, reviewDeckTagProp } from './schema.ts'
+
+const startDeck = async (deck: Block, tagName: string): Promise<void> => {
+  await deck.repo.tx(
+    async tx => {
+      await tx.setProperty(deck.id, reviewDeckTagProp, tagName)
+      await tx.setProperty(deck.id, reviewDeckStartedProp, true)
+    },
+    {scope: ChangeScope.BlockDefault, description: 'start srs review deck'},
+  )
+}
+
+interface DeckOptionProps {
+  workspaceId: string
+  /** '' is the all-due deck. */
+  tagName: string
+  label: string
+  icon: typeof Tag
+  onPick: () => void
+}
+
+const DeckOption = ({workspaceId, tagName, label, icon: Icon, onPick}: DeckOptionProps) => {
+  const due = useDueCards(workspaceId, tagName)
+  const count = due.length
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors',
+        count > 0
+          ? 'border-border bg-background hover:bg-muted'
+          : 'border-border/60 bg-background text-muted-foreground hover:bg-muted',
+      )}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span className="flex-1 truncate font-medium">{label}</span>
+      <span
+        className={cn(
+          'rounded-full px-2 py-0.5 text-xs font-semibold tabular-nums',
+          count > 0 ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground',
+        )}
+      >
+        {count} due
+      </span>
+    </button>
+  )
+}
+
+/** Deck selection surface shown by the deck renderer until a deck is
+ *  started. Lists an "all due" deck plus every tag in the workspace's
+ *  curated tag list, each with a live due count. */
+export const DeckPicker = ({deck}: {deck: Block}) => {
+  const repo = useRepo()
+  const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
+  const [storedTags] = usePluginPrefsProperty(blockTaggingPrefsType, blockTagsConfigProp)
+  const tags = useMemo(() => normalizeBlockTagsConfig(storedTags), [storedTags])
+
+  return (
+    <div className="mx-auto w-full max-w-xl space-y-4 py-4">
+      <div>
+        <h2 className="text-lg font-semibold">Spaced repetition review</h2>
+        <p className="text-sm text-muted-foreground">
+          Pick a deck to review cards due today or earlier.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <DeckOption
+          workspaceId={workspaceId}
+          tagName=""
+          label="All due cards"
+          icon={Layers}
+          onPick={() => void startDeck(deck, '')}
+        />
+        {tags.map(tag => (
+          <DeckOption
+            key={tag}
+            workspaceId={workspaceId}
+            tagName={tag}
+            label={tag}
+            icon={Tag}
+            onPick={() => void startDeck(deck, tag)}
+          />
+        ))}
+      </div>
+
+      {tags.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No tags configured yet. Add tag names under the &quot;Tags&quot; entry in
+          Preferences to review tag-scoped decks, or start with all due cards above.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/plugins/srs-review/ReviewDeckRenderer.tsx
+++ b/src/plugins/srs-review/ReviewDeckRenderer.tsx
@@ -1,0 +1,42 @@
+import type { BlockRenderer, BlockRendererProps } from '@/types.js'
+import { DefaultBlockRenderer } from '@/components/renderer/DefaultBlockRenderer.js'
+import { getBlockTypes } from '@/data/properties.js'
+import { usePropertyValue } from '@/hooks/block.js'
+import {
+  SRS_REVIEW_DECK_TYPE,
+  reviewDeckStartedProp,
+  reviewDeckTagProp,
+} from './schema.ts'
+import { DeckPicker } from './DeckPicker.tsx'
+import { ReviewSession } from './ReviewSession.tsx'
+
+/** Content area for a review-deck page: the deck picker until a deck is
+ *  started, then the review session. Keyed on the tag so picking a
+ *  different deck restarts the session cleanly. */
+const ReviewDeckContent: BlockRenderer = ({block}: BlockRendererProps) => {
+  const [started] = usePropertyValue(block, reviewDeckStartedProp)
+  const [tagName] = usePropertyValue(block, reviewDeckTagProp)
+  if (!started) return <DeckPicker deck={block} />
+  return <ReviewSession key={tagName} deck={block} tagName={tagName} />
+}
+ReviewDeckContent.displayName = 'ReviewDeckContent'
+
+/** Outer wrapper: keep the default block frame, swap the content area
+ *  for the deck UI. Mirrors BlockTypeBlockRenderer / video-player. */
+export const SrsReviewDeckRenderer: BlockRenderer = Object.assign(
+  (props: BlockRendererProps) => (
+    <DefaultBlockRenderer
+      {...props}
+      ContentRenderer={ReviewDeckContent}
+      EditContentRenderer={ReviewDeckContent}
+    />
+  ),
+  {
+    canRender: ({block}: BlockRendererProps): boolean => {
+      const data = block.peek()
+      return !!data && getBlockTypes(data).includes(SRS_REVIEW_DECK_TYPE)
+    },
+    priority: () => 100,
+  },
+)
+SrsReviewDeckRenderer.displayName = 'SrsReviewDeckRenderer'

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -24,6 +24,7 @@ import {
   SRS_SM25_TYPE,
   formatRescheduleToastMessage,
   rescheduleBlock,
+  srsArchivedProp,
   srsNextReviewDateProp,
 } from '@/plugins/srs-rescheduling'
 import { SrsSignal } from '@/plugins/srs-rescheduling/scheduler.js'
@@ -41,17 +42,18 @@ const isEditableElement = (el: HTMLElement | null): boolean => {
 
 /** Whether a block is still a live, schedulable review card — mirrors
  *  the deck's membership conditions (`buildDueCardsQuery`): it must
- *  carry the SRS type AND a non-empty next-review date. A card can lose
- *  either in another panel after the session snapshotted its id; grading
- *  it then would re-add the type and/or write a fresh date via
- *  `rescheduleBlock`, silently resurrecting a card the user just removed
- *  from review. */
+ *  carry the SRS type AND a non-empty next-review date AND not be
+ *  archived. A card can lose any of these in another panel after the
+ *  session snapshotted its id; grading it then would re-add the type
+ *  and/or write a fresh date via `rescheduleBlock`, resurrecting a card
+ *  the user just removed from review. */
 const isLiveSrsCard = (data: BlockData): boolean => {
   if (!getBlockTypes(data).includes(SRS_SM25_TYPE)) return false
-  const raw = data.properties[srsNextReviewDateProp.name]
-  if (raw === undefined) return false
   try {
-    return srsNextReviewDateProp.codec.decode(raw).length > 0
+    const archivedRaw = data.properties[srsArchivedProp.name]
+    if (archivedRaw !== undefined && srsArchivedProp.codec.decode(archivedRaw)) return false
+    const dateRaw = data.properties[srsNextReviewDateProp.name]
+    return dateRaw !== undefined && srsNextReviewDateProp.codec.decode(dateRaw).length > 0
   } catch {
     return false
   }

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ArchiveX,
+  CalendarClock,
+  Check,
+  ChevronLeft,
+  Gauge,
+  PartyPopper,
+  RotateCcw,
+  Sparkles,
+} from 'lucide-react'
+import type { Block } from '@/data/block'
+import { useRepo } from '@/context/repo.js'
+import { NestedBlockContextProvider } from '@/context/block.js'
+import { BlockComponent } from '@/components/BlockComponent.js'
+import { Button } from '@/components/ui/button.js'
+import { cn } from '@/lib/utils.js'
+import { showInfo } from '@/utils/toast.js'
+import { openReschedulePicker } from '@/plugins/daily-notes'
+import {
+  formatRescheduleToastMessage,
+  rescheduleBlock,
+} from '@/plugins/srs-rescheduling'
+import { SrsSignal } from '@/plugins/srs-rescheduling/scheduler.js'
+import { useDueCards } from './useDueCards.ts'
+import { archiveSrsCard } from './archive.ts'
+import { reviewDeckStartedProp } from './schema.ts'
+import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
+
+const isEditableTarget = (): boolean => {
+  const el = document.activeElement as HTMLElement | null
+  if (!el) return false
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
+}
+
+interface GradeButton {
+  signal: SrsSignal
+  label: string
+  hint: string
+  icon: typeof Check
+  className: string
+}
+
+const GRADE_BUTTONS: readonly GradeButton[] = [
+  {signal: SrsSignal.AGAIN, label: 'Again', hint: '1', icon: RotateCcw, className: 'text-rose-600'},
+  {signal: SrsSignal.HARD, label: 'Hard', hint: '2', icon: Gauge, className: 'text-amber-600'},
+  {signal: SrsSignal.GOOD, label: 'Good', hint: '3', icon: Check, className: 'text-emerald-600'},
+  {signal: SrsSignal.EASY, label: 'Easy', hint: '4', icon: Sparkles, className: 'text-sky-600'},
+]
+
+const GRADE_BY_KEY: Readonly<Record<string, SrsSignal>> = {
+  '1': SrsSignal.AGAIN,
+  '2': SrsSignal.HARD,
+  '3': SrsSignal.GOOD,
+  '4': SrsSignal.EASY,
+}
+
+export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) => {
+  const repo = useRepo()
+  const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
+  const dueCards = useDueCards(workspaceId, tagName)
+
+  // Freeze the queue at the first non-empty load. Grading moves a card
+  // out of `dueCards` (its next-review date jumps to the future), so
+  // walking the live list would renumber the session under the user.
+  // We snapshot ids once via the converge-during-render pattern, then
+  // read each card's live state at grade time via `repo.block(id)`.
+  const [queue, setQueue] = useState<readonly string[] | null>(null)
+  if (queue === null && dueCards.length > 0) {
+    setQueue(dueCards.map(c => c.id))
+  }
+
+  const [index, setIndex] = useState(0)
+  const [revealed, setRevealed] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const total = queue?.length ?? 0
+  const currentId = queue && index < queue.length ? queue[index] : null
+
+  const advance = useCallback(() => {
+    setRevealed(false)
+    setIndex(i => i + 1)
+  }, [])
+
+  const grade = useCallback(
+    async (signal: SrsSignal) => {
+      if (!currentId || busy) return
+      setBusy(true)
+      try {
+        const result = await rescheduleBlock(repo.block(currentId), signal)
+        if (result) showInfo(formatRescheduleToastMessage(result))
+      } finally {
+        setBusy(false)
+        advance()
+      }
+    },
+    [currentId, busy, repo, advance],
+  )
+
+  const archive = useCallback(async () => {
+    if (!currentId || busy) return
+    setBusy(true)
+    try {
+      await archiveSrsCard(repo.block(currentId))
+      showInfo('Archived')
+    } finally {
+      setBusy(false)
+      advance()
+    }
+  }, [currentId, busy, repo, advance])
+
+  // Hand the card to the shared reschedule sheet, then move on — the
+  // sheet writes the new date asynchronously; either way this card is
+  // dealt with for the session.
+  const reschedule = useCallback(() => {
+    if (!currentId) return
+    openReschedulePicker({blockId: currentId, workspaceId})
+    advance()
+  }, [currentId, workspaceId, advance])
+
+  const changeDeck = useCallback(() => {
+    void deck.set(reviewDeckStartedProp, false)
+  }, [deck])
+
+  // Keyboard: space/enter reveals, 1–4 grade. Suppressed while focus is
+  // in an editable surface (the revealed answer is a live outline) so
+  // typing into a child block never fires a grade.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (busy || isEditableTarget()) return
+      if (!revealed) {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault()
+          setRevealed(true)
+        }
+        return
+      }
+      const signal = GRADE_BY_KEY[e.key]
+      if (signal !== undefined) {
+        e.preventDefault()
+        void grade(signal)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [busy, revealed, grade])
+
+  const deckLabel = tagName.trim() ? tagName.trim() : 'All due cards'
+
+  const header = (
+    <div className="mb-4 flex items-center justify-between gap-3">
+      <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={changeDeck}>
+        <ChevronLeft className="mr-1 h-3.5 w-3.5" />
+        Decks
+      </Button>
+      <span className="truncate text-sm font-medium text-muted-foreground">{deckLabel}</span>
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {total === 0 ? '' : `${Math.min(index + 1, total)} / ${total}`}
+      </span>
+    </div>
+  )
+
+  // Nothing due (or the deck is still loading its first page — the
+  // effect promotes it to a session the moment cards arrive).
+  if (queue === null) {
+    return (
+      <div className="mx-auto w-full max-w-2xl py-4">
+        {header}
+        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed py-12 text-center text-muted-foreground">
+          <PartyPopper className="h-6 w-6" />
+          <p className="font-medium">No cards due in this deck</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (currentId === null) {
+    return (
+      <div className="mx-auto w-full max-w-2xl py-4">
+        {header}
+        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed py-12 text-center">
+          <PartyPopper className="h-6 w-6 text-emerald-600" />
+          <p className="font-medium">Review complete</p>
+          <p className="text-sm text-muted-foreground">
+            {total} {total === 1 ? 'card' : 'cards'} reviewed.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl py-4">
+      {header}
+
+      <div className="rounded-xl border bg-card p-4 shadow-sm">
+        <NestedBlockContextProvider
+          overrides={{
+            [SRS_REVIEW_CARD_ID]: currentId,
+            [SRS_REVIEW_REVEALED]: revealed,
+            isNestedSurface: true,
+            scopeRootId: currentId,
+            renderScopeId: `srs-review:${currentId}`,
+          }}
+        >
+          {/* keyed by card id so switching cards remounts the subtree
+              rather than diffing one card's outline into the next */}
+          <BlockComponent key={currentId} blockId={currentId} />
+        </NestedBlockContextProvider>
+      </div>
+
+      <div className="mt-4">
+        {!revealed ? (
+          <Button type="button" className="w-full" onClick={() => setRevealed(true)} disabled={busy}>
+            Show answer
+            <span className="ml-2 text-xs opacity-70">space</span>
+          </Button>
+        ) : (
+          <div className="grid grid-cols-4 gap-2">
+            {GRADE_BUTTONS.map(btn => (
+              <Button
+                key={btn.label}
+                type="button"
+                variant="outline"
+                className="flex h-auto flex-col gap-1 py-2"
+                disabled={busy}
+                onClick={() => void grade(btn.signal)}
+              >
+                <btn.icon className={cn('h-4 w-4', btn.className)} />
+                <span className="text-sm font-medium">{btn.label}</span>
+                <span className="text-[10px] opacity-60">{btn.hint}</span>
+              </Button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 flex items-center justify-center gap-4 text-xs text-muted-foreground">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"
+          onClick={reschedule}
+          disabled={busy}
+        >
+          <CalendarClock className="h-3.5 w-3.5" />
+          Reschedule
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"
+          onClick={() => void archive()}
+          disabled={busy}
+        >
+          <ArchiveX className="h-3.5 w-3.5" />
+          Archive
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -12,12 +12,17 @@ import {
 import type { Block } from '@/data/block'
 import { useRepo } from '@/context/repo.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
+import { appMountsFacet } from '@/extensions/core.js'
 import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
 import { Button } from '@/components/ui/button.js'
 import { cn } from '@/lib/utils.js'
 import { showInfo } from '@/utils/toast.js'
-import { hasAnyBlockDateAdapter, openReschedulePicker } from '@/plugins/daily-notes'
+import {
+  hasAnyBlockDateAdapter,
+  openReschedulePicker,
+  reschedulePickerMount,
+} from '@/plugins/daily-notes'
 import {
   formatRescheduleToastMessage,
   rescheduleBlock,
@@ -78,6 +83,17 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
 
   const total = queue?.length ?? 0
   const currentId = queue && index < queue.length ? queue[index] : null
+
+  // Show Reschedule only when it can actually do something: a date
+  // adapter must handle the card (gone if srs-rescheduling is off) AND
+  // the reschedule picker must be mounted (contributed by daily-notes —
+  // its adapter survives even with daily-notes off, so check the mount
+  // separately). Without both, dispatching the picker event would open
+  // nothing and `advance()` would silently skip the card.
+  const canReschedule =
+    currentId !== null &&
+    hasAnyBlockDateAdapter(runtime, repo.block(currentId)) &&
+    runtime.read(appMountsFacet).some(mount => mount.id === reschedulePickerMount.id)
 
   const advance = useCallback(() => {
     setRevealed(false)
@@ -258,11 +274,10 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       </div>
 
       <div className="mt-3 flex items-center justify-center gap-4 text-xs text-muted-foreground">
-        {/* Only when a date adapter can handle this card. With
-            srs-rescheduling disabled there's no adapter (and the picker
-            may not be mounted), so the control would open nothing and
-            then skip the card — hide it instead of silently no-op'ing. */}
-        {hasAnyBlockDateAdapter(runtime, repo.block(currentId)) && (
+        {/* Hidden unless an adapter handles the card and the picker is
+            mounted — otherwise the control would open nothing and then
+            skip the card. */}
+        {canReschedule && (
           <button
             type="button"
             className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -33,6 +33,12 @@ import { reviewDeckStartedProp } from './schema.ts'
 import { SRS_REVIEW_CONTEXT, type SrsReviewController } from './actions.ts'
 import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
 
+const isEditableElement = (el: HTMLElement | null): boolean => {
+  if (!el) return false
+  // `isContentEditable` covers CodeMirror's focusable `.cm-content`.
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
+}
+
 /** Whether a block is still a live, schedulable review card — mirrors
  *  the deck's membership conditions (`buildDueCardsQuery`): it must
  *  carry the SRS type AND a non-empty next-review date. A card can lose
@@ -162,10 +168,16 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
 
   // Reveal/grade run through the app's shortcut system via a dedicated
   // modal `srs-review` context (see actions.ts), not a hand-rolled key
-  // handler. The session activates that context only while its surface
-  // is focused, so a deck in a background panel — or a second open deck
-  // — never grabs Space/1-4, and the dispatcher's default event filter
-  // keeps grade keys from firing while editing the revealed answer.
+  // handler. The session activates that context only while its own
+  // (non-editor) chrome is focused, so a deck in a background panel — or
+  // a second open deck — never grabs Space/1-4.
+  //
+  // We can't rely on the dispatcher's default editable-target filter to
+  // keep grade keys out of the revealed answer's CodeMirror: EDIT_MODE_CM
+  // opts editor events back in via its own eventFilter (filters OR
+  // together), and this modal context would then shadow edit-mode and
+  // eat Enter / 1-4. So we deactivate the context whenever focus lands on
+  // an editable element instead.
   const [surfaceFocused, setSurfaceFocused] = useState(false)
   const controller = useMemo<SrsReviewController>(() => ({
     reveal: () => { if (!busy) setRevealed(true) },
@@ -178,7 +190,11 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   }], [controller, surfaceFocused, currentId])
   useActionContextActivations(shortcutActivations)
 
-  const handleSurfaceFocus = useCallback(() => setSurfaceFocused(true), [])
+  const handleSurfaceFocus = useCallback((e: ReactFocusEvent<HTMLDivElement>) => {
+    // Active only when focus is on the session chrome, not inside the
+    // answer editor — see the context note above.
+    setSurfaceFocused(!isEditableElement(e.target as HTMLElement | null))
+  }, [])
   const handleSurfaceBlur = useCallback((e: ReactFocusEvent<HTMLDivElement>) => {
     // focusout bubbles; only treat it as leaving when focus moves
     // outside the session subtree entirely.

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -11,12 +11,13 @@ import {
 } from 'lucide-react'
 import type { Block } from '@/data/block'
 import { useRepo } from '@/context/repo.js'
+import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
 import { Button } from '@/components/ui/button.js'
 import { cn } from '@/lib/utils.js'
 import { showInfo } from '@/utils/toast.js'
-import { openReschedulePicker } from '@/plugins/daily-notes'
+import { hasAnyBlockDateAdapter, openReschedulePicker } from '@/plugins/daily-notes'
 import {
   formatRescheduleToastMessage,
   rescheduleBlock,
@@ -57,6 +58,7 @@ const GRADE_BY_KEY: Readonly<Record<string, SrsSignal>> = {
 
 export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) => {
   const repo = useRepo()
+  const runtime = useAppRuntime()
   const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
   const dueCards = useDueCards(workspaceId, tagName)
 
@@ -256,15 +258,21 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       </div>
 
       <div className="mt-3 flex items-center justify-center gap-4 text-xs text-muted-foreground">
-        <button
-          type="button"
-          className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"
-          onClick={reschedule}
-          disabled={busy}
-        >
-          <CalendarClock className="h-3.5 w-3.5" />
-          Reschedule
-        </button>
+        {/* Only when a date adapter can handle this card. With
+            srs-rescheduling disabled there's no adapter (and the picker
+            may not be mounted), so the control would open nothing and
+            then skip the card — hide it instead of silently no-op'ing. */}
+        {hasAnyBlockDateAdapter(runtime, repo.block(currentId)) && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"
+            onClick={reschedule}
+            disabled={busy}
+          >
+            <CalendarClock className="h-3.5 w-3.5" />
+            Reschedule
+          </button>
+        )}
         <button
           type="button"
           className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useCallback, useMemo, useRef, useState, type FocusEvent as ReactFocusEvent } from 'react'
 import {
   ArchiveX,
   CalendarClock,
@@ -18,6 +18,7 @@ import { BlockComponent } from '@/components/BlockComponent.js'
 import { Button } from '@/components/ui/button.js'
 import { cn } from '@/lib/utils.js'
 import { showError, showInfo } from '@/utils/toast.js'
+import { useActionContextActivations } from '@/shortcuts/useActionContext.js'
 import { openReschedulePicker } from '@/plugins/daily-notes'
 import {
   SRS_SM25_TYPE,
@@ -29,13 +30,8 @@ import { SrsSignal } from '@/plugins/srs-rescheduling/scheduler.js'
 import { useDueCards } from './useDueCards.ts'
 import { archiveSrsCard } from './archive.ts'
 import { reviewDeckStartedProp } from './schema.ts'
+import { SRS_REVIEW_CONTEXT, type SrsReviewController } from './actions.ts'
 import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
-
-const isEditableTarget = (): boolean => {
-  const el = document.activeElement as HTMLElement | null
-  if (!el) return false
-  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
-}
 
 /** Whether a block is still a live, schedulable review card — mirrors
  *  the deck's membership conditions (`buildDueCardsQuery`): it must
@@ -69,13 +65,6 @@ const GRADE_BUTTONS: readonly GradeButton[] = [
   {signal: SrsSignal.GOOD, label: 'Good', hint: '3', icon: Check, className: 'text-emerald-600'},
   {signal: SrsSignal.EASY, label: 'Easy', hint: '4', icon: Sparkles, className: 'text-sky-600'},
 ]
-
-const GRADE_BY_KEY: Readonly<Record<string, SrsSignal>> = {
-  '1': SrsSignal.AGAIN,
-  '2': SrsSignal.HARD,
-  '3': SrsSignal.GOOD,
-  '4': SrsSignal.EASY,
-}
 
 export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) => {
   const repo = useRepo()
@@ -171,31 +160,30 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     void deck.set(reviewDeckStartedProp, false)
   }, [deck])
 
-  // Keyboard: space/enter reveals, 1–4 grade. Scoped to the session's
-  // own surface via a container `onKeyDown` (not a global `window`
-  // listener) so a deck rendered in a background panel never grabs
-  // these keys while the user is interacting elsewhere — and two open
-  // decks don't fight over them. The editable-target guard additionally
-  // lets typing into the revealed answer (a live outline) through
-  // instead of firing a grade.
-  const handleKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (busy || isEditableTarget()) return
-      if (!revealed) {
-        if (e.key === ' ' || e.key === 'Enter') {
-          e.preventDefault()
-          setRevealed(true)
-        }
-        return
-      }
-      const signal = GRADE_BY_KEY[e.key]
-      if (signal !== undefined) {
-        e.preventDefault()
-        void grade(signal)
-      }
-    },
-    [busy, revealed, grade],
-  )
+  // Reveal/grade run through the app's shortcut system via a dedicated
+  // modal `srs-review` context (see actions.ts), not a hand-rolled key
+  // handler. The session activates that context only while its surface
+  // is focused, so a deck in a background panel — or a second open deck
+  // — never grabs Space/1-4, and the dispatcher's default event filter
+  // keeps grade keys from firing while editing the revealed answer.
+  const [surfaceFocused, setSurfaceFocused] = useState(false)
+  const controller = useMemo<SrsReviewController>(() => ({
+    reveal: () => { if (!busy) setRevealed(true) },
+    grade: signal => { if (revealed && !busy) void grade(signal) },
+  }), [busy, revealed, grade])
+  const shortcutActivations = useMemo(() => [{
+    context: SRS_REVIEW_CONTEXT,
+    dependencies: {controller},
+    enabled: surfaceFocused && currentId !== null,
+  }], [controller, surfaceFocused, currentId])
+  useActionContextActivations(shortcutActivations)
+
+  const handleSurfaceFocus = useCallback(() => setSurfaceFocused(true), [])
+  const handleSurfaceBlur = useCallback((e: ReactFocusEvent<HTMLDivElement>) => {
+    // focusout bubbles; only treat it as leaving when focus moves
+    // outside the session subtree entirely.
+    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setSurfaceFocused(false)
+  }, [])
 
   // Focus the session surface once, when the card view first mounts, so
   // the shortcuts are live without a click. We don't refocus per card —
@@ -257,7 +245,8 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     <div
       ref={focusSessionSurface}
       tabIndex={-1}
-      onKeyDown={handleKeyDown}
+      onFocus={handleSurfaceFocus}
+      onBlur={handleSurfaceBlur}
       className="mx-auto w-full max-w-2xl py-4 outline-none"
     >
       {header}

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type FocusEvent as ReactFocusEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent as ReactFocusEvent } from 'react'
 import {
   ArchiveX,
   CalendarClock,
@@ -34,10 +34,15 @@ import { reviewDeckStartedProp } from './schema.ts'
 import { SRS_REVIEW_CONTEXT, type SrsReviewController } from './actions.ts'
 import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
 
-const isEditableElement = (el: HTMLElement | null): boolean => {
+const isInteractiveTarget = (el: HTMLElement | null): boolean => {
   if (!el) return false
   // `isContentEditable` covers CodeMirror's focusable `.cm-content`.
-  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
+  if (el.isContentEditable) return true
+  if (el.getAttribute('role') === 'button') return true
+  // Buttons/links/form controls keep their own keys (Enter/Space activate
+  // them) — the review context must not shadow that, or keyboard users
+  // couldn't operate the grade/reschedule/archive controls.
+  return ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(el.tagName)
 }
 
 /** Whether a block is still a live, schedulable review card — mirrors
@@ -95,6 +100,20 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
 
   const total = queue?.length ?? 0
   const currentId = queue && index < queue.length ? queue[index] : null
+
+  // A finished session keeps the frozen queue, so it would otherwise show
+  // "Review complete" forever and ignore the (now reactive, midnight-
+  // aware) due query. When genuinely new cards appear — next day's cards,
+  // or ones added elsewhere — restart with those. Filtering to ids not in
+  // the finished queue avoids re-reviewing a just-graded card that's
+  // still lingering in a stale query result.
+  if (queue !== null && index >= queue.length) {
+    const fresh = dueCards.filter(card => !queue.includes(card.id))
+    if (fresh.length > 0) {
+      setQueue(fresh.map(card => card.id))
+      setIndex(0)
+    }
+  }
 
   const advance = useCallback(() => {
     setRevealed(false)
@@ -193,9 +212,10 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   useActionContextActivations(shortcutActivations)
 
   const handleSurfaceFocus = useCallback((e: ReactFocusEvent<HTMLDivElement>) => {
-    // Active only when focus is on the session chrome, not inside the
-    // answer editor — see the context note above.
-    setSurfaceFocused(!isEditableElement(e.target as HTMLElement | null))
+    // Active only when focus is on the session chrome itself, not the
+    // answer editor or an interactive control — see the context note and
+    // `isInteractiveTarget`.
+    setSurfaceFocused(!isInteractiveTarget(e.target as HTMLElement | null))
   }, [])
   const handleSurfaceBlur = useCallback((e: ReactFocusEvent<HTMLDivElement>) => {
     // focusout bubbles; only treat it as leaving when focus moves
@@ -206,13 +226,23 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   // Focus the session surface once, when the card view first mounts, so
   // the shortcuts are live without a click. We don't refocus per card —
   // that would yank focus back from the reschedule sheet after it opens.
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
   const focusedOnce = useRef(false)
   const focusSessionSurface = useCallback((el: HTMLDivElement | null) => {
+    surfaceRef.current = el
     if (el && !focusedOnce.current) {
       focusedOnce.current = true
       el.focus()
     }
   }, [])
+
+  // On reveal, pull focus back to the surface so the grade keys (1-4) are
+  // live — whether the answer was revealed via Space or by clicking the
+  // "Show answer" button (which would otherwise leave focus on a button,
+  // where the review context is intentionally inactive).
+  useEffect(() => {
+    if (revealed) surfaceRef.current?.focus()
+  }, [revealed])
 
   const deckLabel = tagName.trim() ? tagName.trim() : 'All due cards'
 

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -12,19 +12,13 @@ import {
 import type { Block } from '@/data/block'
 import type { BlockData } from '@/data/api'
 import { useRepo } from '@/context/repo.js'
-import { useAppRuntime } from '@/extensions/runtimeContext.js'
-import { appMountsFacet } from '@/extensions/core.js'
 import { getBlockTypes } from '@/data/properties.js'
 import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
 import { Button } from '@/components/ui/button.js'
 import { cn } from '@/lib/utils.js'
 import { showError, showInfo } from '@/utils/toast.js'
-import {
-  hasAnyBlockDateAdapter,
-  openReschedulePicker,
-  reschedulePickerMount,
-} from '@/plugins/daily-notes'
+import { openReschedulePicker } from '@/plugins/daily-notes'
 import {
   SRS_SM25_TYPE,
   formatRescheduleToastMessage,
@@ -85,7 +79,6 @@ const GRADE_BY_KEY: Readonly<Record<string, SrsSignal>> = {
 
 export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) => {
   const repo = useRepo()
-  const runtime = useAppRuntime()
   const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
   const dueCards = useDueCards(workspaceId, tagName)
 
@@ -105,17 +98,6 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
 
   const total = queue?.length ?? 0
   const currentId = queue && index < queue.length ? queue[index] : null
-
-  // Show Reschedule only when it can actually do something: a date
-  // adapter must handle the card (gone if srs-rescheduling is off) AND
-  // the reschedule picker must be mounted (contributed by daily-notes —
-  // its adapter survives even with daily-notes off, so check the mount
-  // separately). Without both, dispatching the picker event would open
-  // nothing and `advance()` would silently skip the card.
-  const canReschedule =
-    currentId !== null &&
-    hasAnyBlockDateAdapter(runtime, repo.block(currentId)) &&
-    runtime.read(appMountsFacet).some(mount => mount.id === reschedulePickerMount.id)
 
   const advance = useCallback(() => {
     setRevealed(false)
@@ -323,20 +305,15 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       </div>
 
       <div className="mt-3 flex items-center justify-center gap-4 text-xs text-muted-foreground">
-        {/* Hidden unless an adapter handles the card and the picker is
-            mounted — otherwise the control would open nothing and then
-            skip the card. */}
-        {canReschedule && (
-          <button
-            type="button"
-            className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"
-            onClick={reschedule}
-            disabled={busy}
-          >
-            <CalendarClock className="h-3.5 w-3.5" />
-            Reschedule
-          </button>
-        )}
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"
+          onClick={reschedule}
+          disabled={busy}
+        >
+          <CalendarClock className="h-3.5 w-3.5" />
+          Reschedule
+        </button>
         <button
           type="button"
           className="inline-flex items-center gap-1 hover:text-foreground disabled:opacity-50"

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -10,6 +10,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 import type { Block } from '@/data/block'
+import type { BlockData } from '@/data/api'
 import { useRepo } from '@/context/repo.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { appMountsFacet } from '@/extensions/core.js'
@@ -28,6 +29,7 @@ import {
   SRS_SM25_TYPE,
   formatRescheduleToastMessage,
   rescheduleBlock,
+  srsNextReviewDateProp,
 } from '@/plugins/srs-rescheduling'
 import { SrsSignal } from '@/plugins/srs-rescheduling/scheduler.js'
 import { useDueCards } from './useDueCards.ts'
@@ -39,6 +41,24 @@ const isEditableTarget = (): boolean => {
   const el = document.activeElement as HTMLElement | null
   if (!el) return false
   return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
+}
+
+/** Whether a block is still a live, schedulable review card — mirrors
+ *  the deck's membership conditions (`buildDueCardsQuery`): it must
+ *  carry the SRS type AND a non-empty next-review date. A card can lose
+ *  either in another panel after the session snapshotted its id; grading
+ *  it then would re-add the type and/or write a fresh date via
+ *  `rescheduleBlock`, silently resurrecting a card the user just removed
+ *  from review. */
+const isLiveSrsCard = (data: BlockData): boolean => {
+  if (!getBlockTypes(data).includes(SRS_SM25_TYPE)) return false
+  const raw = data.properties[srsNextReviewDateProp.name]
+  if (raw === undefined) return false
+  try {
+    return srsNextReviewDateProp.codec.decode(raw).length > 0
+  } catch {
+    return false
+  }
 }
 
 interface GradeButton {
@@ -108,13 +128,13 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       setBusy(true)
       try {
         const block = repo.block(currentId)
-        // The card may have left SRS since the queue was snapshotted
-        // (e.g. its type was removed in another panel). `rescheduleBlock`
-        // re-adds SRS_SM25_TYPE to non-SRS blocks, which would silently
-        // resurrect a card the user just removed — so drop it from the
-        // session instead of grading it.
+        // The card may have left review since the queue was snapshotted
+        // (its type or next-review date removed in another panel).
+        // `rescheduleBlock` would re-add the type and write a fresh date,
+        // silently resurrecting a card the user just removed — so drop it
+        // from the session instead of grading it.
         const data = block.peek() ?? (await block.load())
-        if (!data || !getBlockTypes(data).includes(SRS_SM25_TYPE)) {
+        if (!data || !isLiveSrsCard(data)) {
           showInfo('Card is no longer in spaced repetition')
           advance()
           return

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -13,6 +13,7 @@ import type { Block } from '@/data/block'
 import { useRepo } from '@/context/repo.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { appMountsFacet } from '@/extensions/core.js'
+import { getBlockTypes } from '@/data/properties.js'
 import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
 import { Button } from '@/components/ui/button.js'
@@ -24,6 +25,7 @@ import {
   reschedulePickerMount,
 } from '@/plugins/daily-notes'
 import {
+  SRS_SM25_TYPE,
   formatRescheduleToastMessage,
   rescheduleBlock,
 } from '@/plugins/srs-rescheduling'
@@ -105,12 +107,24 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       if (!currentId || busy) return
       setBusy(true)
       try {
+        const block = repo.block(currentId)
+        // The card may have left SRS since the queue was snapshotted
+        // (e.g. its type was removed in another panel). `rescheduleBlock`
+        // re-adds SRS_SM25_TYPE to non-SRS blocks, which would silently
+        // resurrect a card the user just removed — so drop it from the
+        // session instead of grading it.
+        const data = block.peek() ?? (await block.load())
+        if (!data || !getBlockTypes(data).includes(SRS_SM25_TYPE)) {
+          showInfo('Card is no longer in spaced repetition')
+          advance()
+          return
+        }
         // Advance only when the write lands. A null result means the
-        // reschedule was refused (read-only repo, or the block is no
-        // longer an SRS card) — advancing then would mark progress and
-        // eventually "complete" while the card's due date never moved,
-        // so it'd resurface next session. Keep the card and surface it.
-        const result = await rescheduleBlock(repo.block(currentId), signal)
+        // reschedule was refused (e.g. read-only repo) — advancing then
+        // would mark progress and eventually "complete" while the card's
+        // due date never moved, so it'd resurface next session. Keep the
+        // card and surface it.
+        const result = await rescheduleBlock(block, signal)
         if (result) {
           showInfo(formatRescheduleToastMessage(result))
           advance()

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 import {
   ArchiveX,
   CalendarClock,
@@ -122,11 +122,15 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     void deck.set(reviewDeckStartedProp, false)
   }, [deck])
 
-  // Keyboard: space/enter reveals, 1–4 grade. Suppressed while focus is
-  // in an editable surface (the revealed answer is a live outline) so
-  // typing into a child block never fires a grade.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
+  // Keyboard: space/enter reveals, 1–4 grade. Scoped to the session's
+  // own surface via a container `onKeyDown` (not a global `window`
+  // listener) so a deck rendered in a background panel never grabs
+  // these keys while the user is interacting elsewhere — and two open
+  // decks don't fight over them. The editable-target guard additionally
+  // lets typing into the revealed answer (a live outline) through
+  // instead of firing a grade.
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
       if (busy || isEditableTarget()) return
       if (!revealed) {
         if (e.key === ' ' || e.key === 'Enter') {
@@ -140,10 +144,20 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
         e.preventDefault()
         void grade(signal)
       }
+    },
+    [busy, revealed, grade],
+  )
+
+  // Focus the session surface once, when the card view first mounts, so
+  // the shortcuts are live without a click. We don't refocus per card —
+  // that would yank focus back from the reschedule sheet after it opens.
+  const focusedOnce = useRef(false)
+  const focusSessionSurface = useCallback((el: HTMLDivElement | null) => {
+    if (el && !focusedOnce.current) {
+      focusedOnce.current = true
+      el.focus()
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [busy, revealed, grade])
+  }, [])
 
   const deckLabel = tagName.trim() ? tagName.trim() : 'All due cards'
 
@@ -161,7 +175,8 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   )
 
   // Nothing due (or the deck is still loading its first page — the
-  // effect promotes it to a session the moment cards arrive).
+  // queue is captured the moment cards arrive, promoting this to a
+  // session).
   if (queue === null) {
     return (
       <div className="mx-auto w-full max-w-2xl py-4">
@@ -190,7 +205,12 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   }
 
   return (
-    <div className="mx-auto w-full max-w-2xl py-4">
+    <div
+      ref={focusSessionSurface}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      className="mx-auto w-full max-w-2xl py-4 outline-none"
+    >
       {header}
 
       <div className="rounded-xl border bg-card p-4 shadow-sm">

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -17,7 +17,7 @@ import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
 import { Button } from '@/components/ui/button.js'
 import { cn } from '@/lib/utils.js'
-import { showInfo } from '@/utils/toast.js'
+import { showError, showInfo } from '@/utils/toast.js'
 import {
   hasAnyBlockDateAdapter,
   openReschedulePicker,
@@ -105,11 +105,20 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       if (!currentId || busy) return
       setBusy(true)
       try {
+        // Advance only when the write lands. A null result means the
+        // reschedule was refused (read-only repo, or the block is no
+        // longer an SRS card) — advancing then would mark progress and
+        // eventually "complete" while the card's due date never moved,
+        // so it'd resurface next session. Keep the card and surface it.
         const result = await rescheduleBlock(repo.block(currentId), signal)
-        if (result) showInfo(formatRescheduleToastMessage(result))
+        if (result) {
+          showInfo(formatRescheduleToastMessage(result))
+          advance()
+        } else {
+          showError("Couldn't reschedule this card")
+        }
       } finally {
         setBusy(false)
-        advance()
       }
     },
     [currentId, busy, repo, advance],
@@ -119,11 +128,17 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     if (!currentId || busy) return
     setBusy(true)
     try {
-      await archiveSrsCard(repo.block(currentId))
-      showInfo('Archived')
+      // Same as grade: only advance if the archive write actually
+      // happened (false on read-only / non-SRS block).
+      const archived = await archiveSrsCard(repo.block(currentId))
+      if (archived) {
+        showInfo('Archived')
+        advance()
+      } else {
+        showError("Couldn't archive this card")
+      }
     } finally {
       setBusy(false)
-      advance()
     }
   }, [currentId, busy, repo, advance])
 

--- a/src/plugins/srs-review/actions.ts
+++ b/src/plugins/srs-review/actions.ts
@@ -35,9 +35,10 @@ export const srsReviewActionContext: ActionContextConfig<typeof SRS_REVIEW_CONTE
   displayName: 'SRS Review',
   // Modal so the single-key reveal/grade bindings only fire while a
   // focused review session has activated this context — they never
-  // shadow typing or navigation elsewhere. Editable targets are still
-  // dropped by the dispatcher's default event filter, so grading keys
-  // don't fire while editing the revealed answer.
+  // shadow typing or navigation elsewhere. The session also deactivates
+  // the context when focus is inside the revealed answer's editor (the
+  // dispatcher's default editable filter is bypassed here because
+  // EDIT_MODE_CM opts editor events back in — see ReviewSession).
   modal: true,
   defaultEventOptions: {preventDefault: true},
   validateDependencies: isSrsReviewDependencies,

--- a/src/plugins/srs-review/actions.ts
+++ b/src/plugins/srs-review/actions.ts
@@ -1,0 +1,86 @@
+import { Check, Gauge, RotateCcw, Sparkles } from 'lucide-react'
+import { Block } from '@/data/block'
+import type {
+  ActionConfig,
+  ActionContextConfig,
+  ActionIcon,
+  BaseShortcutDependencies,
+} from '@/shortcuts/types.js'
+import { SrsSignal } from '@/plugins/srs-rescheduling/scheduler.js'
+
+export const SRS_REVIEW_CONTEXT = 'srs-review'
+
+/** Imperative hooks the active review session hands to the shortcut
+ *  system as context dependencies. The session keeps the
+ *  reveal/grade gating (busy, revealed) inside these so the actions
+ *  stay dumb. */
+export interface SrsReviewController {
+  reveal: () => void
+  grade: (signal: SrsSignal) => void
+}
+
+export interface SrsReviewDependencies extends BaseShortcutDependencies {
+  controller: SrsReviewController
+}
+
+const isSrsReviewDependencies = (deps: unknown): deps is SrsReviewDependencies =>
+  typeof deps === 'object' &&
+  deps !== null &&
+  'uiStateBlock' in deps &&
+  (deps as {uiStateBlock: unknown}).uiStateBlock instanceof Block &&
+  'controller' in deps
+
+export const srsReviewActionContext: ActionContextConfig<typeof SRS_REVIEW_CONTEXT> = {
+  type: SRS_REVIEW_CONTEXT,
+  displayName: 'SRS Review',
+  // Modal so the single-key reveal/grade bindings only fire while a
+  // focused review session has activated this context — they never
+  // shadow typing or navigation elsewhere. Editable targets are still
+  // dropped by the dispatcher's default event filter, so grading keys
+  // don't fire while editing the revealed answer.
+  modal: true,
+  defaultEventOptions: {preventDefault: true},
+  validateDependencies: isSrsReviewDependencies,
+}
+
+// Index-signature contexts type handler deps as `BaseShortcutDependencies`;
+// `validateDependencies` gates activation, so the cast is sound at call time.
+const controllerOf = (deps: BaseShortcutDependencies): SrsReviewController =>
+  (deps as SrsReviewDependencies).controller
+
+const revealAction: ActionConfig<typeof SRS_REVIEW_CONTEXT> = {
+  id: 'srs-review.reveal',
+  description: 'SRS review: Show answer',
+  context: SRS_REVIEW_CONTEXT,
+  defaultBinding: {keys: ['Space', 'Enter']},
+  handler: deps => { controllerOf(deps).reveal() },
+}
+
+interface GradeBinding {
+  signal: SrsSignal
+  key: string
+  label: string
+  icon: ActionIcon
+}
+
+// Keys are the on-screen 1–4 order (Again/Hard/Good/Easy), which doesn't
+// match the SrsSignal numeric values (GOOD=4, EASY=5), so map explicitly.
+const GRADE_BINDINGS: readonly GradeBinding[] = [
+  {signal: SrsSignal.AGAIN, key: 'Digit1', label: 'Again', icon: RotateCcw},
+  {signal: SrsSignal.HARD, key: 'Digit2', label: 'Hard', icon: Gauge},
+  {signal: SrsSignal.GOOD, key: 'Digit3', label: 'Good', icon: Check},
+  {signal: SrsSignal.EASY, key: 'Digit4', label: 'Easy', icon: Sparkles},
+]
+
+const gradeActions: readonly ActionConfig<typeof SRS_REVIEW_CONTEXT>[] = GRADE_BINDINGS.map(
+  ({signal, key, label, icon}) => ({
+    id: `srs-review.grade.${label.toLowerCase()}`,
+    description: `SRS review: ${label}`,
+    context: SRS_REVIEW_CONTEXT,
+    icon,
+    defaultBinding: {keys: key},
+    handler: (deps: BaseShortcutDependencies) => { controllerOf(deps).grade(signal) },
+  }),
+)
+
+export const srsReviewActions: readonly ActionConfig[] = [revealAction, ...gradeActions]

--- a/src/plugins/srs-review/archive.ts
+++ b/src/plugins/srs-review/archive.ts
@@ -1,0 +1,15 @@
+import type { Block } from '@/data/block'
+import { getBlockTypes } from '@/data/properties.js'
+import { SRS_SM25_TYPE, srsArchivedProp } from '@/plugins/srs-rescheduling'
+
+/** Mark an SRS card archived. Archived cards drop out of the due-cards
+ *  query (`buildDueCardsQuery` excludes `archived: true`), so this is
+ *  how a card leaves review for good. No-op on non-SRS or read-only
+ *  blocks. Returns whether the write happened. */
+export const archiveSrsCard = async (block: Block): Promise<boolean> => {
+  if (block.repo.isReadOnly) return false
+  const data = block.peek() ?? (await block.load())
+  if (!data || !getBlockTypes(data).includes(SRS_SM25_TYPE)) return false
+  await block.set(srsArchivedProp, true)
+  return true
+}

--- a/src/plugins/srs-review/dataExtension.ts
+++ b/src/plugins/srs-review/dataExtension.ts
@@ -1,0 +1,13 @@
+import { propertySchemasFacet, typesFacet } from '@/data/facets.js'
+import type { AppExtension } from '@/extensions/facet.js'
+import {
+  reviewDeckStartedProp,
+  reviewDeckTagProp,
+  srsReviewDeckType,
+} from './schema.ts'
+
+export const srsReviewDataExtension: AppExtension = [
+  propertySchemasFacet.of(reviewDeckTagProp, {source: 'srs-review'}),
+  propertySchemasFacet.of(reviewDeckStartedProp, {source: 'srs-review'}),
+  typesFacet.of(srsReviewDeckType, {source: 'srs-review'}),
+]

--- a/src/plugins/srs-review/deck.ts
+++ b/src/plugins/srs-review/deck.ts
@@ -1,0 +1,25 @@
+import type { Block } from '@/data/block'
+import type { Repo } from '@/data/repo'
+import { getOrCreateKernelPage, kernelPageBlockId } from '@/data/kernelPage.js'
+import { SRS_REVIEW_DECK_TYPE } from './schema.ts'
+
+// Fresh uuid-v5 namespace so each workspace's review deck lands on one
+// deterministic row — re-launching review reuses the same block (and
+// its last-picked deck) rather than spawning a new page each time.
+const REVIEW_DECK_NS = 'c3f1a9d4-2b8e-4f57-bc6a-1e9d8a4f2c70'
+const REVIEW_DECK_ALIAS = 'SRS Review'
+
+export const reviewDeckBlockId = (workspaceId: string): string =>
+  kernelPageBlockId(workspaceId, REVIEW_DECK_NS)
+
+/** Get-or-create the workspace's singleton review-deck page. Shares the
+ *  kernel-page bootstrap (deterministic id, PAGE_TYPE + marker type,
+ *  restore-on-reach) with Recents / Properties / Types. The
+ *  `srs-review-deck` marker is what `SrsReviewDeckRenderer.canRender`
+ *  keys on. */
+export const getOrCreateReviewDeck = (repo: Repo, workspaceId: string): Promise<Block> =>
+  getOrCreateKernelPage(repo, workspaceId, {
+    namespace: REVIEW_DECK_NS,
+    alias: REVIEW_DECK_ALIAS,
+    markerType: SRS_REVIEW_DECK_TYPE,
+  })

--- a/src/plugins/srs-review/dueQuery.ts
+++ b/src/plugins/srs-review/dueQuery.ts
@@ -1,0 +1,61 @@
+import type { TypedBlockQuery } from '@/data/api'
+import { dailyNoteDateProp } from '@/plugins/daily-notes/schema.js'
+import {
+  SRS_SM25_TYPE,
+  srsArchivedProp,
+  srsNextReviewDateProp,
+} from '@/plugins/srs-rescheduling'
+
+/** A tag id can never legitimately be this string, so a `referencedBy`
+ *  filter against it matches nothing. Used when a deck names a tag
+ *  whose page doesn't exist yet — the deck should show zero due cards,
+ *  not (as an unfiltered query would) every due card in the workspace. */
+export const UNRESOLVED_TAG_ID = 'srs-review:unresolved-tag'
+
+/** Start of *tomorrow* at local midnight. A card counts as due when its
+ *  next-review daily note's date is strictly before this — i.e. today
+ *  or any earlier day — independent of any time-of-day component the
+ *  daily-note date might carry. */
+export const dueBoundary = (now: Date = new Date()): Date => {
+  const boundary = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  boundary.setDate(boundary.getDate() + 1)
+  return boundary
+}
+
+export interface DueCardsQueryInput {
+  workspaceId: string
+  /** Tag's block id, or null/undefined for the "all due" deck. Pass
+   *  `UNRESOLVED_TAG_ID` for a named-but-missing tag. */
+  tagBlockId?: string | null
+  /** Tag on the card itself (`self`) vs the card or any ancestor
+   *  (`ancestor`, the page-as-tag default). */
+  scope?: 'self' | 'ancestor'
+  now?: Date
+}
+
+/** SRS cards due today or earlier, optionally scoped to a tag. Built
+ *  entirely from `core.typedBlocks`' existing capabilities:
+ *   - `where … target` traverses the `next-review-date` ref into its
+ *     daily note and compares the daily note's `daily-note:date`.
+ *   - `match … referencedBy` (ancestor scope) is the tag filter.
+ *   - archived cards are EXCLUDED rather than matched on
+ *     `archived: false`: most cards never set the property, and SQL's
+ *     `archived = 0` never matches a NULL (unset) column, so a match
+ *     would drop every card that's never been archived. */
+export const buildDueCardsQuery = ({
+  workspaceId,
+  tagBlockId,
+  scope = 'ancestor',
+  now,
+}: DueCardsQueryInput): TypedBlockQuery => ({
+  workspaceId,
+  types: [SRS_SM25_TYPE],
+  where: {
+    [srsNextReviewDateProp.name]: {
+      target: {[dailyNoteDateProp.name]: {lt: dueBoundary(now)}},
+    },
+  },
+  exclude: [{scope: 'self', where: {[srsArchivedProp.name]: true}}],
+  ...(tagBlockId ? {match: [{scope, referencedBy: {id: tagBlockId}}]} : {}),
+  order: 'created-asc',
+})

--- a/src/plugins/srs-review/dueQuery.ts
+++ b/src/plugins/srs-review/dueQuery.ts
@@ -12,14 +12,19 @@ import {
  *  not (as an unfiltered query would) every due card in the workspace. */
 export const UNRESOLVED_TAG_ID = 'srs-review:unresolved-tag'
 
-/** Start of *tomorrow* at local midnight. A card counts as due when its
- *  next-review daily note's date is strictly before this — i.e. today
- *  or any earlier day — independent of any time-of-day component the
- *  daily-note date might carry. */
+/** UTC midnight of the day after today's *local* calendar date. A card
+ *  counts as due when its next-review daily note's date is strictly
+ *  before this — i.e. today or any earlier day.
+ *
+ *  Daily notes store `daily-note:date` at UTC midnight of their calendar
+ *  day (`Date.parse(`${iso}T00:00:00Z`)`), so the cutoff has to be UTC
+ *  midnight too. A local-midnight cutoff would, west of UTC, encode to
+ *  later than tomorrow's UTC-midnight daily note and pull tomorrow's
+ *  cards into the deck a day early. */
 export const dueBoundary = (now: Date = new Date()): Date => {
-  const boundary = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  boundary.setDate(boundary.getDate() + 1)
-  return boundary
+  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  return new Date(Date.UTC(tomorrow.getFullYear(), tomorrow.getMonth(), tomorrow.getDate()))
 }
 
 export interface DueCardsQueryInput {

--- a/src/plugins/srs-review/index.ts
+++ b/src/plugins/srs-review/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@/shortcuts/types.js'
 import { getBlockTypes } from '@/data/properties.js'
 import { navigateFromGlobalCommand } from '@/utils/navigation.js'
-import { SRS_SM25_TYPE } from '@/plugins/srs-rescheduling'
+import { SRS_SM25_TYPE, srsReschedulingDataExtension } from '@/plugins/srs-rescheduling'
 import { srsReviewDataExtension } from './dataExtension.ts'
 import { SrsReviewDeckRenderer } from './ReviewDeckRenderer.tsx'
 import { srsReviewCardLayoutContribution } from './reviewCardLayout.tsx'
@@ -62,6 +62,15 @@ export const srsReviewPlugin = ({repo}: {repo: Repo}): AppExtension =>
     name: 'SRS review',
     description: 'Deck-based review mode for spaced-repetition cards due today or earlier.',
   }).of([
+    // Bundle the SRS schema/type registrations. The due-cards query and
+    // archive write reference `srsNextReviewDateProp` / `srsArchivedProp`
+    // / SRS_SM25_TYPE, which only `srsReschedulingDataExtension`
+    // registers — so without this, enabling review while the
+    // `srs-rescheduling` toggle is off would make `core.typedBlocks`
+    // throw on the unregistered schemas. FacetContribution dedup is by
+    // reference, so referencing the same extension from both plugins
+    // registers each schema once when both are enabled.
+    srsReschedulingDataExtension,
     srsReviewDataExtension,
     blockRenderersFacet.of(
       {id: 'srsReviewDeck', renderer: SrsReviewDeckRenderer},

--- a/src/plugins/srs-review/index.ts
+++ b/src/plugins/srs-review/index.ts
@@ -13,6 +13,8 @@ import { getBlockTypes } from '@/data/properties.js'
 import { navigateFromGlobalCommand } from '@/utils/navigation.js'
 import { dailyNotesDataExtension } from '@/plugins/daily-notes'
 import { SRS_SM25_TYPE, srsReschedulingDataExtension } from '@/plugins/srs-rescheduling'
+import { referencesDataExtension } from '@/plugins/references/dataExtension.js'
+import { blockTaggingDataExtension } from '@/plugins/block-tagging/dataExtension.js'
 import { srsReviewDataExtension } from './dataExtension.ts'
 import { SrsReviewDeckRenderer } from './ReviewDeckRenderer.tsx'
 import { srsReviewCardLayoutContribution } from './reviewCardLayout.tsx'
@@ -63,19 +65,17 @@ export const srsReviewPlugin = ({repo}: {repo: Repo}): AppExtension =>
     name: 'SRS review',
     description: 'Deck-based review mode for spaced-repetition cards due today or earlier.',
   }).of([
-    // Bundle the schema/type registrations the deck query depends on so
-    // SRS Review keeps working even when its source plugins' toggles are
-    // off. The due-cards query and archive write reference
-    // `srsNextReviewDateProp` / `srsArchivedProp` / SRS_SM25_TYPE (only
-    // `srsReschedulingDataExtension` registers them) and the due query's
-    // `target` predicate compares against `dailyNoteDateProp` (only
-    // `dailyNotesDataExtension` registers it) — without these,
-    // `core.typedBlocks` throws on the unregistered schemas instead of
-    // rendering the deck. FacetContribution dedup is by reference, so
-    // referencing the same extensions here registers each schema once
-    // when the source plugins are also enabled.
+    // SRS Review hard-depends on the spaced-repetition stack: the
+    // due-cards query reads the SRS and daily-note schemas, matches tags
+    // through the references index, and the picker lists tags from the
+    // block-tagging config. Bundle each dependency's data extension so
+    // the deck works whenever review is enabled; FacetContribution dedup
+    // (by reference) keeps every contribution registered exactly once
+    // when the source plugins are independently enabled too.
     srsReschedulingDataExtension,
     dailyNotesDataExtension,
+    referencesDataExtension,
+    blockTaggingDataExtension,
     srsReviewDataExtension,
     blockRenderersFacet.of(
       {id: 'srsReviewDeck', renderer: SrsReviewDeckRenderer},

--- a/src/plugins/srs-review/index.ts
+++ b/src/plugins/srs-review/index.ts
@@ -2,7 +2,7 @@ import { ArchiveX, GraduationCap } from 'lucide-react'
 import type { Repo } from '@/data/repo'
 import type { AppExtension } from '@/extensions/facet.js'
 import { systemToggle } from '@/extensions/togglable.js'
-import { actionsFacet, blockRenderersFacet } from '@/extensions/core.js'
+import { actionContextsFacet, actionsFacet, blockRenderersFacet } from '@/extensions/core.js'
 import { blockLayoutFacet } from '@/extensions/blockInteraction.js'
 import {
   ActionConfig,
@@ -20,6 +20,7 @@ import { SrsReviewDeckRenderer } from './ReviewDeckRenderer.tsx'
 import { srsReviewCardLayoutContribution } from './reviewCardLayout.tsx'
 import { getOrCreateReviewDeck } from './deck.ts'
 import { archiveSrsCard } from './archive.ts'
+import { srsReviewActionContext, srsReviewActions } from './actions.ts'
 
 export const OPEN_SRS_REVIEW_ACTION_ID = 'open_srs_review'
 export const SRS_ARCHIVE_ACTION_ID = 'srs.archive'
@@ -84,6 +85,10 @@ export const srsReviewPlugin = ({repo}: {repo: Repo}): AppExtension =>
     blockLayoutFacet.of(srsReviewCardLayoutContribution, {source: 'srs-review'}),
     actionsFacet.of(openReviewAction(repo), {source: 'srs-review'}),
     actionsFacet.of(srsArchiveAction, {source: 'srs-review'}),
+    // In-session reveal / grade shortcuts: a dedicated modal context the
+    // review surface activates while focused (see ReviewSession).
+    actionContextsFacet.of(srsReviewActionContext, {source: 'srs-review'}),
+    srsReviewActions.map(action => actionsFacet.of(action, {source: 'srs-review'})),
   ])
 
 export {

--- a/src/plugins/srs-review/index.ts
+++ b/src/plugins/srs-review/index.ts
@@ -11,6 +11,7 @@ import {
 } from '@/shortcuts/types.js'
 import { getBlockTypes } from '@/data/properties.js'
 import { navigateFromGlobalCommand } from '@/utils/navigation.js'
+import { dailyNotesDataExtension } from '@/plugins/daily-notes'
 import { SRS_SM25_TYPE, srsReschedulingDataExtension } from '@/plugins/srs-rescheduling'
 import { srsReviewDataExtension } from './dataExtension.ts'
 import { SrsReviewDeckRenderer } from './ReviewDeckRenderer.tsx'
@@ -62,15 +63,19 @@ export const srsReviewPlugin = ({repo}: {repo: Repo}): AppExtension =>
     name: 'SRS review',
     description: 'Deck-based review mode for spaced-repetition cards due today or earlier.',
   }).of([
-    // Bundle the SRS schema/type registrations. The due-cards query and
-    // archive write reference `srsNextReviewDateProp` / `srsArchivedProp`
-    // / SRS_SM25_TYPE, which only `srsReschedulingDataExtension`
-    // registers — so without this, enabling review while the
-    // `srs-rescheduling` toggle is off would make `core.typedBlocks`
-    // throw on the unregistered schemas. FacetContribution dedup is by
-    // reference, so referencing the same extension from both plugins
-    // registers each schema once when both are enabled.
+    // Bundle the schema/type registrations the deck query depends on so
+    // SRS Review keeps working even when its source plugins' toggles are
+    // off. The due-cards query and archive write reference
+    // `srsNextReviewDateProp` / `srsArchivedProp` / SRS_SM25_TYPE (only
+    // `srsReschedulingDataExtension` registers them) and the due query's
+    // `target` predicate compares against `dailyNoteDateProp` (only
+    // `dailyNotesDataExtension` registers it) — without these,
+    // `core.typedBlocks` throws on the unregistered schemas instead of
+    // rendering the deck. FacetContribution dedup is by reference, so
+    // referencing the same extensions here registers each schema once
+    // when the source plugins are also enabled.
     srsReschedulingDataExtension,
+    dailyNotesDataExtension,
     srsReviewDataExtension,
     blockRenderersFacet.of(
       {id: 'srsReviewDeck', renderer: SrsReviewDeckRenderer},

--- a/src/plugins/srs-review/index.ts
+++ b/src/plugins/srs-review/index.ts
@@ -1,0 +1,82 @@
+import { ArchiveX, GraduationCap } from 'lucide-react'
+import type { Repo } from '@/data/repo'
+import type { AppExtension } from '@/extensions/facet.js'
+import { systemToggle } from '@/extensions/togglable.js'
+import { actionsFacet, blockRenderersFacet } from '@/extensions/core.js'
+import { blockLayoutFacet } from '@/extensions/blockInteraction.js'
+import {
+  ActionConfig,
+  ActionContextTypes,
+  BlockShortcutDependencies,
+} from '@/shortcuts/types.js'
+import { getBlockTypes } from '@/data/properties.js'
+import { navigateFromGlobalCommand } from '@/utils/navigation.js'
+import { SRS_SM25_TYPE } from '@/plugins/srs-rescheduling'
+import { srsReviewDataExtension } from './dataExtension.ts'
+import { SrsReviewDeckRenderer } from './ReviewDeckRenderer.tsx'
+import { srsReviewCardLayoutContribution } from './reviewCardLayout.tsx'
+import { getOrCreateReviewDeck } from './deck.ts'
+import { archiveSrsCard } from './archive.ts'
+
+export const OPEN_SRS_REVIEW_ACTION_ID = 'open_srs_review'
+export const SRS_ARCHIVE_ACTION_ID = 'srs.archive'
+
+const openReviewAction = (
+  repo: Repo,
+): ActionConfig<typeof ActionContextTypes.GLOBAL> => ({
+  id: OPEN_SRS_REVIEW_ACTION_ID,
+  description: 'Open SRS review',
+  context: ActionContextTypes.GLOBAL,
+  icon: GraduationCap,
+  handler: async () => {
+    const workspaceId = repo.activeWorkspaceId
+    if (!workspaceId) return
+    const deck = await getOrCreateReviewDeck(repo, workspaceId)
+    navigateFromGlobalCommand(repo, {blockId: deck.id, workspaceId})
+  },
+  defaultBinding: {
+    keys: 'Control+Shift+r',
+  },
+})
+
+// Reusable inline / command-palette archive, gated to SRS cards. The
+// review session has its own button, but exposing the action lets a
+// card be archived from the outline or palette without opening review.
+const srsArchiveAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
+  id: SRS_ARCHIVE_ACTION_ID,
+  description: 'SRS: Archive card',
+  context: ActionContextTypes.NORMAL_MODE,
+  icon: ArchiveX,
+  canRun: ({block}) => {
+    const data = block.peek()
+    return !!data && getBlockTypes(data).includes(SRS_SM25_TYPE)
+  },
+  handler: async ({block}: BlockShortcutDependencies) => {
+    await archiveSrsCard(block)
+  },
+}
+
+export const srsReviewPlugin = ({repo}: {repo: Repo}): AppExtension =>
+  systemToggle({
+    id: 'system:srs-review',
+    name: 'SRS review',
+    description: 'Deck-based review mode for spaced-repetition cards due today or earlier.',
+  }).of([
+    srsReviewDataExtension,
+    blockRenderersFacet.of(
+      {id: 'srsReviewDeck', renderer: SrsReviewDeckRenderer},
+      {source: 'srs-review'},
+    ),
+    blockLayoutFacet.of(srsReviewCardLayoutContribution, {source: 'srs-review'}),
+    actionsFacet.of(openReviewAction(repo), {source: 'srs-review'}),
+    actionsFacet.of(srsArchiveAction, {source: 'srs-review'}),
+  ])
+
+export {
+  SRS_REVIEW_DECK_TYPE,
+  reviewDeckStartedProp,
+  reviewDeckTagProp,
+  srsReviewDeckType,
+} from './schema.ts'
+export { buildDueCardsQuery, dueBoundary } from './dueQuery.ts'
+export { getOrCreateReviewDeck, reviewDeckBlockId } from './deck.ts'

--- a/src/plugins/srs-review/reviewCardLayout.tsx
+++ b/src/plugins/srs-review/reviewCardLayout.tsx
@@ -1,0 +1,35 @@
+import type {
+  BlockLayoutContribution,
+  BlockLayoutSlots,
+} from '@/extensions/blockInteraction.js'
+
+/** Block-context keys the review session sets on the card it's showing
+ *  so the layout below can hide the answer (children) until the user
+ *  reveals it. Mirrors the video-player pattern: a context-gated
+ *  `blockLayoutFacet` contribution that self-gates on a flag the
+ *  surrounding surface sets, and falls through to the default layout
+ *  for every other block. */
+export const SRS_REVIEW_CARD_ID = 'srsReviewCardId'
+export const SRS_REVIEW_REVEALED = 'srsReviewRevealed'
+
+/** Question phase: render the card's own content only, dropping the
+ *  children subtree (the answer). */
+const QuestionOnlyLayout = ({Content}: BlockLayoutSlots) => (
+  <div className="srs-review-card-question min-w-0">
+    <Content />
+  </div>
+)
+
+export const srsReviewCardLayoutContribution: BlockLayoutContribution = ctx => {
+  const cardId = ctx.blockContext?.[SRS_REVIEW_CARD_ID]
+  // Only the card root, and only while its answer is hidden. Once
+  // revealed we return null so the default layout renders content +
+  // children. Descendants never match (their id differs from cardId).
+  if (cardId !== ctx.block.id) return null
+  if (ctx.blockContext?.[SRS_REVIEW_REVEALED]) return null
+  return {
+    id: 'srs-review.question-only',
+    label: 'SRS review question',
+    render: QuestionOnlyLayout,
+  }
+}

--- a/src/plugins/srs-review/reviewCardLayout.tsx
+++ b/src/plugins/srs-review/reviewCardLayout.tsx
@@ -20,16 +20,28 @@ const QuestionOnlyLayout = ({Content}: BlockLayoutSlots) => (
   </div>
 )
 
+/** Answer phase: render content + the children subtree directly. We do
+ *  NOT fall back to the default layout here — its `Collapsible` only
+ *  opens for a non-collapsed or top-level block, and the review surface
+ *  is `isNestedSurface`, so a card that's collapsed in the outline would
+ *  reveal no answer at all. Rendering `Children` raw shows the answer
+ *  regardless of the card's stored collapse state. */
+const AnswerLayout = ({Content, Children}: BlockLayoutSlots) => (
+  <div className="srs-review-card-answer min-w-0">
+    <Content />
+    <Children />
+  </div>
+)
+
 export const srsReviewCardLayoutContribution: BlockLayoutContribution = ctx => {
+  // Only the card root — descendants never match (their id differs from
+  // cardId), so they keep the default layout. The card itself uses a
+  // dedicated layout for each phase rather than ever falling through to
+  // the default (which would respect collapse and could hide the answer).
   const cardId = ctx.blockContext?.[SRS_REVIEW_CARD_ID]
-  // Only the card root, and only while its answer is hidden. Once
-  // revealed we return null so the default layout renders content +
-  // children. Descendants never match (their id differs from cardId).
   if (cardId !== ctx.block.id) return null
-  if (ctx.blockContext?.[SRS_REVIEW_REVEALED]) return null
-  return {
-    id: 'srs-review.question-only',
-    label: 'SRS review question',
-    render: QuestionOnlyLayout,
-  }
+  const revealed = Boolean(ctx.blockContext?.[SRS_REVIEW_REVEALED])
+  return revealed
+    ? {id: 'srs-review.answer', label: 'SRS review answer', render: AnswerLayout}
+    : {id: 'srs-review.question-only', label: 'SRS review question', render: QuestionOnlyLayout}
 }

--- a/src/plugins/srs-review/schema.ts
+++ b/src/plugins/srs-review/schema.ts
@@ -1,0 +1,30 @@
+import { ChangeScope, codecs, defineBlockType, defineProperty } from '@/data/api'
+
+export const SRS_REVIEW_DECK_TYPE = 'srs-review-deck'
+
+/** The tag a deck reviews, stored as the bare page name (matching
+ *  `blockTagsConfigProp`). Resolved to a block id at query time via
+ *  `core.aliasLookup`. Empty string is the "all due" deck — every SRS
+ *  card due today or earlier, regardless of tag. */
+export const reviewDeckTagProp = defineProperty<string>('srs-review:deck-tag', {
+  codec: codecs.string,
+  defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
+/** False until the user picks a deck in the in-place picker; flips the
+ *  deck renderer from the picker to the review session. A persisted
+ *  flag (rather than React state) so reopening the deck block resumes
+ *  the chosen deck instead of dropping back to the picker. The session
+ *  writes it back to false via its "Change deck" affordance. */
+export const reviewDeckStartedProp = defineProperty<boolean>('srs-review:deck-started', {
+  codec: codecs.boolean,
+  defaultValue: false,
+  changeScope: ChangeScope.BlockDefault,
+})
+
+export const srsReviewDeckType = defineBlockType({
+  id: SRS_REVIEW_DECK_TYPE,
+  label: 'SRS review deck',
+  properties: [reviewDeckTagProp, reviewDeckStartedProp],
+})

--- a/src/plugins/srs-review/test/dueQuery.test.ts
+++ b/src/plugins/srs-review/test/dueQuery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { SRS_SM25_TYPE, srsArchivedProp } from '@/plugins/srs-rescheduling'
+import { dailyNoteDateProp } from '@/plugins/daily-notes/schema.js'
+import { srsNextReviewDateProp } from '@/plugins/srs-rescheduling'
+import { UNRESOLVED_TAG_ID, buildDueCardsQuery, dueBoundary } from '../dueQuery.ts'
+
+describe('dueBoundary', () => {
+  it('is the start of the day after `now`, at local midnight', () => {
+    const boundary = dueBoundary(new Date(2026, 5, 1, 14, 30))
+    expect(boundary).toEqual(new Date(2026, 5, 2, 0, 0, 0, 0))
+  })
+})
+
+describe('buildDueCardsQuery', () => {
+  const ws = 'ws-1'
+
+  it('filters SRS cards by due date via a ref-traversal into the daily note', () => {
+    const now = new Date(2026, 5, 1)
+    const q = buildDueCardsQuery({workspaceId: ws, now})
+    expect(q.types).toEqual([SRS_SM25_TYPE])
+    expect(q.where).toEqual({
+      [srsNextReviewDateProp.name]: {
+        target: {[dailyNoteDateProp.name]: {lt: dueBoundary(now)}},
+      },
+    })
+  })
+
+  it('excludes archived cards rather than matching archived:false', () => {
+    // An unset `archived` never equals `false` in SQL, so matching
+    // would drop every never-archived card — exclusion is the only
+    // correct shape here.
+    const q = buildDueCardsQuery({workspaceId: ws})
+    expect(q.exclude).toEqual([
+      {scope: 'self', where: {[srsArchivedProp.name]: true}},
+    ])
+  })
+
+  it('adds an ancestor-scoped tag filter only when a tag id is given', () => {
+    const withTag = buildDueCardsQuery({workspaceId: ws, tagBlockId: 'tag-1'})
+    expect(withTag.match).toEqual([{scope: 'ancestor', referencedBy: {id: 'tag-1'}}])
+
+    const allDue = buildDueCardsQuery({workspaceId: ws})
+    expect(allDue.match).toBeUndefined()
+  })
+
+  it('honours an explicit self scope for the tag filter', () => {
+    const q = buildDueCardsQuery({workspaceId: ws, tagBlockId: 'tag-1', scope: 'self'})
+    expect(q.match).toEqual([{scope: 'self', referencedBy: {id: 'tag-1'}}])
+  })
+
+  it('targets an unresolvable id so a missing tag yields zero, not all cards', () => {
+    const q = buildDueCardsQuery({workspaceId: ws, tagBlockId: UNRESOLVED_TAG_ID})
+    expect(q.match).toEqual([{scope: 'ancestor', referencedBy: {id: UNRESOLVED_TAG_ID}}])
+  })
+})

--- a/src/plugins/srs-review/test/dueQuery.test.ts
+++ b/src/plugins/srs-review/test/dueQuery.test.ts
@@ -5,9 +5,12 @@ import { srsNextReviewDateProp } from '@/plugins/srs-rescheduling'
 import { UNRESOLVED_TAG_ID, buildDueCardsQuery, dueBoundary } from '../dueQuery.ts'
 
 describe('dueBoundary', () => {
-  it('is the start of the day after `now`, at local midnight', () => {
+  it('is UTC midnight of the day after the local date (matching daily-note storage)', () => {
+    // Daily notes store `daily-note:date` at UTC midnight, so the cutoff
+    // must be UTC midnight of tomorrow's local date — not local
+    // midnight, which west of UTC would include tomorrow's cards.
     const boundary = dueBoundary(new Date(2026, 5, 1, 14, 30))
-    expect(boundary).toEqual(new Date(2026, 5, 2, 0, 0, 0, 0))
+    expect(boundary.toISOString()).toBe('2026-06-02T00:00:00.000Z')
   })
 })
 

--- a/src/plugins/srs-review/useDueCards.ts
+++ b/src/plugins/srs-review/useDueCards.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react'
+import type { BlockData } from '@/data/api'
+import { useRepo } from '@/context/repo.js'
+import { useBlockQuery, useHandle } from '@/hooks/block.js'
+import { UNRESOLVED_TAG_ID, buildDueCardsQuery } from './dueQuery.ts'
+
+/** Reactive list of SRS cards due today or earlier for a deck.
+ *
+ *  A non-empty `tagName` is resolved to its page block id via
+ *  `core.aliasLookup`; when the page doesn't exist the deck targets
+ *  `UNRESOLVED_TAG_ID` so it reports zero rather than every due card.
+ *  An empty `tagName` is the "all due" deck (no tag filter). */
+export const useDueCards = (workspaceId: string, tagName: string): BlockData[] => {
+  const repo = useRepo()
+  const alias = tagName.trim()
+  const wantsTag = alias.length > 0
+
+  // aliasLookup short-circuits to null on an empty alias, so the
+  // all-due deck simply gets a null tag id.
+  const resolvedId = useHandle(
+    repo.query.aliasLookup({workspaceId, alias: wantsTag ? alias : ''}),
+    {selector: data => (data ? data.id : null)},
+  ) as string | null
+  const tagBlockId = wantsTag ? (resolvedId ?? UNRESOLVED_TAG_ID) : null
+
+  const query = useMemo(
+    () => buildDueCardsQuery({workspaceId, tagBlockId}),
+    [workspaceId, tagBlockId],
+  )
+  return useBlockQuery(query)
+}

--- a/src/plugins/srs-review/useDueCards.ts
+++ b/src/plugins/srs-review/useDueCards.ts
@@ -1,8 +1,27 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { BlockData } from '@/data/api'
 import { useRepo } from '@/context/repo.js'
 import { useBlockQuery, useHandle } from '@/hooks/block.js'
 import { UNRESOLVED_TAG_ID, buildDueCardsQuery } from './dueQuery.ts'
+
+const startOfLocalDay = (now: Date = new Date()): number =>
+  new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+
+/** Local-midnight timestamp for today, advanced when the date rolls
+ *  over. Polls once a minute (cheap, and only re-renders on the minute
+ *  the day actually changes) so a deck left open overnight refreshes its
+ *  due cutoff instead of staying pinned to yesterday. */
+const useStartOfToday = (): number => {
+  const [ts, setTs] = useState(startOfLocalDay)
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = startOfLocalDay()
+      setTs(prev => (prev === next ? prev : next))
+    }, 60_000)
+    return () => clearInterval(id)
+  }, [])
+  return ts
+}
 
 /** Reactive list of SRS cards due today or earlier for a deck.
  *
@@ -23,9 +42,13 @@ export const useDueCards = (workspaceId: string, tagName: string): BlockData[] =
   ) as string | null
   const tagBlockId = wantsTag ? (resolvedId ?? UNRESOLVED_TAG_ID) : null
 
+  // Drives the due cutoff off today's local midnight, which advances
+  // overnight — so a deck left open past midnight starts surfacing the
+  // newly-due cards instead of staying pinned to yesterday's boundary.
+  const startOfToday = useStartOfToday()
   const query = useMemo(
-    () => buildDueCardsQuery({workspaceId, tagBlockId}),
-    [workspaceId, tagBlockId],
+    () => buildDueCardsQuery({workspaceId, tagBlockId, now: new Date(startOfToday)}),
+    [workspaceId, tagBlockId, startOfToday],
   )
   return useBlockQuery(query)
 }


### PR DESCRIPTION
## What

A roam-memo-style review mode, built as an `srs-review` plugin layered on top of the existing `srs-rescheduling` plugin. You select a tag (or "all due"), and review/reschedule/archive cards in an ergonomic flashcard UI. By default only cards due **today or earlier** appear.

A review **deck is a first-class block** (`srs-review-deck`) with a custom renderer — so it composes inside a panel like any page, and doubles as an immersive full-surface review experience when focused.

## How it works

- **Deck** — a workspace-singleton kernel page (deterministic id, via `getOrCreateKernelPage`, same pattern as Recents/Properties). The in-place **deck picker** lists an "All due" deck plus every tag in the curated tag list (`blockTagsConfigProp`), each with a **live due count**.
- **Due-cards query** — built entirely from `core.typedBlocks`' existing capabilities, no new kernel query:
  - `where … target` traverses each card's `next-review-date` ref into its daily note and compares `daily-note:date` against the start of tomorrow ("due today or earlier").
  - an **ancestor-scoped** `referencedBy` is the tag filter (a tag on the card or any ancestor page).
  - archived cards are **excluded** rather than matched on `archived: false` — an unset `archived` never equals `false` in SQL, so a match would drop every never-archived card.
- **Session** — snapshots the due ids at start (stable order) but reads each card's live state at grade time. Grade via the existing `rescheduleBlock` (**Again / Hard / Good / Easy**, keys `1`–`4`), reschedule via the shared date picker, archive via a reusable `srs.archive` action. The answer (children) stays hidden until revealed, via a context-gated `blockLayoutFacet` contribution (mirrors the video-player layout pattern). Keyboard grading is suppressed while focus is in the editable answer.
- **Launch** — an "Open SRS review" global command + <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>.

No schema migration, no new scheduling math — it reuses the scheduler, toast, daily-note date index, references index, and tag config already in the codebase.

## Files

`src/plugins/srs-review/` — `schema.ts`, `dataExtension.ts`, `dueQuery.ts` (+ `test/`), `useDueCards.ts`, `deck.ts`, `archive.ts`, `reviewCardLayout.tsx`, `DeckPicker.tsx`, `ReviewSession.tsx`, `ReviewDeckRenderer.tsx`, `index.ts`; registered in `staticAppExtensions.ts`.

## Verification

`yarn run check` is green — compile clean, lint 0 errors, **2730/2730 tests pass** (incl. new `dueQuery` tests covering the due-boundary, archived-exclusion, and tag-scope decisions).

https://claude.ai/code/session_013g5NkCB7qSgEZUGiHNmYH6

---
_Generated by [Claude Code](https://claude.ai/code/session_013g5NkCB7qSgEZUGiHNmYH6)_