### PR TITLE
SRS review: faster breadcrumbs, persisted per-deck sessions, promote-in-place

### DIFF
--- a/src/data/globalState.ts
+++ b/src/data/globalState.ts
@@ -35,6 +35,7 @@ import {
   getLayoutSessionBlock,
   getPluginPrefsBlock,
   getPluginUIStateBlock,
+  getPluginUIStateChild,
   getUIStateBlock,
   getUserBlock,
   requireSchemaScope,
@@ -150,6 +151,14 @@ export function usePluginUIStateBlock(type: TypeContribution): Block {
   const workspaceId = requireWorkspaceId(repo, 'usePluginUIStateBlock')
 
   return use(getPluginUIStateBlock(repo, workspaceId, user, type))
+}
+
+/** Resolve a per-`key` child of the plugin's ui-state sub-block, for
+ *  plugins that partition their ui-state (e.g. one frozen review session
+ *  per deck, keyed by deck id) instead of overloading a single block. The
+ *  child is bootstrapped on first access. */
+export function usePluginUIStateChildBlock(type: TypeContribution, key: string): Block {
+  return use(getPluginUIStateChild(usePluginUIStateBlock(type), key))
 }
 
 /** Read/write a ui-state property on the plugin's own ui-state

--- a/src/data/stateBlocks.ts
+++ b/src/data/stateBlocks.ts
@@ -393,6 +393,18 @@ export const getPluginUIStateBlock = memoize(
     `${repoIdentity(repo)}:${workspaceId}:${user.id}:plugin-ui-state:${type.id}`,
 )
 
+/** A per-key child under a plugin's ui-state sub-block, so a plugin can
+ *  partition its ui-state (e.g. one frozen review session per deck)
+ *  instead of overloading a single block and discriminating by hand.
+ *  Inherits the parent's `ChangeScope.UiState` (undo-segregated from
+ *  document edits). Mirrors `getLayoutSessionBlock`. */
+export const getPluginUIStateChild = memoize(
+  async (pluginUIStateBlock: Block, key: string): Promise<Block> =>
+    ensureUiChild(pluginUIStateBlock.repo, pluginUIStateBlock, key),
+  (pluginUIStateBlock, key) =>
+    `${repoIdentity(pluginUIStateBlock.repo)}:${pluginUIStateBlock.id}:${key}`,
+)
+
 // ──── Selection-state helpers (pure operations on a Block) ────
 
 /** Sync selection-state read; doesn't subscribe — for use in

--- a/src/plugins/backlinks/BacklinkEntry.tsx
+++ b/src/plugins/backlinks/BacklinkEntry.tsx
@@ -1,15 +1,14 @@
-import { useCallback, useMemo, useState, type MouseEvent } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Block } from '@/data/block'
 import { BlockLoadingPlaceholder } from '@/components/BlockLoadingPlaceholder.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
-import { BreadcrumbList } from '@/plugins/breadcrumbs/BreadcrumbList.js'
+import { PromotableBreadcrumbList } from '@/plugins/breadcrumbs/PromotableBreadcrumbList.js'
+import { usePromotableBreadcrumb } from '@/plugins/breadcrumbs/usePromotableBreadcrumb.js'
 import { NestedBlockContextProvider, useBlockContext } from '@/context/block.js'
 import { LazyViewportMount } from '@/components/util/LazyViewportMount.js'
 import type { LazyViewportPlaceholderProps } from '@/components/util/LazyViewportMount.js'
 import { useParents } from '@/hooks/block.js'
 import { useRepo } from '@/context/repo.js'
-import { useBlockOpener } from '@/utils/navigation.js'
-import { withMoveTransition } from '@/utils/viewTransition.js'
 import {
   backlinkEntryShortcutContextOverrides,
   promoteClosestBreadcrumb,
@@ -24,32 +23,6 @@ const BACKLINK_OVERSCAN_PX = 600
 const BACKLINK_BLOCK_PLACEHOLDER_HEIGHT_PX = 32
 
 const EMPTY_PARENTS: readonly Block[] = []
-
-interface BacklinkBreadcrumbListProps {
-  parents: readonly Block[]
-  workspaceId: string
-  onSelect: (parent: Block) => void
-}
-
-const BacklinkBreadcrumbList = ({parents, workspaceId, onSelect}: BacklinkBreadcrumbListProps) => {
-  const openBlock = useBlockOpener()
-  const handleLinkClick = useCallback((event: MouseEvent, parent: Block) => {
-    openBlock(event, {blockId: parent.id, workspaceId})
-  }, [openBlock, workspaceId])
-
-  return (
-    <BreadcrumbList
-      parents={parents}
-      workspaceId={workspaceId}
-      overrides={BREADCRUMB_OVERRIDES}
-      onSelect={onSelect}
-      onLinkClick={handleLinkClick}
-      className="flex items-center gap-1 text-xs text-muted-foreground/80 mb-1 flex-wrap"
-      itemClassName="no-underline cursor-pointer truncate max-w-[24ch] hover:text-foreground"
-      separatorClassName="mx-1 text-muted-foreground/40"
-    />
-  )
-}
 
 // Roam-style: breadcrumbs are the chain ABOVE the currently-shown block.
 // Click a segment to "unfurl" — promote it to the shown block. The
@@ -109,7 +82,15 @@ const BacklinkItemContent = ({
   return (
     <>
       {workspaceId && (
-        <BacklinkBreadcrumbList parents={parents} workspaceId={workspaceId} onSelect={onSelect}/>
+        <PromotableBreadcrumbList
+          parents={parents}
+          workspaceId={workspaceId}
+          overrides={BREADCRUMB_OVERRIDES}
+          onPromote={onSelect}
+          className="flex items-center gap-1 text-xs text-muted-foreground/80 mb-1 flex-wrap"
+          itemClassName="no-underline cursor-pointer truncate max-w-[24ch] hover:text-foreground"
+          separatorClassName="mx-1 text-muted-foreground/40"
+        />
       )}
       <NestedBlockContextProvider overrides={bodyOverrides}>
         <BlockComponent blockId={shownBlock.id}/>
@@ -152,9 +133,10 @@ const BacklinkItem = ({
 }) => {
   const repo = useRepo()
   const parentContext = useBlockContext()
-  const [shownBlockId, setShownBlockId] = useState(block.id)
-  const shownBlock = useMemo(() => repo.block(shownBlockId), [repo, shownBlockId])
-  const isInitial = shownBlockId === block.id
+  // Promote-in-place state (unfurl an ancestor, with the panel-nav
+  // crossfade) shared with the SRS review session.
+  const {shownId, isInitial, promote, showBlock} = usePromotableBreadcrumb(block.id)
+  const shownBlock = useMemo(() => repo.block(shownId), [repo, shownId])
   const parentRenderScopeId = typeof parentContext.renderScopeId === 'string'
     ? parentContext.renderScopeId
     : 'backlinks-root'
@@ -163,21 +145,6 @@ const BacklinkItem = ({
     [parentRenderScopeId, scopeId],
   )
 
-  // Wrap in withMoveTransition so unfurling the breadcrumb chain gets
-  // the same crossfade as panel breadcrumb navigation. The state change
-  // is local React (`setShownBlockId`), not a DB write — `navigateInPanel`'s
-  // internal wrap doesn't help here, so the wrap lives at the call site.
-  const handleSelect = useCallback((parent: Block) => {
-    void withMoveTransition(async () => {
-      setShownBlockId(parent.id)
-    })
-  }, [])
-  const handleShowBlock = useCallback((blockId: string) => {
-    void withMoveTransition(async () => {
-      setShownBlockId(blockId)
-    })
-  }, [])
-
   return (
     <div className="border-l-2 border-muted pl-3 py-2">
       {isInitial
@@ -185,16 +152,16 @@ const BacklinkItem = ({
             <BacklinkItemContent
               shownBlock={shownBlock}
               parents={initialParents}
-              onSelect={handleSelect}
-              onShowBlock={handleShowBlock}
+              onSelect={promote}
+              onShowBlock={showBlock}
               renderScopeId={renderScopeId}
             />
           )
         : (
             <BacklinkDynamicContent
               shownBlock={shownBlock}
-              onSelect={handleSelect}
-              onShowBlock={handleShowBlock}
+              onSelect={promote}
+              onShowBlock={showBlock}
               renderScopeId={renderScopeId}
             />
           )}

--- a/src/plugins/breadcrumbs/PromotableBreadcrumbList.tsx
+++ b/src/plugins/breadcrumbs/PromotableBreadcrumbList.tsx
@@ -1,0 +1,48 @@
+import { useCallback, type MouseEvent } from 'react'
+import type { Block } from '@/data/block'
+import type { BlockContextType } from '@/types.js'
+import { useBlockOpener } from '@/utils/navigation.js'
+import { BreadcrumbList } from './BreadcrumbList.js'
+
+interface PromotableBreadcrumbListProps {
+  parents: readonly Block[]
+  workspaceId: string
+  overrides: Partial<BlockContextType>
+  /** Plain primary click promotes (unfurls) the segment in place. */
+  onPromote: (parent: Block) => void
+  className?: string
+  itemClassName?: string
+  separatorClassName?: string
+}
+
+/** A `BreadcrumbList` wired for promote-in-place: a plain primary click
+ *  promotes the segment (`onPromote`); modifier clicks fall through to the
+ *  shared block opener (shift / shift+alt → sidebar / new panel). Used by
+ *  both the backlink entries and the SRS review session. */
+export const PromotableBreadcrumbList = ({
+  parents,
+  workspaceId,
+  overrides,
+  onPromote,
+  className,
+  itemClassName,
+  separatorClassName,
+}: PromotableBreadcrumbListProps) => {
+  const openBlock = useBlockOpener()
+  const handleLinkClick = useCallback((event: MouseEvent, parent: Block) => {
+    openBlock(event, {blockId: parent.id, workspaceId})
+  }, [openBlock, workspaceId])
+
+  return (
+    <BreadcrumbList
+      parents={parents}
+      workspaceId={workspaceId}
+      overrides={overrides}
+      onSelect={onPromote}
+      onLinkClick={handleLinkClick}
+      className={className}
+      itemClassName={itemClassName}
+      separatorClassName={separatorClassName}
+    />
+  )
+}

--- a/src/plugins/breadcrumbs/index.ts
+++ b/src/plugins/breadcrumbs/index.ts
@@ -6,6 +6,8 @@ import { Breadcrumbs } from './Breadcrumbs.tsx'
 import { BreadcrumbRenderer } from './BreadcrumbRenderer.tsx'
 
 export { BreadcrumbList } from './BreadcrumbList.tsx'
+export { PromotableBreadcrumbList } from './PromotableBreadcrumbList.tsx'
+export { usePromotableBreadcrumb, type PromotableBreadcrumb } from './usePromotableBreadcrumb.ts'
 export { BreadcrumbRenderer } from './BreadcrumbRenderer.tsx'
 export { Breadcrumbs } from './Breadcrumbs.tsx'
 export { getBreadcrumbContentPreview } from './breadcrumbPreview.ts'

--- a/src/plugins/breadcrumbs/usePromotableBreadcrumb.ts
+++ b/src/plugins/breadcrumbs/usePromotableBreadcrumb.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react'
+import type { Block } from '@/data/block'
+import { withMoveTransition } from '@/utils/viewTransition.js'
+
+export interface PromotableBreadcrumb {
+  /** The block currently shown as the subtree root — the original root
+   *  until the user promotes (unfurls) an ancestor. */
+  shownId: string
+  /** Whether the shown block is still the original root (no promotion). */
+  isInitial: boolean
+  /** Promote a breadcrumb ancestor to the shown block. */
+  promote: (parent: Block) => void
+  /** Show an arbitrary block id (e.g. a keyboard "promote closest"). */
+  showBlock: (blockId: string) => void
+}
+
+/** Shared state for "promote-in-place" breadcrumbs: clicking an ancestor
+ *  unfurls it as the shown subtree root, with the same crossfade as panel
+ *  breadcrumb navigation. The shown id resets to `rootId` whenever it
+ *  changes, so a surface whose root swaps under it (e.g. the SRS card
+ *  advancing) snaps back to the new root; for a stable root (e.g. a
+ *  backlink entry) the reset never fires. */
+export function usePromotableBreadcrumb(rootId: string): PromotableBreadcrumb {
+  const [shownId, setShownId] = useState(rootId)
+  // Reset on root change, the "adjust state during render" pattern — no
+  // effect, so the new root paints in the same commit.
+  const [prevRoot, setPrevRoot] = useState(rootId)
+  if (prevRoot !== rootId) {
+    setPrevRoot(rootId)
+    setShownId(rootId)
+  }
+
+  // Local React state, not a DB write, so the crossfade wrap lives here
+  // rather than coming from `navigateInPanel`.
+  const showBlock = useCallback((blockId: string) => {
+    void withMoveTransition(async () => { setShownId(blockId) })
+  }, [])
+  const promote = useCallback((parent: Block) => { showBlock(parent.id) }, [showBlock])
+
+  return { shownId, isInitial: shownId === rootId, promote, showBlock }
+}

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -59,6 +59,22 @@ import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
 const BREADCRUMB_OVERRIDES = {isNestedSurface: true, isBreadcrumb: true}
 const EMPTY_PARENTS: readonly Block[] = []
 
+/** Today's local day key, advanced when the date rolls over. Polls once a
+ *  minute (cheap; only re-renders the minute the day changes), mirroring
+ *  `useDueCards`' midnight-aware cutoff so a deck left open overnight saves
+ *  and restores under the correct day. */
+const useTodayKey = (): string => {
+  const [key, setKey] = useState(localDayKey)
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = localDayKey()
+      setKey(prev => (prev === next ? prev : next))
+    }, 60_000)
+    return () => clearInterval(id)
+  }, [])
+  return key
+}
+
 const isInteractiveTarget = (el: HTMLElement | null): boolean => {
   if (!el) return false
   // `isContentEditable` covers CodeMirror's focusable `.cm-content`.
@@ -145,15 +161,17 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
   const dueCards = useDueCards(workspaceId, tagName)
 
-  // Device-local, non-synced persistence of the in-progress session
-  // (frozen queue + place), so navigating away and back resumes instantly
-  // instead of re-running the due query and restarting at card one. Lives
-  // on the plugin's ui-state block — see `reviewProgressProp`.
+  // Persist the in-progress session (frozen queue + place) on the
+  // plugin's ui-state block so navigating away and back resumes instantly
+  // instead of re-running the due query and restarting at card one — see
+  // `reviewProgressProp`.
   const progressBlock = usePluginUIStateBlock(srsReviewProgressType)
   const [progress, setProgress] = useProperty(progressBlock, reviewProgressProp)
-  // Recomputed per mount; a midnight rollover between sessions invalidates
-  // a saved queue so it rebuilds from the live due set.
-  const todayKey = useMemo(() => localDayKey(), [])
+  // Today's day key, advanced on rollover (mirrors `useDueCards`' cutoff)
+  // so a session kept open past midnight saves under the new day and still
+  // restores; a memoized-once key would stamp post-midnight saves with
+  // yesterday and lose the user's place on the next visit.
+  const todayKey = useTodayKey()
 
   // Resume a saved session if one's valid for this deck/day; otherwise
   // start empty and let the live-snapshot path below capture the queue.
@@ -219,8 +237,8 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   )
 
   // Write-through: persist the live session so it survives unmount. One
-  // object write per state change; `ChangeScope.UiState` keeps it local
-  // (no upload). Skipped until the queue is established so we never
+  // object write per state change (UI-state scope, undo-segregated from
+  // document edits). Skipped until the queue is established so we never
   // clobber a saved session with an empty one during the initial load.
   useEffect(() => {
     if (queue === null) return

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useState,
   type FocusEvent as ReactFocusEvent,
-  type MouseEvent as ReactMouseEvent,
 } from 'react'
 import {
   ArchiveX,
@@ -25,7 +24,7 @@ import type { Block } from '@/data/block'
 import type { BlockData } from '@/data/api'
 import { useRepo } from '@/context/repo.js'
 import { useManyParents, useProperty } from '@/hooks/block.js'
-import { usePluginUIStateBlock } from '@/data/globalState.js'
+import { usePluginUIStateChildBlock } from '@/data/globalState.js'
 import { getBlockTypes } from '@/data/properties.js'
 import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
@@ -34,8 +33,7 @@ import { cn } from '@/lib/utils.js'
 import { showError, showInfo } from '@/utils/toast.js'
 import { useActionContextActivations } from '@/shortcuts/useActionContext.js'
 import { useBlockOpener } from '@/utils/navigation.js'
-import { withMoveTransition } from '@/utils/viewTransition.js'
-import { BreadcrumbList } from '@/plugins/breadcrumbs'
+import { PromotableBreadcrumbList, usePromotableBreadcrumb } from '@/plugins/breadcrumbs'
 import { openReschedulePicker } from '@/plugins/daily-notes'
 import {
   SRS_SM25_TYPE,
@@ -167,11 +165,13 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   const dueCards = useDueCards(workspaceId, tagName)
   const dueLoaded = useDueCardsReady(workspaceId, tagName)
 
-  // Persist the in-progress session (frozen queue + place) on the
-  // plugin's ui-state block so navigating away and back resumes instantly
-  // instead of re-running the due query and restarting at card one — see
-  // `reviewProgressProp`.
-  const progressBlock = usePluginUIStateBlock(srsReviewProgressType)
+  // Persist the in-progress session (frozen queue + place) on a per-deck
+  // child of the plugin's ui-state block so navigating away and back
+  // resumes instantly instead of re-running the due query and restarting
+  // at card one — see `reviewProgressProp`. Keying by deck id (rather than
+  // a single shared block discriminated by tag) lets every deck keep its
+  // own frozen session, so switching decks no longer clobbers the others.
+  const progressBlock = usePluginUIStateChildBlock(srsReviewProgressType, deck.id)
   const [progress, setProgress] = useProperty(progressBlock, reviewProgressProp)
   // Today's day key, advanced on rollover (mirrors `useDueCards`' cutoff)
   // so a session kept open past midnight saves under the new day and still
@@ -305,38 +305,18 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   // Promote-in-place: a plain breadcrumb click "unfurls" that ancestor —
   // the card surface re-renders its subtree (the card is still visible
   // nested below) and the chain truncates to it, mirroring the backlinks
-  // entry. Modifier clicks still navigate (handled by `onLinkClick`).
-  // `shownId` defaults to the card and snaps back whenever the card
-  // changes (advance / back / skip / restart), so promotion never leaks
-  // across cards.
-  const [shownBlockId, setShownBlockId] = useState<string | null>(currentId)
-  // Snap the promoted view back to the card whenever the card changes
-  // (advance / back / skip / restart) — the "reset state on change during
-  // render" pattern, so a promotion never leaks across cards.
-  const [promotedForCard, setPromotedForCard] = useState(currentId)
-  if (promotedForCard !== currentId) {
-    setPromotedForCard(currentId)
-    setShownBlockId(currentId)
-  }
-  const shownId = shownBlockId ?? currentId
+  // entry. The shared hook owns the shown-block state and snaps back to
+  // the card whenever it changes (advance / back / skip / restart), so a
+  // promotion never leaks across cards; modifier clicks navigate (handled
+  // by `PromotableBreadcrumbList`).
+  const {shownId, promote: promoteBreadcrumb} = usePromotableBreadcrumb(currentId ?? '')
   // The shown block's ancestors are a prefix of the card's chain, so we
   // can slice the already-fetched parents instead of querying again.
   const shownParents = useMemo(() => {
-    if (!shownId || shownId === currentId) return currentParents
+    if (!currentId || shownId === currentId) return currentParents
     const cut = currentParents.findIndex(p => p.id === shownId)
     return cut >= 0 ? currentParents.slice(0, cut) : currentParents
   }, [shownId, currentId, currentParents])
-  const promoteBreadcrumb = useCallback((parent: Block) => {
-    void withMoveTransition(async () => { setShownBlockId(parent.id) })
-  }, [])
-
-  const openBreadcrumb = useBlockOpener()
-  const handleBreadcrumbClick = useCallback(
-    (e: ReactMouseEvent, parent: Block) => {
-      openBreadcrumb(e, {blockId: parent.id, workspaceId})
-    },
-    [openBreadcrumb, workspaceId],
-  )
 
   const grade = useCallback(
     async (signal: SrsSignal) => {
@@ -534,7 +514,7 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
 
   // currentId is non-null past the guards above, so the shown surface id
   // is always a concrete block id (the card, or a promoted ancestor).
-  const surfaceId = shownBlockId ?? currentId
+  const surfaceId = shownId
   const showingCard = surfaceId === currentId
 
   return (
@@ -552,12 +532,11 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
           already warm; renders nothing for a top-level block. Plain click
           unfurls a segment in place (promote); modifier clicks navigate. */}
       {shownParents.length > 0 && (
-        <BreadcrumbList
+        <PromotableBreadcrumbList
           parents={shownParents}
           workspaceId={workspaceId}
           overrides={BREADCRUMB_OVERRIDES}
-          onSelect={promoteBreadcrumb}
-          onLinkClick={handleBreadcrumbClick}
+          onPromote={promoteBreadcrumb}
           className="mb-2 flex flex-wrap items-center gap-1 overflow-x-auto py-1 text-sm text-muted-foreground"
           itemClassName="max-w-full cursor-pointer truncate no-underline"
           separatorClassName="mx-1 text-muted-foreground/50"

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -48,7 +48,7 @@ import {
   srsNextReviewDateProp,
 } from '@/plugins/srs-rescheduling'
 import { SrsSignal, estimateSrsIntervalDays } from '@/plugins/srs-rescheduling/scheduler.js'
-import { useDueCards } from './useDueCards.ts'
+import { useDueCards, useDueCardsReady } from './useDueCards.ts'
 import { archiveSrsCard } from './archive.ts'
 import { reviewDeckStartedProp, reviewProgressProp, srsReviewProgressType } from './schema.ts'
 import { localDayKey, reconcileRestoredQueue, restoreSavedSession } from './reviewProgress.ts'
@@ -165,6 +165,7 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   const repo = useRepo()
   const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
   const dueCards = useDueCards(workspaceId, tagName)
+  const dueLoaded = useDueCardsReady(workspaceId, tagName)
 
   // Persist the in-progress session (frozen queue + place) on the
   // plugin's ui-state block so navigating away and back resumes instantly
@@ -259,15 +260,17 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   // drop not-yet-reached cards that are no longer due — e.g. rescheduled
   // on another surface since the session was saved. `useDueCards` is
   // already running for the snapshot/refresh paths, so this needs no extra
-  // query. Runs once; an empty due set is treated as "still loading"
-  // (mirrors the snapshot guard) so we never nuke the queue mid-load.
+  // query. Runs once, and only after the query has actually resolved
+  // (`dueLoaded`) — a loaded-but-empty deck (everything rescheduled away)
+  // must still reconcile to "complete", which is why we gate on load
+  // status rather than on a non-empty array.
   const reconciledRef = useRef(false)
   useEffect(() => {
-    if (!wasRestored || reconciledRef.current || dueCards.length === 0) return
+    if (!wasRestored || reconciledRef.current || !dueLoaded) return
     reconciledRef.current = true
     const dueIds = new Set(dueCards.map(c => c.id))
     setQueue(prev => (prev === null ? prev : reconcileRestoredQueue(prev, index, dueIds)))
-  }, [wasRestored, dueCards, index])
+  }, [wasRestored, dueLoaded, dueCards, index])
 
   // Discard the saved session and rebuild from the live due set. Now that
   // progress persists (navigating away no longer resets it), this is the

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -58,6 +58,10 @@ import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
  *  header renderer so the in-review chain renders identically. */
 const BREADCRUMB_OVERRIDES = {isNestedSurface: true, isBreadcrumb: true}
 const EMPTY_PARENTS: readonly Block[] = []
+/** How many cards' ancestors to prefetch per chunk (two chunks are in
+ *  flight at once). Bounds the `core.manyAncestors` id count so a large
+ *  deck can't exceed SQLite's host-parameter limit. */
+const BREADCRUMB_PREFETCH = 24
 
 /** Today's local day key, advanced when the date rolls over. Polls once a
  *  minute (cheap; only re-renders the minute the day changes), mirroring
@@ -256,14 +260,19 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     setProgress(null)
   }, [setProgress])
 
-  // Batch-prefetch ancestors for the whole frozen queue in one query
-  // (`core.manyAncestors`) so each card's breadcrumb chain is already warm
-  // when it appears — a per-card `useParents` otherwise loads cold on
-  // every card and lags visibly. The frozen queue keeps the handle key
-  // stable, so advancing through cards doesn't re-query.
+  // Window the ancestor prefetch. Passing every queued id to one
+  // `core.manyAncestors` call (one SQL placeholder per id) would let a deck
+  // with a very large due queue exceed SQLite's host-parameter limit and
+  // fail the whole session. Anchor the window to a fixed-size chunk so the
+  // handle key — and thus the query — changes only every
+  // BREADCRUMB_PREFETCH cards rather than on every advance, and span two
+  // chunks so the next chunk is already warm before the user reaches it.
+  const prefetchStart = Math.floor(index / BREADCRUMB_PREFETCH) * BREADCRUMB_PREFETCH
   const queueBlocks = useMemo(
-    () => (queue ?? []).map(id => repo.block(id)),
-    [queue, repo],
+    () => (queue ?? [])
+      .slice(prefetchStart, prefetchStart + BREADCRUMB_PREFETCH * 2)
+      .map(id => repo.block(id)),
+    [queue, repo, prefetchStart],
   )
   const parentsByCardId = useManyParents(queueBlocks)
   const currentParents = currentId

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -34,6 +34,7 @@ import { cn } from '@/lib/utils.js'
 import { showError, showInfo } from '@/utils/toast.js'
 import { useActionContextActivations } from '@/shortcuts/useActionContext.js'
 import { useBlockOpener } from '@/utils/navigation.js'
+import { withMoveTransition } from '@/utils/viewTransition.js'
 import { BreadcrumbList } from '@/plugins/breadcrumbs'
 import { openReschedulePicker } from '@/plugins/daily-notes'
 import {
@@ -297,6 +298,35 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   const currentParents = currentId
     ? parentsByCardId.get(currentId) ?? EMPTY_PARENTS
     : EMPTY_PARENTS
+
+  // Promote-in-place: a plain breadcrumb click "unfurls" that ancestor —
+  // the card surface re-renders its subtree (the card is still visible
+  // nested below) and the chain truncates to it, mirroring the backlinks
+  // entry. Modifier clicks still navigate (handled by `onLinkClick`).
+  // `shownId` defaults to the card and snaps back whenever the card
+  // changes (advance / back / skip / restart), so promotion never leaks
+  // across cards.
+  const [shownBlockId, setShownBlockId] = useState<string | null>(currentId)
+  // Snap the promoted view back to the card whenever the card changes
+  // (advance / back / skip / restart) — the "reset state on change during
+  // render" pattern, so a promotion never leaks across cards.
+  const [promotedForCard, setPromotedForCard] = useState(currentId)
+  if (promotedForCard !== currentId) {
+    setPromotedForCard(currentId)
+    setShownBlockId(currentId)
+  }
+  const shownId = shownBlockId ?? currentId
+  // The shown block's ancestors are a prefix of the card's chain, so we
+  // can slice the already-fetched parents instead of querying again.
+  const shownParents = useMemo(() => {
+    if (!shownId || shownId === currentId) return currentParents
+    const cut = currentParents.findIndex(p => p.id === shownId)
+    return cut >= 0 ? currentParents.slice(0, cut) : currentParents
+  }, [shownId, currentId, currentParents])
+  const promoteBreadcrumb = useCallback((parent: Block) => {
+    void withMoveTransition(async () => { setShownBlockId(parent.id) })
+  }, [])
+
   const openBreadcrumb = useBlockOpener()
   const handleBreadcrumbClick = useCallback(
     (e: ReactMouseEvent, parent: Block) => {
@@ -499,6 +529,11 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     )
   }
 
+  // currentId is non-null past the guards above, so the shown surface id
+  // is always a concrete block id (the card, or a promoted ancestor).
+  const surfaceId = shownBlockId ?? currentId
+  const showingCard = surfaceId === currentId
+
   return (
     <div
       ref={focusSessionSurface}
@@ -509,14 +544,16 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     >
       {header}
 
-      {/* Ancestor chain for the card under review, so its context isn't
-          lost outside the outline. Fed from the batched prefetch above so
-          it's already warm; renders nothing for a top-level card. */}
-      {currentParents.length > 0 && (
+      {/* Ancestor chain for the block on screen, so its context isn't lost
+          outside the outline. Fed from the batched prefetch above so it's
+          already warm; renders nothing for a top-level block. Plain click
+          unfurls a segment in place (promote); modifier clicks navigate. */}
+      {shownParents.length > 0 && (
         <BreadcrumbList
-          parents={currentParents}
+          parents={shownParents}
           workspaceId={workspaceId}
           overrides={BREADCRUMB_OVERRIDES}
+          onSelect={promoteBreadcrumb}
           onLinkClick={handleBreadcrumbClick}
           className="mb-2 flex flex-wrap items-center gap-1 overflow-x-auto py-1 text-sm text-muted-foreground"
           itemClassName="max-w-full cursor-pointer truncate no-underline"
@@ -526,17 +563,24 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
 
       <div className="rounded-xl border bg-card p-4 shadow-sm">
         <NestedBlockContextProvider
-          overrides={{
+          // While the card itself is shown, gate its answer with the review
+          // layout context. A promoted ancestor renders its full subtree
+          // normally (the card sits within it, in context).
+          overrides={showingCard ? {
             [SRS_REVIEW_CARD_ID]: currentId,
             [SRS_REVIEW_REVEALED]: revealed,
             isNestedSurface: true,
             scopeRootId: currentId,
             renderScopeId: `srs-review:${currentId}`,
+          } : {
+            isNestedSurface: true,
+            scopeRootId: surfaceId,
+            renderScopeId: `srs-review:${currentId}:${surfaceId}`,
           }}
         >
-          {/* keyed by card id so switching cards remounts the subtree
-              rather than diffing one card's outline into the next */}
-          <BlockComponent key={currentId} blockId={currentId} />
+          {/* keyed by the shown id so switching cards (or promoting) remounts
+              the subtree rather than diffing one outline into the next */}
+          <BlockComponent key={surfaceId} blockId={surfaceId} />
         </NestedBlockContextProvider>
       </div>
 

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent as ReactFocusEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent as ReactFocusEvent,
+  type MouseEvent as ReactMouseEvent,
+} from 'react'
 import {
   ArchiveX,
   ArrowLeft,
@@ -8,6 +16,7 @@ import {
   ExternalLink,
   Gauge,
   PartyPopper,
+  RefreshCw,
   RotateCcw,
   SkipForward,
   Sparkles,
@@ -15,7 +24,8 @@ import {
 import type { Block } from '@/data/block'
 import type { BlockData } from '@/data/api'
 import { useRepo } from '@/context/repo.js'
-import { useProperty } from '@/hooks/block.js'
+import { useManyParents, useProperty } from '@/hooks/block.js'
+import { usePluginUIStateBlock } from '@/data/globalState.js'
 import { getBlockTypes } from '@/data/properties.js'
 import { NestedBlockContextProvider } from '@/context/block.js'
 import { BlockComponent } from '@/components/BlockComponent.js'
@@ -24,7 +34,7 @@ import { cn } from '@/lib/utils.js'
 import { showError, showInfo } from '@/utils/toast.js'
 import { useActionContextActivations } from '@/shortcuts/useActionContext.js'
 import { useBlockOpener } from '@/utils/navigation.js'
-import { Breadcrumbs } from '@/plugins/breadcrumbs'
+import { BreadcrumbList } from '@/plugins/breadcrumbs'
 import { openReschedulePicker } from '@/plugins/daily-notes'
 import {
   SRS_SM25_TYPE,
@@ -39,9 +49,15 @@ import {
 import { SrsSignal, estimateSrsIntervalDays } from '@/plugins/srs-rescheduling/scheduler.js'
 import { useDueCards } from './useDueCards.ts'
 import { archiveSrsCard } from './archive.ts'
-import { reviewDeckStartedProp } from './schema.ts'
+import { reviewDeckStartedProp, reviewProgressProp, srsReviewProgressType } from './schema.ts'
+import { localDayKey, restoreSavedSession } from './reviewProgress.ts'
 import { SRS_REVIEW_CONTEXT, type SrsReviewController } from './actions.ts'
 import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
+
+/** Breadcrumb context overrides — mirrors the breadcrumbs plugin's own
+ *  header renderer so the in-review chain renders identically. */
+const BREADCRUMB_OVERRIDES = {isNestedSurface: true, isBreadcrumb: true}
+const EMPTY_PARENTS: readonly Block[] = []
 
 const isInteractiveTarget = (el: HTMLElement | null): boolean => {
   if (!el) return false
@@ -129,19 +145,35 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   const workspaceId = deck.peek()?.workspaceId ?? repo.activeWorkspaceId ?? ''
   const dueCards = useDueCards(workspaceId, tagName)
 
-  // Freeze the queue at the first non-empty load. Grading moves a card
-  // out of `dueCards` (its next-review date jumps to the future), so
-  // walking the live list would renumber the session under the user.
-  // We snapshot ids once via the converge-during-render pattern, then
-  // read each card's live state at grade time via `repo.block(id)`.
-  const [queue, setQueue] = useState<readonly string[] | null>(null)
+  // Device-local, non-synced persistence of the in-progress session
+  // (frozen queue + place), so navigating away and back resumes instantly
+  // instead of re-running the due query and restarting at card one. Lives
+  // on the plugin's ui-state block — see `reviewProgressProp`.
+  const progressBlock = usePluginUIStateBlock(srsReviewProgressType)
+  const [progress, setProgress] = useProperty(progressBlock, reviewProgressProp)
+  // Recomputed per mount; a midnight rollover between sessions invalidates
+  // a saved queue so it rebuilds from the live due set.
+  const todayKey = useMemo(() => localDayKey(), [])
+
+  // Resume a saved session if one's valid for this deck/day; otherwise
+  // start empty and let the live-snapshot path below capture the queue.
+  // `progressBlock` is loaded by the suspending hook above, so `progress`
+  // already reflects storage on this first render.
+  const savedSession = restoreSavedSession(progress, tagName, todayKey)
+  const [queue, setQueue] = useState<readonly string[] | null>(() => savedSession?.queue ?? null)
+  const [index, setIndex] = useState(() => savedSession?.index ?? 0)
+  const [revealed, setRevealed] = useState(() => savedSession?.revealed ?? false)
+  const [busy, setBusy] = useState(false)
+
+  // Freeze the queue at the first non-empty load (a restored session is
+  // already non-null, so this is skipped for it). Grading moves a card out
+  // of `dueCards` (its next-review date jumps to the future), so walking
+  // the live list would renumber the session under the user. We snapshot
+  // ids once via the converge-during-render pattern, then read each card's
+  // live state at grade time via `repo.block(id)`.
   if (queue === null && dueCards.length > 0) {
     setQueue(dueCards.map(c => c.id))
   }
-
-  const [index, setIndex] = useState(0)
-  const [revealed, setRevealed] = useState(false)
-  const [busy, setBusy] = useState(false)
 
   const total = queue?.length ?? 0
   const currentId = queue && index < queue.length ? queue[index] : null
@@ -180,10 +212,51 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   // honouring the shared modifier policy (plain click zooms it into the
   // main panel, shift / shift+alt open it in the sidebar / a new panel).
   const openBlock = useBlockOpener({plainClick: 'navigator'})
-  // Stable handle for the breadcrumb chain above the card.
+  // Stable handle for the card's grade-interval estimates.
   const currentBlock = useMemo(
     () => (currentId ? repo.block(currentId) : null),
     [repo, currentId],
+  )
+
+  // Write-through: persist the live session so it survives unmount. One
+  // object write per state change; `ChangeScope.UiState` keeps it local
+  // (no upload). Skipped until the queue is established so we never
+  // clobber a saved session with an empty one during the initial load.
+  useEffect(() => {
+    if (queue === null) return
+    setProgress({queue: [...queue], index, revealed, tag: tagName, day: todayKey})
+  }, [queue, index, revealed, tagName, todayKey, setProgress])
+
+  // Discard the saved session and rebuild from the live due set. Now that
+  // progress persists (navigating away no longer resets it), this is the
+  // way to start over. Setting the queue to null re-enters the
+  // live-snapshot path; clearing storage is rewritten on the next snapshot.
+  const restart = useCallback(() => {
+    setRevealed(false)
+    setIndex(0)
+    setQueue(null)
+    setProgress(null)
+  }, [setProgress])
+
+  // Batch-prefetch ancestors for the whole frozen queue in one query
+  // (`core.manyAncestors`) so each card's breadcrumb chain is already warm
+  // when it appears — a per-card `useParents` otherwise loads cold on
+  // every card and lags visibly. The frozen queue keeps the handle key
+  // stable, so advancing through cards doesn't re-query.
+  const queueBlocks = useMemo(
+    () => (queue ?? []).map(id => repo.block(id)),
+    [queue, repo],
+  )
+  const parentsByCardId = useManyParents(queueBlocks)
+  const currentParents = currentId
+    ? parentsByCardId.get(currentId) ?? EMPTY_PARENTS
+    : EMPTY_PARENTS
+  const openBreadcrumb = useBlockOpener()
+  const handleBreadcrumbClick = useCallback(
+    (e: ReactMouseEvent, parent: Block) => {
+      openBreadcrumb(e, {blockId: parent.id, workspaceId})
+    },
+    [openBreadcrumb, workspaceId],
   )
 
   const grade = useCallback(
@@ -323,9 +396,24 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
         Decks
       </Button>
       <span className="truncate text-sm font-medium text-muted-foreground">{deckLabel}</span>
-      <span className="text-xs tabular-nums text-muted-foreground">
-        {total === 0 ? '' : `${Math.min(index + 1, total)} / ${total}`}
-      </span>
+      <div className="flex items-center gap-1">
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {total === 0 ? '' : `${Math.min(index + 1, total)} / ${total}`}
+        </span>
+        {queue !== null && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={restart}
+            disabled={busy}
+            title="Restart review from the cards due now"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
     </div>
   )
 
@@ -376,8 +464,19 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
       {header}
 
       {/* Ancestor chain for the card under review, so its context isn't
-          lost outside the outline. Renders nothing for a top-level card. */}
-      {currentBlock && <Breadcrumbs block={currentBlock} />}
+          lost outside the outline. Fed from the batched prefetch above so
+          it's already warm; renders nothing for a top-level card. */}
+      {currentParents.length > 0 && (
+        <BreadcrumbList
+          parents={currentParents}
+          workspaceId={workspaceId}
+          overrides={BREADCRUMB_OVERRIDES}
+          onLinkClick={handleBreadcrumbClick}
+          className="mb-2 flex flex-wrap items-center gap-1 overflow-x-auto py-1 text-sm text-muted-foreground"
+          itemClassName="max-w-full cursor-pointer truncate no-underline"
+          separatorClassName="mx-1 text-muted-foreground/50"
+        />
+      )}
 
       <div className="rounded-xl border bg-card p-4 shadow-sm">
         <NestedBlockContextProvider

--- a/src/plugins/srs-review/ReviewSession.tsx
+++ b/src/plugins/srs-review/ReviewSession.tsx
@@ -50,7 +50,7 @@ import { SrsSignal, estimateSrsIntervalDays } from '@/plugins/srs-rescheduling/s
 import { useDueCards } from './useDueCards.ts'
 import { archiveSrsCard } from './archive.ts'
 import { reviewDeckStartedProp, reviewProgressProp, srsReviewProgressType } from './schema.ts'
-import { localDayKey, restoreSavedSession } from './reviewProgress.ts'
+import { localDayKey, reconcileRestoredQueue, restoreSavedSession } from './reviewProgress.ts'
 import { SRS_REVIEW_CONTEXT, type SrsReviewController } from './actions.ts'
 import { SRS_REVIEW_CARD_ID, SRS_REVIEW_REVEALED } from './reviewCardLayout.tsx'
 
@@ -186,6 +186,10 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
   const [index, setIndex] = useState(() => savedSession?.index ?? 0)
   const [revealed, setRevealed] = useState(() => savedSession?.revealed ?? false)
   const [busy, setBusy] = useState(false)
+  // True only when this mount resumed a saved session. Captured once:
+  // `savedSession` itself flips back to non-null as soon as write-through
+  // re-persists, so it can't serve as a stable "did we restore" signal.
+  const [wasRestored] = useState(() => savedSession !== null)
 
   // Freeze the queue at the first non-empty load (a restored session is
   // already non-null, so this is skipped for it). Grading moves a card out
@@ -248,6 +252,21 @@ export const ReviewSession = ({deck, tagName}: {deck: Block; tagName: string}) =
     if (queue === null) return
     setProgress({queue: [...queue], index, revealed, tag: tagName, day: todayKey})
   }, [queue, index, revealed, tagName, todayKey, setProgress])
+
+  // Reconcile a restored session against the live due set once it loads:
+  // keep everything already reviewed (so Back/re-grade still works) but
+  // drop not-yet-reached cards that are no longer due — e.g. rescheduled
+  // on another surface since the session was saved. `useDueCards` is
+  // already running for the snapshot/refresh paths, so this needs no extra
+  // query. Runs once; an empty due set is treated as "still loading"
+  // (mirrors the snapshot guard) so we never nuke the queue mid-load.
+  const reconciledRef = useRef(false)
+  useEffect(() => {
+    if (!wasRestored || reconciledRef.current || dueCards.length === 0) return
+    reconciledRef.current = true
+    const dueIds = new Set(dueCards.map(c => c.id))
+    setQueue(prev => (prev === null ? prev : reconcileRestoredQueue(prev, index, dueIds)))
+  }, [wasRestored, dueCards, index])
 
   // Discard the saved session and rebuild from the live due set. Now that
   // progress persists (navigating away no longer resets it), this is the

--- a/src/plugins/srs-review/dataExtension.ts
+++ b/src/plugins/srs-review/dataExtension.ts
@@ -3,11 +3,15 @@ import type { AppExtension } from '@/extensions/facet.js'
 import {
   reviewDeckStartedProp,
   reviewDeckTagProp,
+  reviewProgressProp,
   srsReviewDeckType,
+  srsReviewProgressType,
 } from './schema.ts'
 
 export const srsReviewDataExtension: AppExtension = [
   propertySchemasFacet.of(reviewDeckTagProp, {source: 'srs-review'}),
   propertySchemasFacet.of(reviewDeckStartedProp, {source: 'srs-review'}),
+  propertySchemasFacet.of(reviewProgressProp, {source: 'srs-review'}),
   typesFacet.of(srsReviewDeckType, {source: 'srs-review'}),
+  typesFacet.of(srsReviewProgressType, {source: 'srs-review'}),
 ]

--- a/src/plugins/srs-review/reviewProgress.ts
+++ b/src/plugins/srs-review/reviewProgress.ts
@@ -1,0 +1,33 @@
+import type { ReviewProgress } from './schema.ts'
+
+/** Local calendar day (YYYY-MM-DD), used to invalidate a saved session
+ *  after a midnight rollover. */
+export const localDayKey = (now: Date = new Date()): string =>
+  `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`
+
+/** The saved session to resume, or null when there's nothing valid to
+ *  restore (no save, a different deck tag, or a day rollover). Used as the
+ *  lazy initial state so a restored queue is non-null from the first
+ *  render — which keeps the live-snapshot path (gated on `queue === null`)
+ *  from clobbering it, no extra flag needed. The index is clamped to the
+ *  queue length so a saved "complete" session (index === length) resumes
+ *  on the completion screen rather than out of bounds. */
+export const restoreSavedSession = (
+  progress: ReviewProgress | null,
+  tagName: string,
+  todayKey: string,
+): {queue: readonly string[]; index: number; revealed: boolean} | null => {
+  if (
+    progress &&
+    progress.queue.length > 0 &&
+    progress.tag === tagName &&
+    progress.day === todayKey
+  ) {
+    return {
+      queue: progress.queue,
+      index: Math.min(progress.index, progress.queue.length),
+      revealed: progress.revealed,
+    }
+  }
+  return null
+}

--- a/src/plugins/srs-review/reviewProgress.ts
+++ b/src/plugins/srs-review/reviewProgress.ts
@@ -31,3 +31,19 @@ export const restoreSavedSession = (
   }
   return null
 }
+
+/** Reconcile a restored queue against the live due set: keep everything
+ *  already reviewed (`< index`, so Back/re-grade still works) and drop
+ *  not-yet-reached cards (`>= index`) that are no longer due — e.g.
+ *  rescheduled on another surface since the session was saved. Returns the
+ *  same array reference when nothing was dropped so callers can skip a
+ *  needless state update. */
+export const reconcileRestoredQueue = (
+  queue: readonly string[],
+  index: number,
+  dueIds: ReadonlySet<string>,
+): readonly string[] => {
+  const upcoming = queue.slice(index).filter(id => dueIds.has(id))
+  const next = [...queue.slice(0, index), ...upcoming]
+  return next.length === queue.length ? queue : next
+}

--- a/src/plugins/srs-review/schema.ts
+++ b/src/plugins/srs-review/schema.ts
@@ -32,13 +32,13 @@ export const srsReviewDeckType = defineBlockType({
 export const SRS_REVIEW_PROGRESS_TYPE = 'srs-review-progress'
 
 /** A frozen review session's persisted state. Stored on the plugin's
- *  device-local ui-state block (see `usePluginUIStateProperty`) so the
- *  session survives navigating away and back — both the user's place
- *  (`index`/`revealed`) and the frozen card order (`queue`), so returning
- *  doesn't re-run the due-cards query or restart at card one. `tag` and
- *  `day` scope the saved state: a different deck tag, or a midnight
- *  rollover, invalidates it so the queue rebuilds from the live due set
- *  instead of resuming a stale one. */
+ *  ui-state block (see `usePluginUIStateProperty`) so the session survives
+ *  navigating away and back — both the user's place (`index`/`revealed`)
+ *  and the frozen card order (`queue`), so returning doesn't re-run the
+ *  due-cards query or restart at card one. `tag` and `day` scope the saved
+ *  state: a different deck tag, or a midnight rollover, invalidates it so
+ *  the queue rebuilds from the live due set instead of resuming a stale
+ *  one. */
 export interface ReviewProgress {
   queue: string[]
   index: number
@@ -48,8 +48,9 @@ export interface ReviewProgress {
 }
 
 /** Single object property (one write per state change) rather than five
- *  scalar props. `ChangeScope.UiState` keeps it out of the upload
- *  queue — it's per-device session state, not synced content. */
+ *  scalar props. `ChangeScope.UiState` routes it into the ui-state
+ *  subtree, undo-segregated from document edits — it's session/UI state,
+ *  not document content. */
 export const reviewProgressProp = defineProperty<ReviewProgress | null>('srs-review:progress', {
   codec: codecs.unsafeIdentity<ReviewProgress | null>(),
   defaultValue: null,

--- a/src/plugins/srs-review/schema.ts
+++ b/src/plugins/srs-review/schema.ts
@@ -28,3 +28,36 @@ export const srsReviewDeckType = defineBlockType({
   label: 'SRS review deck',
   properties: [reviewDeckTagProp, reviewDeckStartedProp],
 })
+
+export const SRS_REVIEW_PROGRESS_TYPE = 'srs-review-progress'
+
+/** A frozen review session's persisted state. Stored on the plugin's
+ *  device-local ui-state block (see `usePluginUIStateProperty`) so the
+ *  session survives navigating away and back — both the user's place
+ *  (`index`/`revealed`) and the frozen card order (`queue`), so returning
+ *  doesn't re-run the due-cards query or restart at card one. `tag` and
+ *  `day` scope the saved state: a different deck tag, or a midnight
+ *  rollover, invalidates it so the queue rebuilds from the live due set
+ *  instead of resuming a stale one. */
+export interface ReviewProgress {
+  queue: string[]
+  index: number
+  revealed: boolean
+  tag: string
+  day: string
+}
+
+/** Single object property (one write per state change) rather than five
+ *  scalar props. `ChangeScope.UiState` keeps it out of the upload
+ *  queue — it's per-device session state, not synced content. */
+export const reviewProgressProp = defineProperty<ReviewProgress | null>('srs-review:progress', {
+  codec: codecs.unsafeIdentity<ReviewProgress | null>(),
+  defaultValue: null,
+  changeScope: ChangeScope.UiState,
+})
+
+export const srsReviewProgressType = defineBlockType({
+  id: SRS_REVIEW_PROGRESS_TYPE,
+  label: 'SRS review progress',
+  properties: [reviewProgressProp],
+})

--- a/src/plugins/srs-review/schema.ts
+++ b/src/plugins/srs-review/schema.ts
@@ -31,14 +31,14 @@ export const srsReviewDeckType = defineBlockType({
 
 export const SRS_REVIEW_PROGRESS_TYPE = 'srs-review-progress'
 
-/** A frozen review session's persisted state. Stored on the plugin's
- *  ui-state block (see `usePluginUIStateProperty`) so the session survives
- *  navigating away and back — both the user's place (`index`/`revealed`)
- *  and the frozen card order (`queue`), so returning doesn't re-run the
- *  due-cards query or restart at card one. `tag` and `day` scope the saved
- *  state: a different deck tag, or a midnight rollover, invalidates it so
- *  the queue rebuilds from the live due set instead of resuming a stale
- *  one. */
+/** A frozen review session's persisted state. Stored on a per-deck child
+ *  of the plugin's ui-state block (see `usePluginUIStateChildBlock`, keyed
+ *  by deck id) so each deck keeps its own session across navigating away
+ *  and back — both the user's place (`index`/`revealed`) and the frozen
+ *  card order (`queue`), so returning doesn't re-run the due-cards query or
+ *  restart at card one. `tag` and `day` still scope the saved state:
+ *  retagging the deck, or a midnight rollover, invalidates it so the queue
+ *  rebuilds from the live due set instead of resuming a stale one. */
 export interface ReviewProgress {
   queue: string[]
   index: number

--- a/src/plugins/srs-review/test/reviewProgress.test.ts
+++ b/src/plugins/srs-review/test/reviewProgress.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { restoreSavedSession } from '../reviewProgress.ts'
+import type { ReviewProgress } from '../schema.ts'
+
+const progress = (over: Partial<ReviewProgress> = {}): ReviewProgress => ({
+  queue: ['a', 'b', 'c'],
+  index: 1,
+  revealed: true,
+  tag: 'math',
+  day: '2026-6-2',
+  ...over,
+})
+
+describe('restoreSavedSession', () => {
+  it('resumes a session saved for the same tag and day', () => {
+    expect(restoreSavedSession(progress(), 'math', '2026-6-2')).toEqual({
+      queue: ['a', 'b', 'c'],
+      index: 1,
+      revealed: true,
+    })
+  })
+
+  it('discards a session saved under a different tag', () => {
+    expect(restoreSavedSession(progress(), 'history', '2026-6-2')).toBeNull()
+  })
+
+  it('discards a session saved on a different day (midnight rollover)', () => {
+    expect(restoreSavedSession(progress(), 'math', '2026-6-3')).toBeNull()
+  })
+
+  it('ignores empty or absent saves', () => {
+    expect(restoreSavedSession(null, 'math', '2026-6-2')).toBeNull()
+    expect(restoreSavedSession(progress({queue: []}), 'math', '2026-6-2')).toBeNull()
+  })
+
+  it('clamps a completed save to the completion screen rather than out of bounds', () => {
+    // index === queue.length is the "review complete" state; it must survive
+    // restore so the user resumes on the summary, not past the end.
+    expect(restoreSavedSession(progress({index: 9}), 'math', '2026-6-2')).toEqual({
+      queue: ['a', 'b', 'c'],
+      index: 3,
+      revealed: true,
+    })
+  })
+})

--- a/src/plugins/srs-review/test/reviewProgress.test.ts
+++ b/src/plugins/srs-review/test/reviewProgress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { restoreSavedSession } from '../reviewProgress.ts'
+import { reconcileRestoredQueue, restoreSavedSession } from '../reviewProgress.ts'
 import type { ReviewProgress } from '../schema.ts'
 
 const progress = (over: Partial<ReviewProgress> = {}): ReviewProgress => ({
@@ -41,5 +41,31 @@ describe('restoreSavedSession', () => {
       index: 3,
       revealed: true,
     })
+  })
+})
+
+describe('reconcileRestoredQueue', () => {
+  const due = (...ids: string[]) => new Set(ids)
+
+  it('drops not-yet-reached cards that are no longer due', () => {
+    // At index 2, c/d/e are upcoming; d was rescheduled away (not due).
+    expect(reconcileRestoredQueue(['a', 'b', 'c', 'd', 'e'], 2, due('c', 'e')))
+      .toEqual(['a', 'b', 'c', 'e'])
+  })
+
+  it('keeps already-reviewed cards even though they are no longer due', () => {
+    // a/b were graded this session (now future-dated, absent from the due
+    // set) but precede the index — kept so Back/re-grade still works.
+    expect(reconcileRestoredQueue(['a', 'b', 'c'], 2, due('c')))
+      .toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns the same reference when nothing is dropped', () => {
+    const queue = ['a', 'b', 'c']
+    expect(reconcileRestoredQueue(queue, 1, due('b', 'c'))).toBe(queue)
+  })
+
+  it('can empty the upcoming portion when nothing ahead is due', () => {
+    expect(reconcileRestoredQueue(['a', 'b', 'c'], 1, due('x'))).toEqual(['a'])
   })
 })

--- a/src/plugins/srs-review/useDueCards.ts
+++ b/src/plugins/srs-review/useDueCards.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { BlockData } from '@/data/api'
+import type { BlockData, TypedBlockQuery } from '@/data/api'
 import { useRepo } from '@/context/repo.js'
 import { useBlockQuery, useHandle } from '@/hooks/block.js'
 import { UNRESOLVED_TAG_ID, buildDueCardsQuery } from './dueQuery.ts'
@@ -23,13 +23,14 @@ const useStartOfToday = (): number => {
   return ts
 }
 
-/** Reactive list of SRS cards due today or earlier for a deck.
+/** Shared query builder for the due-cards hooks, so `useDueCards` and
+ *  `useDueCardsReady` observe the exact same typed-blocks handle.
  *
  *  A non-empty `tagName` is resolved to its page block id via
  *  `core.aliasLookup`; when the page doesn't exist the deck targets
  *  `UNRESOLVED_TAG_ID` so it reports zero rather than every due card.
  *  An empty `tagName` is the "all due" deck (no tag filter). */
-export const useDueCards = (workspaceId: string, tagName: string): BlockData[] => {
+const useDueCardsQuery = (workspaceId: string, tagName: string): TypedBlockQuery => {
   const repo = useRepo()
   const alias = tagName.trim()
   const wantsTag = alias.length > 0
@@ -46,9 +47,26 @@ export const useDueCards = (workspaceId: string, tagName: string): BlockData[] =
   // overnight — so a deck left open past midnight starts surfacing the
   // newly-due cards instead of staying pinned to yesterday's boundary.
   const startOfToday = useStartOfToday()
-  const query = useMemo(
+  return useMemo(
     () => buildDueCardsQuery({workspaceId, tagBlockId, now: new Date(startOfToday)}),
     [workspaceId, tagBlockId, startOfToday],
   )
-  return useBlockQuery(query)
+}
+
+/** Reactive list of SRS cards due today or earlier for a deck. */
+export const useDueCards = (workspaceId: string, tagName: string): BlockData[] =>
+  useBlockQuery(useDueCardsQuery(workspaceId, tagName))
+
+/** Whether the due-cards query has produced a result yet (vs. still
+ *  loading). A loaded-but-empty deck reports `true` here while
+ *  `useDueCards` returns `[]`, letting callers tell "nothing due" apart
+ *  from "not loaded yet" — the query handle's data is `undefined` until
+ *  the first resolve, then an array (possibly empty). Shares the handle
+ *  with `useDueCards`, so it adds no extra query. */
+export const useDueCardsReady = (workspaceId: string, tagName: string): boolean => {
+  const repo = useRepo()
+  const query = useDueCardsQuery(workspaceId, tagName)
+  return useHandle(repo.query.typedBlocks(query), {
+    selector: data => data !== undefined,
+  }) as boolean
 }


### PR DESCRIPTION
Review-session improvements, retargeted onto `master` (the original PR #98 went onto a feature branch by mistake). Same work, plus the follow-ups from that review.

## Breadcrumbs were slow to appear
Each card's breadcrumb chain ran its own single-card `ancestors` query that loaded cold the moment the card appeared, and the handle got GC'd between cards — so every card paid the latency again. Now batch-prefetch ancestors for the frozen queue via `core.manyAncestors` (the batched "2.3s → 150ms" path) and render the current card's chain from that prewarmed data. The prefetch is **windowed** around the current index so a large queue doesn't fetch everything up front.

## Navigating away reset the session
`queue` / `index` / `revealed` lived in component state, so leaving the review discarded them and returning re-ran the due-cards query (~1s) and restarted at card one. Now persisted on the plugin's ui-state block (`ChangeScope.UiState`, undo-segregated from document edits) and read as lazy initial state, so a restored queue is non-null from the first render.

**Stored per deck.** Rather than one shared block discriminated by tag/day (which let only one deck's session survive at a time), progress is keyed by deck id via a new generic `getPluginUIStateChild` / `usePluginUIStateChildBlock` (a per-key child of the plugin ui-state block, mirroring `getLayoutSessionBlock`). Each deck keeps its own frozen session; `tag`/`day` remain as retag/midnight-rollover guards. The saved day key is reactive, so a deck left open across midnight saves/restores under the correct day.

**Restore reconciliation.** A restored session is reconciled against the live due set — including when the due set is empty — so a stale queue rebuilds rather than resuming cards that are no longer due.

## Promote-in-place breadcrumbs
A plain breadcrumb click now "unfurls" that ancestor in place (the card stays visible nested below, the chain truncates to it) instead of navigating away; modifier clicks still navigate. This logic was duplicated with the backlink entries, so it's extracted into `plugins/breadcrumbs`:
- `usePromotableBreadcrumb(rootId)` — owns the shown-block state + crossfade, resets when the root changes (review's per-card snap-back; a no-op for backlinks' stable root).
- `PromotableBreadcrumbList` — `BreadcrumbList` wired for plain-click-promote / modifier-click-navigate.

Both `BacklinkEntry` and `ReviewSession` are refactored onto them, dropping their bespoke copies.

## Restart control
Since progress now persists, a **Restart** button in the header discards the saved session and rebuilds from the cards due now.

## Verification
`tsc -b` clean, eslint 0 errors, 960 tests pass across `srs-review`, `backlinks`, `breadcrumbs`, and `data` (including the `restoreSavedSession` / day-key unit tests).

https://claude.ai/code/session_01EntmoQxi5U1VuhNPfFJgSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EntmoQxi5U1VuhNPfFJgSV)_