### PR TITLE
Fix SRS review showing zero due cards (typed-query exclude NULL trap)

### DIFF
--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -472,11 +472,31 @@ describe('repo.queryBlocks', () => {
       })
     }, {scope: ChangeScope.BlockDefault})
 
-    const out = await env.repo.queryBlocks({workspaceId: WS, 
+    const out = await env.repo.queryBlocks({workspaceId: WS,
       where: {status: 'open'},
       match: [{scope: 'ancestor', id: 'parent'}],
     })
     expect(ids(out)).toEqual(['open-child'])
+  })
+
+  it('exclude keeps rows whose filtered property is unset (NULL is not a match)', async () => {
+    // Regression: a scalar `exclude` where compiles to
+    // `json_extract(...) = ?`, which is NULL when the property is
+    // missing. A bare `NOT (NULL)` is NULL — not TRUE — so it used to
+    // drop every row that never set the property, the opposite of the
+    // documented NOR contract ("exclude iff a predicate matches"; an
+    // unknown does not match). This is exactly how SRS due-cards lost
+    // every card that had never been archived.
+    await create({id: 'unset', types: ['todo']})
+    await create({id: 'explicit-false', types: ['todo'], properties: {[doneProp.name]: doneProp.codec.encode(false)}})
+    await create({id: 'explicit-true', types: ['todo'], properties: {[doneProp.name]: doneProp.codec.encode(true)}})
+
+    const out = await env.repo.queryBlocks({
+      workspaceId: WS,
+      types: ['todo'],
+      exclude: [{scope: 'self', where: {[doneProp.name]: true}}],
+    })
+    expect(ids(out).sort()).toEqual(['explicit-false', 'unset'])
   })
 })
 

--- a/src/data/internals/typedBlockQuery.ts
+++ b/src/data/internals/typedBlockQuery.ts
@@ -486,7 +486,16 @@ export const buildCandidatesCte = (
   for (const predicate of excludePredicates) {
     if (!isSelfScope(predicate)) continue
     const compiled = compilePredicateAgainstRow(predicate, 'b', propertySchemas)
-    clauses.push(`NOT (${compiled.sql})`)
+    // `IS NOT TRUE` (not bare `NOT`): exclude a row only when the
+    // predicate is *definitely* true. A scalar `where` over an unset
+    // property compiles to `json_extract(...) = ?`, which is NULL when
+    // the property is missing; `NOT (NULL)` is NULL — not TRUE — so a
+    // bare `NOT` would drop every row that never set the property. The
+    // documented contract is NOR ("exclude iff a predicate matches"),
+    // and an unknown does not match, so unset rows must survive. See
+    // SRS due-cards: `exclude {archived: true}` was silently hiding
+    // every card that had never been archived.
+    clauses.push(`(${compiled.sql}) IS NOT TRUE`)
     params.push(...compiled.params)
   }
 
@@ -553,7 +562,12 @@ export const compileTypedBlockQuery = (
   for (const predicate of excludePredicates) {
     if (isSelfScope(predicate)) continue
     const compiled = compileScopedPredicate(predicate, propertySchemas)
-    filterClauses.push(`NOT (${compiled.sql})`)
+    // `IS NOT TRUE` for the same NULL-safety reason as the self-scope
+    // exclude above. The ancestor predicate compiles to `EXISTS(...)`
+    // (always 0/1, so `IS NOT TRUE` == `NOT` here), but keeping both
+    // exclude sites identical avoids a latent trap if the shape ever
+    // changes.
+    filterClauses.push(`(${compiled.sql}) IS NOT TRUE`)
     params.push(...compiled.params)
   }
 

--- a/src/plugins/srs-review/test/dueCards.integration.test.ts
+++ b/src/plugins/srs-review/test/dueCards.integration.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+//
+// End-to-end coverage for the SRS due-cards query against a real DB.
+// The sibling `dueQuery.test.ts` only asserts the query *shape*, which
+// is why it never caught that a never-archived card was silently
+// excluded — the bug lived in the query engine's three-valued handling
+// of `exclude`, not in the query we build. These tests run the actual
+// query so that regression stays caught.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveFacetRuntimeSync } from '@/extensions/facet'
+import { ChangeScope, type BlockReference } from '@/data/api'
+import { BlockCache } from '@/data/blockCache'
+import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { typesProp } from '@/data/properties'
+import { propertySchemasFacet, typesFacet } from '@/data/facets'
+import { kernelDataExtension } from '@/data/kernelDataExtension'
+import { Repo } from '@/data/repo'
+import { dailyNoteDateProp, dailyNoteType, DAILY_NOTE_TYPE } from '@/plugins/daily-notes/schema.ts'
+import {
+  SRS_SM25_TYPE,
+  srsSm25Type,
+  srsNextReviewDateProp,
+  srsArchivedProp,
+} from '@/plugins/srs-rescheduling/schema.ts'
+import { buildDueCardsQuery } from '../dueQuery.ts'
+
+const WS = 'ws-1'
+const NOW = new Date('2026-06-02T12:00:00')
+
+interface Harness { h: TestDb; repo: Repo }
+
+const setup = async (): Promise<Harness> => {
+  const h = await createTestDb()
+  const cache = new BlockCache()
+  let timeCursor = 1700_000_000_000
+  let idCursor = 0
+  const repo = new Repo({
+    db: h.db,
+    cache,
+    user: {id: 'user-1'},
+    now: () => ++timeCursor,
+    newId: () => `gen-${++idCursor}`,
+    registerKernelProcessors: false,
+  })
+  repo.setFacetRuntime(resolveFacetRuntimeSync([
+    kernelDataExtension,
+    typesFacet.of(dailyNoteType, {source: 'test'}),
+    typesFacet.of(srsSm25Type, {source: 'test'}),
+    propertySchemasFacet.of(dailyNoteDateProp, {source: 'test'}),
+    propertySchemasFacet.of(srsNextReviewDateProp, {source: 'test'}),
+    propertySchemasFacet.of(srsArchivedProp, {source: 'test'}),
+  ]))
+  repo.setActiveWorkspaceId(WS)
+  return {h, repo}
+}
+
+let env: Harness
+beforeEach(async () => { env = await setup() })
+afterEach(async () => { await env.h.cleanup() })
+
+const create = async (args: {
+  id: string
+  parentId?: string | null
+  types?: readonly string[]
+  properties?: Record<string, unknown>
+  references?: BlockReference[]
+}) => {
+  const properties = {...(args.properties ?? {})}
+  if (args.types !== undefined) {
+    properties[typesProp.name] = typesProp.codec.encode(args.types)
+  }
+  await env.repo.tx(tx => tx.create({
+    id: args.id,
+    workspaceId: WS,
+    parentId: args.parentId ?? null,
+    orderKey: `k-${args.id}`,
+    properties,
+    references: args.references ?? [],
+  }), {scope: ChangeScope.BlockDefault})
+}
+
+const dailyNote = (id: string, iso: string) =>
+  create({
+    id,
+    types: [DAILY_NOTE_TYPE],
+    properties: {
+      alias: [iso],
+      [dailyNoteDateProp.name]: dailyNoteDateProp.codec.encode(new Date(`${iso}T00:00:00.000Z`)),
+    },
+  })
+
+const card = (id: string, dueNoteId: string, opts: {parentId?: string | null; archived?: boolean} = {}) =>
+  create({
+    id,
+    parentId: opts.parentId ?? null,
+    types: [SRS_SM25_TYPE],
+    properties: {
+      [srsNextReviewDateProp.name]: srsNextReviewDateProp.codec.encode(dueNoteId),
+      ...(opts.archived === undefined
+        ? {}
+        : {[srsArchivedProp.name]: srsArchivedProp.codec.encode(opts.archived)}),
+    },
+    references: [{id: dueNoteId, alias: dueNoteId, sourceField: srsNextReviewDateProp.name}],
+  })
+
+const runIds = async (...args: Parameters<typeof buildDueCardsQuery>) =>
+  (await env.repo.queryBlocks(buildDueCardsQuery(...args))).map(b => b.id)
+
+describe('SRS due cards (end-to-end)', () => {
+  it('surfaces a never-archived card whose review date is in the past', async () => {
+    await dailyNote('dn-past', '2026-05-01')
+    await card('card1', 'dn-past') // archived never set — the common case
+
+    expect(await runIds({workspaceId: WS, tagBlockId: null, now: NOW})).toEqual(['card1'])
+  })
+
+  it('keeps due cards but drops the archived one', async () => {
+    await dailyNote('dn-past', '2026-05-01')
+    await card('live', 'dn-past')
+    await card('archived', 'dn-past', {archived: true})
+
+    expect(await runIds({workspaceId: WS, tagBlockId: null, now: NOW})).toEqual(['live'])
+  })
+
+  it('excludes cards whose review date is today-or-later', async () => {
+    await dailyNote('dn-past', '2026-05-01')
+    await dailyNote('dn-future', '2026-07-01')
+    await card('due', 'dn-past')
+    await card('not-due', 'dn-future')
+
+    expect(await runIds({workspaceId: WS, tagBlockId: null, now: NOW})).toEqual(['due'])
+  })
+
+  it('scopes to a page-as-tag via ancestor scope', async () => {
+    await create({id: 'roam-page', types: [DAILY_NOTE_TYPE], properties: {alias: ['Roam']}})
+    await dailyNote('dn-past', '2026-05-01')
+    await card('on-roam', 'dn-past', {parentId: 'roam-page'})
+    await card('off-roam', 'dn-past')
+
+    expect(await runIds({workspaceId: WS, tagBlockId: 'roam-page', now: NOW})).toEqual(['on-roam'])
+  })
+})


### PR DESCRIPTION
## Problem

The SRS review decks reported **0 due** for every deck — the "all due" deck and every tag-scoped deck (e.g. `Roam`) — even when there were plenty of cards with past review dates.

## Root cause

It's the query engine's handling of `exclude`, exactly the "filters" hunch.

The due-cards query deliberately drops archived cards via:

```ts
exclude: [{scope: 'self', where: {[srsArchivedProp.name]: true}}]
```

A scalar `where` compiles to `json_extract(b.properties_json, '$."archived"') = ?`. For the common case — a card that **never set** `archived` — `json_extract` returns `NULL`, so the predicate is `NULL = true` → `NULL`. The compiler then wrapped the predicate in a bare `NOT (...)`, and `NOT (NULL)` is `NULL`, which SQLite does **not** treat as true. So the row was filtered out.

Net effect: every card that had never been archived (i.e. almost all of them) was silently excluded → 0 due everywhere. This is the symmetric twin of the `archived = false` NULL trap that the due-query comment was already trying to avoid by switching to `exclude`; the engine just had the same trap on the `NOT` side.

The documented contract for `exclude` is NOR — "a block matches iff none of these match" — and an *unknown* does not match, so unset rows must survive.

## Fix

Compile both exclude sites as `(<predicate>) IS NOT TRUE` instead of `NOT (<predicate>)`, so a row is removed only when the predicate is **definitely true**; `false` and `unknown (NULL)` rows survive. The ancestor-scope exclude wraps an `EXISTS(...)` (always 0/1) so it's a no-op there, but both sites are kept identical to avoid a latent trap.

This is a general query-engine fix, not SRS-specific — any `exclude` with a scalar filter over an optionally-set property was affected.

## Tests

- **Engine regression** (`typedBlockQuery.test.ts`): an `exclude {prop: true}` keeps rows where the prop is unset or explicitly `false`, and only drops the explicit-`true` row.
- **End-to-end SRS due-cards** (`srs-review/test/dueCards.integration.test.ts`): runs the real `buildDueCardsQuery` against the production client schema via the `@powersync/node` test DB — covers never-archived cards surfacing, archived cards dropped, due-date filtering, and page-as-tag scoping. (The pre-existing `dueQuery.test.ts` only asserted the query *shape*, which is why it never caught this.)

## Verification

- `tsc -b` clean, eslint clean on touched files.
- Targeted suites green: `typedBlockQuery` / `kernelQueries` / `kernelInvalidation` (153), and all `srs-review` / `srs-rescheduling` / `daily-notes` suites (145).
- Browser smoke test: booted the app in local-only mode and opened the review deck (Ctrl+Shift+R) — the deck UI renders cleanly with no console errors and the due query runs. (A fresh local workspace has no cards, and the scheduler's 1-day minimum interval means a *today*-due card can't be minted purely through the UI, so behavioral correctness is covered by the integration test above.)

https://claude.ai/code/session_013g5NkCB7qSgEZUGiHNmYH6

---
_Generated by [Claude Code](https://claude.ai/code/session_013g5NkCB7qSgEZUGiHNmYH6)_