### PR TITLE
Update stale comments claiming UI-state blocks don't sync

### DIFF
--- a/src/components/workspace/WorkspaceSettingsDialog.tsx
+++ b/src/components/workspace/WorkspaceSettingsDialog.tsx
@@ -25,7 +25,7 @@ type InviteRole = Exclude<WorkspaceRole, 'owner'>
 
 const INVITE_ROLES: ReadonlyArray<{value: InviteRole, label: string, hint: string}> = [
   {value: 'editor', label: 'Editor', hint: 'Can read and edit the workspace.'},
-  {value: 'viewer', label: 'Viewer', hint: 'Read-only access; UI navigation state stays local to their session.'},
+  {value: 'viewer', label: 'Viewer', hint: 'Read-only access; cannot modify the workspace.'},
 ]
 
 const roleSelectClassName =

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -297,9 +297,10 @@ export interface RepoOptions {
   db: PowerSyncDb
   cache: BlockCache
   user: User
-  /** Read-only mode disables `BlockDefault` / `References` writes.
-   *  `UiState` stays local-only and `UserPrefs` degrades to local-only.
-   *  Default false. */
+  /** Read-only mode rejects `BlockDefault` / `References` writes
+   *  (`ReadOnlyError`). `UiState` and `UserPrefs` writes still proceed
+   *  and upload like any other write — any server-side RLS / FK
+   *  rejection lands in the upload-rejection quarantine. Default false. */
   isReadOnly?: boolean
   /** Now provider — default `Date.now`. Injected for test determinism. */
   now?: () => number
@@ -1055,8 +1056,9 @@ export class Repo {
   /** Toggle read-only mode. Wrapping the field write in a method
    *  keeps call sites that come from inside React hooks lint-clean
    *  (`react-hooks/immutability` flags direct property writes on
-   *  hook outputs). UI-state writes still pass through regardless of
-   *  this flag; UserPrefs writes pass through but stop uploading. */
+   *  hook outputs). UI-state and UserPrefs writes still pass through
+   *  and upload regardless of this flag; only `BlockDefault` /
+   *  `References` writes are rejected. */
   setReadOnly(value: boolean): void {
     this.isReadOnly = value
   }

--- a/src/data/stateBlocks.ts
+++ b/src/data/stateBlocks.ts
@@ -367,10 +367,10 @@ export const getLayoutSessionBlock = memoize(
 )
 
 /** Per-plugin ui-state sub-block under the root ui-state block. The
- *  mirror of `getPluginPrefsBlock` for state that is persistent but
- *  per-device (and therefore should NOT sync) — e.g. "what blocks did
- *  the user open recently on this device". Writes flow through
- *  `ChangeScope.UiState` so they stay out of the upload queue. */
+ *  mirror of `getPluginPrefsBlock` for persistent UI state — e.g.
+ *  "what blocks did the user open recently". Writes flow through
+ *  `ChangeScope.UiState`: not undoable, but they upload and sync
+ *  across devices like any other write. */
 export const getPluginUIStateBlock = memoize(
   async (
     repo: Repo,


### PR DESCRIPTION
UI-state writes used to land with source='local-ephemeral' and bypass
the upload queue. Phase 2 unified all repo.tx writes to source='user',
so UiState blocks now upload and sync like any other write. Refresh the
in-code comments and one user-facing role hint that still claimed UI
state stayed local-only:

- stateBlocks.ts: per-plugin UI-state block now syncs across devices
- repo.ts: read-only mode still allows UiState/UserPrefs writes, which
  upload normally (server-side RLS/FK rejections quarantine)
- WorkspaceSettingsDialog.tsx: drop stale 'navigation state stays local'
  from the viewer role hint

Docs in docs/ left as-is; they are historical.