### PR TITLE
Harden typed-query exclude against the NULL trap recurring

### DIFF
--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -479,24 +479,63 @@ describe('repo.queryBlocks', () => {
     expect(ids(out)).toEqual(['open-child'])
   })
 
-  it('exclude keeps rows whose filtered property is unset (NULL is not a match)', async () => {
-    // Regression: a scalar `exclude` where compiles to
-    // `json_extract(...) = ?`, which is NULL when the property is
-    // missing. A bare `NOT (NULL)` is NULL — not TRUE — so it used to
-    // drop every row that never set the property, the opposite of the
-    // documented NOR contract ("exclude iff a predicate matches"; an
-    // unknown does not match). This is exactly how SRS due-cards lost
-    // every card that had never been archived.
-    await create({id: 'unset', types: ['todo']})
-    await create({id: 'explicit-false', types: ['todo'], properties: {[doneProp.name]: doneProp.codec.encode(false)}})
-    await create({id: 'explicit-true', types: ['todo'], properties: {[doneProp.name]: doneProp.codec.encode(true)}})
+  // The shared invariant: a predicate over a property a row never set
+  // is *unknown*, not a match — so an unset row is kept by `exclude` and
+  // dropped by `match` (the documented NOR/AND contract). Each operator
+  // seeds an unset row alongside a matching and a non-matching one and
+  // checks both sides. The `exclude` half is the regression guard for
+  // the SRS due-cards bug (a bare `NOT` dropped unset rows); covering
+  // every operator keeps the symmetric NULL trap from creeping back in
+  // through a new code path.
+  describe('match / exclude treat an unset property as not-a-match', () => {
+    const matchSelf = (predicate: object) =>
+      env.repo.queryBlocks({workspaceId: WS, types: ['todo'], match: [{scope: 'self', ...predicate}]})
+    const excludeSelf = (predicate: object) =>
+      env.repo.queryBlocks({workspaceId: WS, types: ['todo'], exclude: [{scope: 'self', ...predicate}]})
 
-    const out = await env.repo.queryBlocks({
-      workspaceId: WS,
-      types: ['todo'],
-      exclude: [{scope: 'self', where: {[doneProp.name]: true}}],
+    it('scalar string equality', async () => {
+      await create({id: 'unset', types: ['todo']})
+      await create({id: 'hit', types: ['todo'], properties: {status: 'open'}})
+      await create({id: 'miss', types: ['todo'], properties: {status: 'done'}})
+
+      expect(ids(await matchSelf({where: {status: 'open'}}))).toEqual(['hit'])
+      expect(ids(await excludeSelf({where: {status: 'open'}})).sort()).toEqual(['miss', 'unset'])
     })
-    expect(ids(out).sort()).toEqual(['explicit-false', 'unset'])
+
+    it('boolean equality (the archived shape)', async () => {
+      await create({id: 'unset', types: ['todo']})
+      await create({id: 'true-row', types: ['todo'], properties: {[doneProp.name]: doneProp.codec.encode(true)}})
+      await create({id: 'false-row', types: ['todo'], properties: {[doneProp.name]: doneProp.codec.encode(false)}})
+
+      expect(ids(await matchSelf({where: {[doneProp.name]: true}}))).toEqual(['true-row'])
+      expect(ids(await excludeSelf({where: {[doneProp.name]: true}})).sort()).toEqual(['false-row', 'unset'])
+    })
+
+    it('comparator (lt) on a number', async () => {
+      await create({id: 'unset', types: ['todo']})
+      await create({id: 'low', types: ['todo'], properties: {[priorityProp.name]: priorityProp.codec.encode(1)}})
+      await create({id: 'high', types: ['todo'], properties: {[priorityProp.name]: priorityProp.codec.encode(9)}})
+
+      expect(ids(await matchSelf({where: {[priorityProp.name]: {lt: 5}}}))).toEqual(['low'])
+      expect(ids(await excludeSelf({where: {[priorityProp.name]: {lt: 5}}})).sort()).toEqual(['high', 'unset'])
+    })
+
+    it('exists', async () => {
+      await create({id: 'unset', types: ['todo']})
+      await create({id: 'set', types: ['todo'], properties: {status: 'x'}})
+
+      expect(ids(await matchSelf({where: {status: {exists: true}}}))).toEqual(['set'])
+      expect(ids(await excludeSelf({where: {status: {exists: true}}}))).toEqual(['unset'])
+    })
+
+    it('referencedBy', async () => {
+      await create({id: 'target', types: ['todo']})
+      await create({id: 'unset', types: ['todo']}) // no references at all
+      await create({id: 'refs', types: ['todo'], references: [{id: 'target', alias: 'target', sourceField: 'body'}]})
+
+      expect(ids(await matchSelf({referencedBy: {id: 'target'}}))).toEqual(['refs'])
+      expect(ids(await excludeSelf({referencedBy: {id: 'target'}})).sort()).toEqual(['target', 'unset'])
+    })
   })
 })
 

--- a/src/data/internals/typedBlockQuery.ts
+++ b/src/data/internals/typedBlockQuery.ts
@@ -337,6 +337,18 @@ const compileScopedPredicate = (
   }
 }
 
+/** NULL-safe negation for `exclude` predicates. Per the documented NOR
+ *  contract ("a block matches iff none of these match"), a row is
+ *  removed only when the predicate is *definitely* true — `false` and
+ *  `unknown` survive. A scalar `where` over an unset property compiles
+ *  to `json_extract(...) = ?`, which is NULL when the property is
+ *  missing, and a bare `NOT (NULL)` is NULL — not TRUE — so it would
+ *  drop every row that never set the property (this is what silently
+ *  zeroed out the SRS due-cards decks via `exclude {archived: true}`).
+ *  `(... ) IS NOT TRUE` keeps unknown rows. Route every exclude site
+ *  through here so the trap can't reappear at a new call site. */
+const excludeNegation = (compiledSql: string): string => `(${compiledSql}) IS NOT TRUE`
+
 const dedupePredicates = (predicates: readonly BlockPredicate[] | undefined): BlockPredicate[] => {
   if (!predicates) return []
   return predicates.filter(p => {
@@ -486,16 +498,7 @@ export const buildCandidatesCte = (
   for (const predicate of excludePredicates) {
     if (!isSelfScope(predicate)) continue
     const compiled = compilePredicateAgainstRow(predicate, 'b', propertySchemas)
-    // `IS NOT TRUE` (not bare `NOT`): exclude a row only when the
-    // predicate is *definitely* true. A scalar `where` over an unset
-    // property compiles to `json_extract(...) = ?`, which is NULL when
-    // the property is missing; `NOT (NULL)` is NULL — not TRUE — so a
-    // bare `NOT` would drop every row that never set the property. The
-    // documented contract is NOR ("exclude iff a predicate matches"),
-    // and an unknown does not match, so unset rows must survive. See
-    // SRS due-cards: `exclude {archived: true}` was silently hiding
-    // every card that had never been archived.
-    clauses.push(`(${compiled.sql}) IS NOT TRUE`)
+    clauses.push(excludeNegation(compiled.sql))
     params.push(...compiled.params)
   }
 
@@ -562,12 +565,10 @@ export const compileTypedBlockQuery = (
   for (const predicate of excludePredicates) {
     if (isSelfScope(predicate)) continue
     const compiled = compileScopedPredicate(predicate, propertySchemas)
-    // `IS NOT TRUE` for the same NULL-safety reason as the self-scope
-    // exclude above. The ancestor predicate compiles to `EXISTS(...)`
-    // (always 0/1, so `IS NOT TRUE` == `NOT` here), but keeping both
-    // exclude sites identical avoids a latent trap if the shape ever
-    // changes.
-    filterClauses.push(`(${compiled.sql}) IS NOT TRUE`)
+    // The ancestor predicate compiles to `EXISTS(...)` (always 0/1, so
+    // the NULL-safety is a no-op here), but routing through the same
+    // helper keeps both exclude sites identical if the shape changes.
+    filterClauses.push(excludeNegation(compiled.sql))
     params.push(...compiled.params)
   }
 

--- a/src/plugins/srs-review/test/dueCards.integration.test.ts
+++ b/src/plugins/srs-review/test/dueCards.integration.test.ts
@@ -22,7 +22,7 @@ import {
   srsNextReviewDateProp,
   srsArchivedProp,
 } from '@/plugins/srs-rescheduling/schema.ts'
-import { buildDueCardsQuery } from '../dueQuery.ts'
+import { UNRESOLVED_TAG_ID, buildDueCardsQuery } from '../dueQuery.ts'
 
 const WS = 'ws-1'
 const NOW = new Date('2026-06-02T12:00:00')
@@ -138,5 +138,37 @@ describe('SRS due cards (end-to-end)', () => {
     await card('off-roam', 'dn-past')
 
     expect(await runIds({workspaceId: WS, tagBlockId: 'roam-page', now: NOW})).toEqual(['on-roam'])
+  })
+
+  it('self scope matches the card itself, not just an ancestor page', async () => {
+    // The default ancestor scope treats "card lives under page X" as a
+    // tag hit; self scope is stricter — only a card that *itself*
+    // references the tag counts.
+    await create({id: 'roam-page', types: [DAILY_NOTE_TYPE], properties: {alias: ['Roam']}})
+    await dailyNote('dn-past', '2026-05-01')
+    await create({
+      id: 'direct',
+      types: [SRS_SM25_TYPE],
+      properties: {[srsNextReviewDateProp.name]: srsNextReviewDateProp.codec.encode('dn-past')},
+      references: [
+        {id: 'dn-past', alias: 'dn-past', sourceField: srsNextReviewDateProp.name},
+        {id: 'roam-page', alias: 'Roam', sourceField: 'body'},
+      ],
+    })
+    await card('under-page-only', 'dn-past', {parentId: 'roam-page'})
+
+    expect(await runIds({workspaceId: WS, tagBlockId: 'roam-page', scope: 'self', now: NOW}))
+      .toEqual(['direct'])
+  })
+
+  it('a named-but-missing tag yields zero, not every due card', async () => {
+    // useDueCards maps an unresolvable tag name to UNRESOLVED_TAG_ID so
+    // a typo'd / not-yet-created tag page reports an empty deck instead
+    // of falling through to the unfiltered "all due" set.
+    await dailyNote('dn-past', '2026-05-01')
+    await card('c1', 'dn-past')
+    await card('c2', 'dn-past')
+
+    expect(await runIds({workspaceId: WS, tagBlockId: UNRESOLVED_TAG_ID, now: NOW})).toEqual([])
   })
 })

--- a/src/plugins/srs-review/test/dueQuery.test.ts
+++ b/src/plugins/srs-review/test/dueQuery.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { SRS_SM25_TYPE, srsArchivedProp } from '@/plugins/srs-rescheduling'
-import { dailyNoteDateProp } from '@/plugins/daily-notes/schema.js'
-import { srsNextReviewDateProp } from '@/plugins/srs-rescheduling'
-import { UNRESOLVED_TAG_ID, buildDueCardsQuery, dueBoundary } from '../dueQuery.ts'
+import { dueBoundary } from '../dueQuery.ts'
 
+// The query *shape* used to be asserted here (e.g. `expect(q.exclude)
+// .toEqual(...)`), but those tests just re-stated the builder and gave
+// false confidence — they passed while the compiled query returned zero
+// due cards. Behavior is now covered end-to-end against a real DB in
+// `dueCards.integration.test.ts`. Only `dueBoundary` keeps a unit test:
+// it's a non-trivial date computation, not a re-statement of code.
 describe('dueBoundary', () => {
   it('is UTC midnight of the day after the local date (matching daily-note storage)', () => {
     // Daily notes store `daily-note:date` at UTC midnight, so the cutoff
@@ -11,48 +14,5 @@ describe('dueBoundary', () => {
     // midnight, which west of UTC would include tomorrow's cards.
     const boundary = dueBoundary(new Date(2026, 5, 1, 14, 30))
     expect(boundary.toISOString()).toBe('2026-06-02T00:00:00.000Z')
-  })
-})
-
-describe('buildDueCardsQuery', () => {
-  const ws = 'ws-1'
-
-  it('filters SRS cards by due date via a ref-traversal into the daily note', () => {
-    const now = new Date(2026, 5, 1)
-    const q = buildDueCardsQuery({workspaceId: ws, now})
-    expect(q.types).toEqual([SRS_SM25_TYPE])
-    expect(q.where).toEqual({
-      [srsNextReviewDateProp.name]: {
-        target: {[dailyNoteDateProp.name]: {lt: dueBoundary(now)}},
-      },
-    })
-  })
-
-  it('excludes archived cards rather than matching archived:false', () => {
-    // An unset `archived` never equals `false` in SQL, so matching
-    // would drop every never-archived card — exclusion is the only
-    // correct shape here.
-    const q = buildDueCardsQuery({workspaceId: ws})
-    expect(q.exclude).toEqual([
-      {scope: 'self', where: {[srsArchivedProp.name]: true}},
-    ])
-  })
-
-  it('adds an ancestor-scoped tag filter only when a tag id is given', () => {
-    const withTag = buildDueCardsQuery({workspaceId: ws, tagBlockId: 'tag-1'})
-    expect(withTag.match).toEqual([{scope: 'ancestor', referencedBy: {id: 'tag-1'}}])
-
-    const allDue = buildDueCardsQuery({workspaceId: ws})
-    expect(allDue.match).toBeUndefined()
-  })
-
-  it('honours an explicit self scope for the tag filter', () => {
-    const q = buildDueCardsQuery({workspaceId: ws, tagBlockId: 'tag-1', scope: 'self'})
-    expect(q.match).toEqual([{scope: 'self', referencedBy: {id: 'tag-1'}}])
-  })
-
-  it('targets an unresolvable id so a missing tag yields zero, not all cards', () => {
-    const q = buildDueCardsQuery({workspaceId: ws, tagBlockId: UNRESOLVED_TAG_ID})
-    expect(q.match).toEqual([{scope: 'ancestor', referencedBy: {id: UNRESOLVED_TAG_ID}}])
   })
 })


### PR DESCRIPTION
Follow-up to #87 (the SRS "0 due" fix). #87 fixed the bug; this PR adds guardrails so the same three-valued-logic (NULL) trap is less likely to slip through again. **Stacked on #87** — its base will retarget to `master` once #87 merges, and the diff here is just the hardening.

## Why this is needed

Two things let the original bug ship:
1. The query engine's NULL handling for `exclude` was wrong in one spot — and nothing structurally stopped a *second* spot from being wrong the same way.
2. `dueQuery.test.ts` only asserted the query *object's shape* (`expect(q.exclude).toEqual(...)`). That's the "tests that re-state the code" anti-pattern — it passed happily while the compiled query returned zero due cards, because the bug lived one layer down in the SQL compiler.

## Changes

1. **Centralize the NULL-safe negation.** Both exclude sites (self- and ancestor-scope) now go through a single `excludeNegation(sql)` → `(sql) IS NOT TRUE` helper, with the rationale documented once. A future third exclude call site can't quietly reintroduce a bare `NOT (...)`.

2. **Operator × unset-value matrix test** (`typedBlockQuery.test.ts`). For scalar-string equality, boolean equality (the `archived` shape), `lt`, `exists`, and `referencedBy`, seed an *unset* row alongside a matching and a non-matching one and assert both sides: `match` drops the unset row, `exclude` keeps it. The "unset" axis is the one fixtures rarely add by reflex, and it's exactly where these traps hide.

3. **Retire the shape-only `dueQuery.test.ts` assertions.** Replaced with behavioral coverage against a real DB in `dueCards.integration.test.ts` (self-scope tag matching: a card that itself references the tag matches, one merely living under the page does not; and an unresolvable tag yields zero rather than all due cards). Only `dueBoundary` keeps a unit test — it's a non-trivial date computation, not a re-statement of code.

## Verification

- `tsc -b` clean; eslint clean on touched files.
- `typedBlockQuery.test.ts` (36), `dueCards.integration.test.ts` + `dueQuery.test.ts` (7) all green.

https://claude.ai/code/session_013g5NkCB7qSgEZUGiHNmYH6

---
_Generated by [Claude Code](https://claude.ai/code/session_013g5NkCB7qSgEZUGiHNmYH6)_