### PR TITLE
Phase 0: shared chord canonicalizer with sequence parsing

### DIFF
--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -110,6 +110,25 @@ canonicalizer must split on space first into an ordered list of presses, then ca
 (3) re-export from <code>keyCapture.ts</code> so the settings UI is unchanged; (4) point
 <code>keybindingConflicts.ts</code>' <code>toChordArray</code> bucketing at the canonical key.
 Keep the descriptor shape open (the <code>kind</code> field) so Phase 3 adds variants, not a rewrite.</p>
+<p><strong>Known limits (deferred — Phase 0 shipped in PR&nbsp;#102 with these left open on purpose):</strong></p>
+<ul class="tight">
+  <li><strong>Conflict bucketing is case-sensitive on the final key.</strong> The canonical key preserves the
+      final key's case, so <code>cmd+k</code> and <code>cmd+K</code> bucket as <em>distinct</em> chords in
+      <code>keybindingConflicts</code>. This matches today's case-sensitive raw-string behavior — <em>not</em> a
+      regression — but it means a <code>Shift</code>-less uppercase-letter binding won't be flagged as colliding
+      with its <code>Shift</code>+lowercase equivalent. Revisit when the comparator lands: decide whether key
+      comparison should fold case so the physical key + an explicit <code>Shift</code> modifier is the canonical
+      form. (Touches <code>canonicalizeChord</code>'s key handling, so it would also shift the resolver — do it
+      deliberately, not as a drive-by.)</li>
+  <li><strong>Conflict bucketing ignores <code>phase</code> — and that asymmetry is intentional.</strong>
+      <code>keybindingConflicts</code> calls <code>canonicalizeChord(chord)</code> with <em>no</em> phase, so two
+      actions on the same chord+context differing only by phase (keydown vs keyup vs hold) bucket together. That
+      is inert today (no such default pair) and arguably correct — a same-chord/different-phase pair is a
+      plausible UX surprise worth surfacing. <strong>The resolver must do the opposite:</strong> the
+      phase-aware key (<code>canonicalizeChord(raw, phase)</code>) exists precisely so dispatch does <em>not</em>
+      dedup hold&nbsp;<code>s</code> against keyup&nbsp;<code>s</code> (see the Phase&nbsp;1 "same key different
+      phase does NOT dedup" test). Don't unify the two call sites onto one phase policy.</li>
+</ul>
 </div>
 
 <div class="phase">

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -68,7 +68,7 @@ input-unification consumer, it's work that gets torn out.
 <tr><td><code>modal</code>?</td><td>Retained, orthogonal — "own all chords, even unbound." Above priority.</td><td class="done">settled</td></tr>
 <tr><td>Trigger type?</td><td>Normalized input descriptor (<code>{kind, modifiers, phase, role}</code>), not <code>KeyboardEvent</code>; phase/role first-class.</td><td class="done">settled</td></tr>
 <tr><td>Replace facets / flatten contexts?</td><td>No. Keep facet contribution + scoping. Unify resolution only.</td><td class="done">settled</td></tr>
-<tr><td><code>global</code> vs active <code>modal</code> on same chord (Escape)?</td><td>Lean: modal is the one tier allowed to override global. Needs explicit sign-off.</td><td class="open">OPEN</td></tr>
+<tr><td><code>global</code> vs active <code>modal</code> on same chord (Escape)?</td><td>Lean: modal is the one tier allowed to override global. <strong>But</strong> nothing binds <code>Escape</code> at <code>global</code> today (both Escape bindings are scoped), so this is likely moot for Escape — revisit with a real collision. Needs explicit sign-off.</td><td class="open">OPEN</td></tr>
 <tr><td>Equal-priority determinism?</td><td>Fall back to recency for now; revisit only if a real case bites.</td><td class="open">deferred</td></tr>
 <tr><td>Full provider/DI dependency model?</td><td>Build only the caller-supplied <em>seam</em> now; full token registry deferred until "dep shapes grow faster than contexts."</td><td class="open">deferred</td></tr>
 <tr><td>Focus-tree activation model?</td><td>Separate prototype track; not a dependency of any phase below.</td><td class="open">prototype</td></tr>
@@ -223,8 +223,17 @@ The reporting surface declares <code>'high'</code> to beat <code>normal-mode</co
 tier only when a real case needs one.</p>
 
 <p><strong>The <code>global</code>-vs-<code>modal</code> sub-question (the "Escape case") — DECIDE before coding:</strong>
-<code>global</code> owns <code>Escape</code> (clear focus) as reserved top tier, but a modal mode (e.g. scrub)
-wants <code>Escape</code> to cancel <em>itself</em>. <strong>Recommended &amp; assumed by this plan: an active
+<strong>Reality check (verified):</strong> nothing binds <code>Escape</code> at the <code>global</code> tier today.
+The only two <code>Escape</code> bindings are <em>scoped</em> — <code>exit_edit_mode_cm</code> in
+<code>EDIT_MODE_CM</code> and <code>clear_selection</code> in <code>MULTI_SELECT_MODE</code>
+(<span class="filepath">defaultShortcuts.ts:565 / :920</span>) — and <code>global</code> binds
+undo/redo/preferences/import-export, <em>not</em> <code>Escape</code> (no "clear focus" binding exists). So
+"<code>global</code> owns <code>Escape</code>" is the canonical <em>illustration</em> of the tension, not current
+behavior: a modal mode (e.g. scrub) that wants <code>Escape</code> to cancel <em>itself</em> contends only with
+those scoped bindings, which the ordinary comparator already resolves — the modal-over-<code>global</code> special
+case may never fire for <code>Escape</code> specifically. Still pick the rule before Phase 1 wires the comparator,
+but frame it as "modal vs. a scoped exit/clear binding" and revisit with a real collision rather than abstractly.
+<strong>Recommended &amp; assumed by this plan: an active
 <code>modal</code> context may override <code>global</code> on a shared chord</strong> (consistent with modal
 already being the tier that suppresses everything else). Encode as: comparator ranks active-<code>modal</code>
 above <code>global</code>, <code>global</code> above all other tiers. Two alternatives, if you'd rather not bake

--- a/src/plugins/keybindings-settings/keyCapture.ts
+++ b/src/plugins/keybindings-settings/keyCapture.ts
@@ -16,8 +16,6 @@
 const isMacPlatform = (): boolean =>
   typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
 
-const MODIFIER_ORDER = ['$mod', 'Control', 'Meta', 'Alt', 'Shift'] as const
-
 /** Map raw `KeyboardEvent.key` values to tinykeys' canonical names. */
 const KEY_ALIASES: Record<string, string> = {
   ' ': 'Space',
@@ -198,41 +196,7 @@ export const formatChord = (chord: string): string => {
   ).join(' ')
 }
 
-/** Canonicalise a chord — stable modifier ordering, aliases (`cmd` →
- *  `$mod`, `Option` → `Alt`, etc.). Used to detect equivalence when
- *  checking for duplicates ('Meta+K' and '$mod+k' should match on a
- *  Mac-style binding, where Meta is the primary). */
-export const normalizeChord = (chord: string): string => {
-  const tokens = chord.split('+').map(t => t.trim()).filter(Boolean)
-  const lowered = tokens.map(t => t.toLowerCase())
-  // Letter-case retained on the final key (the trailing non-modifier
-  // token). Modifier tokens always get their canonical name.
-  const aliasMap: Record<string, string> = {
-    cmd: '$mod',
-    meta: '$mod',
-    os: '$mod',
-    ctrl: 'Control',
-    control: 'Control',
-    option: 'Alt',
-    alt: 'Alt',
-    shift: 'Shift',
-    '$mod': '$mod',
-  }
-  const modifiers: string[] = []
-  let key = ''
-  for (let i = 0; i < tokens.length; i++) {
-    const alias = aliasMap[lowered[i]!]
-    if (alias && i < tokens.length - 1) {
-      modifiers.push(alias)
-    } else if (alias && i === tokens.length - 1) {
-      // Modifier in the last slot (e.g. user typed `cmd`); preserve it
-      // so we don't drop the chord. Unusual but possible during
-      // partial-capture states.
-      modifiers.push(alias)
-    } else {
-      key = tokens[i]!
-    }
-  }
-  const orderedModifiers = MODIFIER_ORDER.filter(m => modifiers.includes(m))
-  return [...orderedModifiers, key].filter(Boolean).join('+')
-}
+// `normalizeChord` now lives in the shared canonicaliser so dedup,
+// conflict detection, and the resolver all compare chords identically.
+// Re-exported here so the settings UI keeps a single import surface.
+export { normalizeChord } from '@/shortcuts/canonicalizeChord.js'

--- a/src/shortcuts/canonicalizeChord.test.ts
+++ b/src/shortcuts/canonicalizeChord.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalizeChord, parseChord } from './canonicalizeChord.ts'
+
+describe('parseChord', () => {
+  it('splits a sequence chord into one descriptor per press', () => {
+    // The historical gap: 'g g' / 'd d' were treated as a single atomic
+    // key because the splitter only split on '+'. They must become an
+    // ordered list of presses.
+    expect(parseChord('g g')).toEqual([
+      {kind: 'key', key: 'g', mods: [], phase: 'keydown'},
+      {kind: 'key', key: 'g', mods: [], phase: 'keydown'},
+    ])
+  })
+
+  it('keeps a modifier press whole within a sequence', () => {
+    expect(parseChord('Cmd+K Cmd+S')).toEqual([
+      {kind: 'key', key: 'K', mods: ['$mod'], phase: 'keydown'},
+      {kind: 'key', key: 'S', mods: ['$mod'], phase: 'keydown'},
+    ])
+  })
+
+  it('alias-folds and orders modifiers on a plain chord', () => {
+    expect(parseChord('Shift+Cmd+k')).toEqual([
+      {kind: 'key', key: 'k', mods: ['$mod', 'Shift'], phase: 'keydown'},
+    ])
+  })
+
+  it('stamps the requested phase onto every press', () => {
+    expect(parseChord('s', 'keyup').map(d => d.phase)).toEqual(['keyup'])
+  })
+})
+
+describe('canonicalizeChord', () => {
+  it('canonicalises each press of a sequence instead of mangling on "+"', () => {
+    // A naive '+' split would shatter 'Cmd+K Cmd+S' into ['Cmd', 'K Cmd',
+    // 'S']; splitting on space first keeps each press intact.
+    expect(canonicalizeChord('Cmd+K Cmd+S')).toBe('$mod+K $mod+S')
+  })
+
+  it('treats alias- and order-equivalent chords as the same key', () => {
+    expect(canonicalizeChord('Shift+Cmd+k')).toBe(canonicalizeChord('cmd+shift+k'))
+    expect(canonicalizeChord('Meta+k')).toBe(canonicalizeChord('$mod+k'))
+  })
+
+  it('distinguishes the same chord on different phases', () => {
+    expect(canonicalizeChord('s', 'hold')).not.toBe(canonicalizeChord('s', 'keyup'))
+    expect(canonicalizeChord('s')).toBe('s')
+  })
+})

--- a/src/shortcuts/canonicalizeChord.test.ts
+++ b/src/shortcuts/canonicalizeChord.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { canonicalizeChord, parseChord } from './canonicalizeChord.ts'
+import { canonicalizeChord, normalizeChord, parseChord } from './canonicalizeChord.ts'
 
 describe('parseChord', () => {
   it('splits a sequence chord into one descriptor per press', () => {
@@ -45,5 +45,22 @@ describe('canonicalizeChord', () => {
   it('distinguishes the same chord on different phases', () => {
     expect(canonicalizeChord('s', 'hold')).not.toBe(canonicalizeChord('s', 'keyup'))
     expect(canonicalizeChord('s')).toBe('s')
+  })
+})
+
+describe('normalizeChord (behaviour pinned across the lift)', () => {
+  // The whole PR's safety rests on normalizeChord being a relocation, not a
+  // change. keyCapture.test.ts covers the ordinary cases through the
+  // re-export; these pin the adversarial edges that the position-aware →
+  // "alias or key" rewrite could plausibly have shifted.
+  it.each([
+    ['cmd+shift', '$mod+Shift'],       // all-modifier chord, no final key
+    ['k+cmd', '$mod+k'],               // non-modifier before a modifier
+    ['meta+cmd+k', '$mod+k'],          // duplicate primary folds to one $mod
+    ['Meta+K', '$mod+K'],              // meta→$mod alias; final-key case kept
+    [' cmd + k ', '$mod+k'],           // surrounding whitespace trimmed
+    ['', ''],                          // empty input stays empty
+  ])('normalizeChord(%j) === %j', (input, expected) => {
+    expect(normalizeChord(input)).toBe(expected)
   })
 })

--- a/src/shortcuts/canonicalizeChord.ts
+++ b/src/shortcuts/canonicalizeChord.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared chord canonicalisation for the action/shortcut system.
+ *
+ * Lifted out of `keybindings-settings/keyCapture.ts` (which re-exports
+ * `normalizeChord` for back-compat) so that dedup, conflict detection,
+ * and — in later phases — the resolver all compare chords the same way.
+ *
+ * Two levels of structure:
+ *  - A single *press* ('Cmd+Shift+K') alias-folds its modifiers
+ *    (cmd|meta|os → $mod, ctrl → Control, option → Alt), sorts them into
+ *    a stable order, and keeps the final key's case. That already worked
+ *    here; this is a relocation, not a fix.
+ *  - A *chord* is a SEQUENCE of presses separated by spaces ('g g',
+ *    'Cmd+K Cmd+S'). The lifted splitter only ever split on '+', so a
+ *    space-bearing chord like 'd d' was treated as one atomic key — that
+ *    is the real gap this module closes. Split on space FIRST, then
+ *    canonicalise each press.
+ */
+
+/**
+ * Canonical modifier names a descriptor can carry. `$mod` is the
+ * platform-primary modifier (Cmd on macOS, Ctrl elsewhere); the rest are
+ * literal. `cmd`/`meta`/`os` all alias-fold to `$mod`, so `Meta` never
+ * survives canonicalisation.
+ */
+export type Modifier = '$mod' | 'Control' | 'Alt' | 'Shift'
+
+/** When in the key lifecycle a press resolves. Mirrors the binding
+ *  `phase` field in `types.ts`. */
+export type ChordPhase = 'keydown' | 'keyup' | 'hold'
+
+/**
+ * One press within a chord. A plain chord ('Cmd+K') is a single
+ * descriptor; a sequence ('g g') is several. `kind` stays open so Phase 3
+ * can add `'mouse' | 'touch'` variants rather than forcing a rewrite.
+ */
+export interface ChordDescriptor {
+  readonly kind: 'key'
+  /** Canonical final key, original case preserved ('k', 'K', 'Escape'). */
+  readonly key: string
+  /** Alias-folded and sorted into `MODIFIER_ORDER`. */
+  readonly mods: readonly Modifier[]
+  readonly phase: ChordPhase
+}
+
+/** A chord is a sequence of presses; an ordinary chord is length 1. */
+export type ChordSequence = readonly ChordDescriptor[]
+
+/** Stable modifier order, so the same physical chord always serialises
+ *  identically. `$mod` first, then the literal modifiers. */
+const MODIFIER_ORDER: readonly Modifier[] = ['$mod', 'Control', 'Alt', 'Shift']
+
+/** Fold the assorted spellings of each modifier onto one canonical name. */
+const MODIFIER_ALIASES: Record<string, Modifier> = {
+  cmd: '$mod',
+  meta: '$mod',
+  os: '$mod',
+  '$mod': '$mod',
+  ctrl: 'Control',
+  control: 'Control',
+  option: 'Alt',
+  alt: 'Alt',
+  shift: 'Shift',
+}
+
+interface ParsedPress {
+  readonly mods: readonly Modifier[]
+  readonly key: string
+}
+
+/** Parse a single press ('Cmd+Shift+K') into ordered, alias-folded
+ *  modifiers plus the final key (case preserved). Modifier tokens in any
+ *  position fold to a modifier; the remaining token is the key. */
+const parsePress = (press: string): ParsedPress => {
+  const tokens = press.split('+').map(t => t.trim()).filter(Boolean)
+  const mods: Modifier[] = []
+  let key = ''
+  for (const token of tokens) {
+    const alias = MODIFIER_ALIASES[token.toLowerCase()]
+    if (alias) {
+      mods.push(alias)
+    } else {
+      key = token
+    }
+  }
+  // Filtering `MODIFIER_ORDER` both orders the modifiers and dedups them.
+  return {mods: MODIFIER_ORDER.filter(m => mods.includes(m)), key}
+}
+
+/** Split a chord into its presses. A chord is space-separated presses
+ *  ('g g'); ordinary chords yield a single press. */
+const splitSequence = (raw: string): string[] =>
+  raw.split(' ').map(p => p.trim()).filter(Boolean)
+
+/** Serialise a parsed press back to its canonical chord string. */
+const formatPress = ({mods, key}: ParsedPress): string =>
+  [...mods, key].filter(Boolean).join('+')
+
+/**
+ * Canonicalise a single press — stable modifier ordering, alias folding
+ * (`cmd` → `$mod`, `Option` → `Alt`, …). Used to detect equivalence when
+ * checking for duplicates ('Meta+K' and '$mod+k' match on a Mac-style
+ * binding, where Meta is the primary).
+ *
+ * Kept single-press (splits on `+` only) for the settings UI, which
+ * re-exports it via `keyCapture.ts` and feeds it one press at a time. For
+ * sequence-aware canonicalisation use `canonicalizeChord`.
+ */
+export const normalizeChord = (chord: string): string =>
+  formatPress(parsePress(chord))
+
+/**
+ * Canonicalise a whole chord, sequence-aware: splits on space first, then
+ * canonicalises each press, so 'Cmd+K Cmd+S' becomes '$mod+k $mod+s'
+ * instead of being mangled by a naive `+` split. Returns a stable string
+ * key for bucketing/dedup. When `phase` is supplied it is folded into the
+ * key, so the same chord on different phases (hold `s` vs keyup `s`) does
+ * not collapse together.
+ */
+export const canonicalizeChord = (raw: string, phase?: ChordPhase): string => {
+  const canonical = splitSequence(raw)
+    .map(press => formatPress(parsePress(press)))
+    .join(' ')
+  return phase ? `${phase}:${canonical}` : canonical
+}
+
+/**
+ * Parse a chord into an ordered sequence of descriptors for matching.
+ * Splits on space first, so 'd d' / 'g g' become two presses instead of
+ * one atomic key — the historical cause of dead sequence chords. Plain
+ * chords yield a length-1 sequence.
+ */
+export const parseChord = (raw: string, phase: ChordPhase = 'keydown'): ChordSequence =>
+  splitSequence(raw).map(press => {
+    const {mods, key} = parsePress(press)
+    return {kind: 'key', key, mods, phase}
+  })

--- a/src/shortcuts/keybindingConflicts.test.ts
+++ b/src/shortcuts/keybindingConflicts.test.ts
@@ -33,6 +33,17 @@ describe('findKeybindingConflicts', () => {
     expect(conflicts[0]!.actions.map(a => a.actionId)).toEqual(['a', 'b'])
   })
 
+  it('flags alias-equivalent chords and reports the raw authored form', () => {
+    const conflicts = findKeybindingConflicts([
+      action('a', ActionContextTypes.NORMAL_MODE, 'cmd+k'),
+      action('b', ActionContextTypes.NORMAL_MODE, '$mod+k'),
+    ])
+
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]!.chord).toBe('cmd+k')
+    expect(conflicts[0]!.actions.map(a => a.actionId)).toEqual(['a', 'b'])
+  })
+
   it('flags a global vs a scoped action sharing a chord', () => {
     const conflicts = findKeybindingConflicts([
       action('a', ActionContextTypes.GLOBAL, 'cmd+k'),

--- a/src/shortcuts/keybindingConflicts.ts
+++ b/src/shortcuts/keybindingConflicts.ts
@@ -16,6 +16,7 @@ import type {
   ActionContextType,
   KeyCombination,
 } from '@/shortcuts/types.js'
+import { canonicalizeChord } from './canonicalizeChord.ts'
 
 export interface KeybindingConflict {
   readonly chord: string
@@ -46,18 +47,23 @@ const participantOf = (action: ActionConfig): ActionConflictParticipant => ({
 export const findKeybindingConflicts = (
   actions: readonly ActionConfig[],
 ): readonly KeybindingConflict[] => {
-  const byChord = new Map<string, ActionConfig[]>()
+  // Bucket by the canonical key so alias-equivalent chords (`Cmd+K` and
+  // `$mod+k`, or a reordered `Shift+$mod+k`) land together; keep the
+  // first-seen raw chord as the bucket's reported form so the warning
+  // shows the chord the user actually authored, not its canonical spelling.
+  const byChord = new Map<string, {chord: string; actions: ActionConfig[]}>()
   for (const action of actions) {
     if (!action.defaultBinding) continue
     for (const chord of toChordArray(action.defaultBinding.keys)) {
-      const bucket = byChord.get(chord) ?? []
-      bucket.push(action)
-      byChord.set(chord, bucket)
+      const key = canonicalizeChord(chord)
+      const bucket = byChord.get(key) ?? {chord, actions: []}
+      bucket.actions.push(action)
+      byChord.set(key, bucket)
     }
   }
 
   const conflicts: KeybindingConflict[] = []
-  for (const [chord, candidates] of byChord) {
+  for (const {chord, actions: candidates} of byChord.values()) {
     if (candidates.length < 2) continue
     const participants = findOverlappingGroup(candidates)
     if (participants.length < 2) continue


### PR DESCRIPTION
First implementation slice of the action-system plan (`docs/action-system-implementation-plan.html`, Phase 0). Enabling, no behavior change to the keyboard path — it lays the canonical-comparison foundation the resolver core (Phase 1) and input unification (Phase 3) all assume.

## What

- **New `src/shortcuts/canonicalizeChord.ts`** — lifts `normalizeChord` out of `keybindings-settings/keyCapture.ts` (re-exported there, so the settings UI is unchanged) and adds the gap it was actually missing: **sequence-chord parsing**. A chord is a *sequence* of presses split on **space first** (`g g`, `Cmd+K Cmd+S`), then each press canonicalized — instead of the old naive `+` split that mangled space-bearing chords.
  - `ChordDescriptor` / `ChordSequence` types — `kind` stays open so Phase 3 adds `'mouse' | 'touch'` rather than a rewrite.
  - `canonicalizeChord(raw, phase?)` — sequence-aware stable key; an optional `phase` is folded in so the same chord on different phases (hold `s` vs keyup `s`) won't collapse together (Phase 1 leans on this).
  - `parseChord(raw, phase?)` — descriptor sequence for matching.
- **`keybindingConflicts.ts`** retrofitted to bucket by the **canonical key**, so alias-/order-equivalent chords (`Cmd+K` ≡ `$mod+k` ≡ `Shift+$mod+k`) collide — while still reporting the **raw authored chord** in the warning.

## Why these are not no-ops

- Modifier alias-folding + sort already existed; that part is a pure relocation. The **sequence parsing** is the net-new behavior — it's the historical cause of dead sequence chords (`g g`/`d d`).
- The conflict-detector change is a real behavior change: alias-equivalent chords that authored differently now surface as conflicts.

## Verification

`yarn run check` green: tsc clean, lint 0 errors (only pre-existing react-refresh warnings), **2767 tests pass**. New tests cover sequence parsing, alias/order equivalence, phase distinction, and the new conflict grouping; the lifted `normalizeChord` stays covered through `keyCapture.test.ts` via the re-export.

## Also

Corrects the plan doc's "`global` owns Escape" line — verified **nothing binds `Escape` at the `global` tier** (both `Escape` bindings are scoped: `exit_edit_mode_cm`/`EDIT_MODE_CM`, `clear_selection`/`MULTI_SELECT_MODE`). So the modal-over-`global` "Escape case" is illustrative, not current behavior, and the open precedence decision is likely moot for `Escape` specifically.

## Next

Phase 1 (resolver core + single-winner coordinator — closes the double-fire bug) builds on this as its own PR.

https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg)_