### PR TITLE
Phase 1: resolution core + single-winner coordinator (fixes the double-fire)

### DIFF
--- a/agent-extensions/readwise.tsx
+++ b/agent-extensions/readwise.tsx
@@ -1,5 +1,5 @@
 import {
-  actionDecoratorsFacet, actionsFacet, ActionContextTypes, appEffectsFacet, appMountsFacet,
+  actionTransformsFacet, actionsFacet, ActionContextTypes, appEffectsFacet, appMountsFacet,
   blockContentDecoratorsFacet, ChangeScope, codecs, defineBlockType, defineProperty,
   definePropertyEditorOverride, getPluginPrefsBlock,
   keyBetween, keysBetween, pluginBlockId,
@@ -8,7 +8,7 @@ import {
   showSuccess, typesFacet, useRepo,
   type ActionConfig,
   type ActionContextType,
-  type ActionDecorator,
+  type ActionTransform,
   type BlockContentDecorator,
   type BlockContentDecoratorContribution,
   type PropertyEditorProps,
@@ -1017,10 +1017,10 @@ const toggleHighlightReviewed = async (block: any): Promise<boolean> => {
 const decorateActionToToggleReadwiseReview = (
   actionId: string,
   context?: ActionContextType,
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   ...(context ? { context } : {}),
-  decorate: (action: ActionConfig): ActionConfig => ({
+  apply: (action: ActionConfig): ActionConfig => ({
     ...action,
     handler: async (deps, trigger, dispatch) => {
       const block = (deps as BlockShortcutDependencies).block
@@ -1030,10 +1030,10 @@ const decorateActionToToggleReadwiseReview = (
   }),
 })
 
-const readwiseSwipeRightDecorator: ActionDecorator =
+const readwiseSwipeRightDecorator: ActionTransform =
   decorateActionToToggleReadwiseReview(SWIPE_RIGHT_BLOCK_ACTION_ID)
 
-const readwiseTodoCycleDecorators: readonly ActionDecorator[] = [
+const readwiseTodoCycleDecorators: readonly ActionTransform[] = [
   decorateActionToToggleReadwiseReview(
     TODO_CYCLE_ACTION_ID,
     ActionContextTypes.NORMAL_MODE,
@@ -1660,7 +1660,7 @@ export default [
   actionsFacet.of(openSettingsAction, { source }),
   actionsFacet.of(syncNowAction, { source }),
   actionsFacet.of(connectAction, { source }),
-  actionDecoratorsFacet.of(readwiseSwipeRightDecorator, { source }),
+  actionTransformsFacet.of(readwiseSwipeRightDecorator, { source }),
   ...readwiseTodoCycleDecorators.map(decorator =>
-    actionDecoratorsFacet.of(decorator, { source })),
+    actionTransformsFacet.of(decorator, { source })),
 ]

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -368,6 +368,14 @@ type ActionTransform = {
       <code>spatial-navigation</code>'s decorators, plus the keybinding-override pass. There are <em>no</em> "vim
       skip-decorators" in this repo — those belong to the external agenda user and are out of scope here.</li>
 </ul>
+<p class="note"><strong>Shipped (supersedes the bullets above):</strong> the owner chose a
+   <strong>hard removal, no deprecation window</strong> — <code>ActionOverride</code>/<code>ActionDecorator</code>,
+   <code>actionOverridesFacet</code>/<code>actionDecoratorsFacet</code>, their guards, and their
+   <code>extensions/api.ts</code> exports are deleted outright rather than kept one release. Collapsed to
+   a <strong>single</strong> <code>actionTransformsFacet</code> (not two facet ids). Codemod inventory was
+   <strong>incomplete</strong>: it also had to migrate <code>agent-extensions/readwise.tsx</code> (the same
+   mark-complete/reviewed transforms as SRS), which is outside <code>tsconfig</code>/ESLint scope so
+   <code>yarn run check</code> did not flag it — a reviewer caught it.</p>
 </div>
 
 <div class="phase">

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -113,21 +113,21 @@ Lower-effort variant: leave the direct-call pattern, but lift the focus dance in
 
 Originally surfaced while debugging codex-flagged P2s on PR #21 (palette quick-action race + edit-mode latch). The handler-level workaround landed; this is the architectural cleanup.
 
-### Semantic action groups for decorator targets
+### Semantic action groups for transform targets
 
-SRS and Readwise both want to intercept the same user intent — "mark this block as complete/reviewed" — across three concrete actions: `todo.cycle`, `edit.cm.todo.cycle`, and `block.swipe-right`. Today each plugin contributes three decorators. That is locally simple and matches the current `actionDecoratorsFacet` contract, but it leaks the physical action list into every plugin that wants to specialize the semantic behavior.
+SRS and Readwise both want to intercept the same user intent — "mark this block as complete/reviewed" — across three concrete actions: `todo.cycle`, `edit.cm.todo.cycle`, and `block.swipe-right`. Today each plugin contributes three transforms. That is locally simple and matches the current `actionTransformsFacet` contract, but it leaks the physical action list into every plugin that wants to specialize the semantic behavior.
 
-Important distinction: the todo actions already delegate to one implementation function (`cycleTodoState`), but decorators do not wrap implementation calls. They wrap registered `ActionConfig` records by exact `action.id` plus optional context. So "decorate only todo cycle" would miss edit-mode and swipe-right unless those actions stopped being distinct action records.
+Important distinction: the todo actions already delegate to one implementation function (`cycleTodoState`), but transforms do not wrap implementation calls. They wrap registered `ActionConfig` records by exact `action.id` plus optional context. So "transform only todo cycle" would miss edit-mode and swipe-right unless those actions stopped being distinct action records.
 
-Explore adding semantic grouping metadata to actions, e.g. `groups: ['block.primary-complete']`, and letting decorators target a group as well as an id. Todo would mark all three concrete actions with the group; SRS/Readwise would contribute one group decorator that checks the block type and either consumes the action or falls through. Keep group membership as metadata during `getEffectiveActions` expansion — not a dispatch alias — so `block.swipe-right` remains a gesture-owned action and the swipe menu does not have to route through keyboard active-context dispatch.
+Explore adding semantic grouping metadata to actions, e.g. `groups: ['block.primary-complete']`, and letting transforms target a group as well as an id. Todo would mark all three concrete actions with the group; SRS/Readwise would contribute one group transform that checks the block type and either consumes the action or falls through. Keep group membership as metadata during `getEffectiveActions` expansion — not a dispatch alias — so `block.swipe-right` remains a gesture-owned action and the swipe menu does not have to route through keyboard active-context dispatch.
 
 Questions to answer before building:
 
-- Does `ActionDecorator` grow `groupId?: string`, or do actions expose `aliases?: readonly string[]` and decorators keep the single `actionId` field?
-- What is the ordering rule when both id-targeted and group-targeted decorators match the same action? Preserve contribution order if possible.
-- Should group decorators optionally constrain context, same as id decorators do today?
+- Does `ActionTransform` grow `groupId?: string`, or do actions expose `aliases?: readonly string[]` and transforms keep the single `actionId` field?
+- What is the ordering rule when both id-targeted and group-targeted transforms match the same action? Preserve contribution order if possible.
+- Should group transforms optionally constrain context, same as id transforms do today?
 - How should command palette / shortcut settings display grouped semantics without hiding the concrete action id that the user binds?
-- Is this worth a runtime semantic change, or is a helper like `decorateActions([ids...], factory)` enough until a third plugin needs the same pattern?
+- Is this worth a runtime semantic change, or is a helper like `transformActions([ids...], factory)` enough until a third plugin needs the same pattern?
 
 Acceptance for the exploration: produce a small design note or spike with tests around `getEffectiveActions`, compare it against the helper-only option, and only then migrate SRS/Readwise. Avoid making `block.swipe-right` delegate to `todo.cycle`; that would blur gesture deps with active keyboard contexts and make swipe behavior harder to reason about.
 

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -1,5 +1,11 @@
 # Follow-ups
 
+> **Deprecated — track new follow-ups as GitHub issues, not here.** This file
+> is frozen: open an issue at https://github.com/Stvad/knowledge-medium/issues
+> instead of appending. The entries below predate that decision and are kept as
+> historical context until they're migrated or closed. **Future agents: create
+> a GitHub issue rather than adding to this doc.**
+
 Sorted by priority. **P0** = security/data-loss risk active. **P1** = clear user impact or near-term blocker. **P2** = improvement with a mild trigger present. **P3** = deferred until a measured trigger fires. The "Architectural ideas" section at the bottom holds shapes with no current trigger — they exist so future-us doesn't re-derive the analysis from scratch.
 
 ## P0 — Security
@@ -186,16 +192,6 @@ The same id-only shape would work for the other three list-handle factories in `
 - `backlinkIds` — Backlinks UI also renders each backlink's content; row deps are bounded by the backlinks list size.
 
 Add when a measured hot path appears, not preemptively. Phase 4's `queriesFacet` (per `tasks/data-layer-redesign.md` §13.4) is the canonical place for these — `repo.childIds` will migrate alongside `repo.children` to `repo.query.childIds` with no callsite changes downstream of the hooks.
-
-### Single-key binding shadowing a co-active sequence chord — surface as a keybinding conflict
-
-The single-winner coordinator (`HotkeyReconciler`) feeds each candidate its own tinykeys matcher, then orders the set that completed *this* event through `resolve(...)` by context tier → priority → recency. Chord *length* is not a factor. So if a single-key binding is a prefix of a sequence in a co-active context — say a plugin binds `g` while vim normal mode keeps `g g` — both matchers complete on the second `g`, and the prefix can out-rank the sequence by context, so `g g` never fires. (Raised as a P2 by Codex on PR #103.)
-
-Not a resolver fix, for two reasons: (1) a "prefer the longer chord" tiebreak would have to rank *below* the modal/global tiers — a modal that binds `g` must still beat a background `g g` ("modal owns all chords"), so length can't be a top-level rule in the one comparator everything routes through; (2) the single-key prefix fires on the *first* press regardless (its matcher completes immediately), so even a perfect press-2 tiebreak can't undo the press-1 dispatch. The situation is fundamentally a misconfiguration — a single key racing a sequence it prefixes — which the conflict detector is the right place to catch.
-
-Fix shape: extend `keybindingConflicts.ts` (which already buckets chords via the Phase-0 canonical key and warns on collisions) to also flag "binding X is a strict prefix of sequence Y in an overlapping context" as an intentional-shadow-style warning, so the author sees it in shortcut settings rather than discovering a dead sequence at runtime. Needs the sequence-aware `parseChord` (already landed in Phase 0) to compare press lists, not just the atomic key.
-
-Not reachable today: the repo has exactly one sequence binding (`g g`, vim normal mode) and no single-key `g` binding in any context, so no prefix/sequence collision exists. Build it when a real one appears (or when the conflict-UI work in the plan's "Opportunistic" section gets picked up).
 
 ### `rendererProp` silently no-ops on a misspelled renderer id
 

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -187,6 +187,16 @@ The same id-only shape would work for the other three list-handle factories in `
 
 Add when a measured hot path appears, not preemptively. Phase 4's `queriesFacet` (per `tasks/data-layer-redesign.md` §13.4) is the canonical place for these — `repo.childIds` will migrate alongside `repo.children` to `repo.query.childIds` with no callsite changes downstream of the hooks.
 
+### Single-key binding shadowing a co-active sequence chord — surface as a keybinding conflict
+
+The single-winner coordinator (`HotkeyReconciler`) feeds each candidate its own tinykeys matcher, then orders the set that completed *this* event through `resolve(...)` by context tier → priority → recency. Chord *length* is not a factor. So if a single-key binding is a prefix of a sequence in a co-active context — say a plugin binds `g` while vim normal mode keeps `g g` — both matchers complete on the second `g`, and the prefix can out-rank the sequence by context, so `g g` never fires. (Raised as a P2 by Codex on PR #103.)
+
+Not a resolver fix, for two reasons: (1) a "prefer the longer chord" tiebreak would have to rank *below* the modal/global tiers — a modal that binds `g` must still beat a background `g g` ("modal owns all chords"), so length can't be a top-level rule in the one comparator everything routes through; (2) the single-key prefix fires on the *first* press regardless (its matcher completes immediately), so even a perfect press-2 tiebreak can't undo the press-1 dispatch. The situation is fundamentally a misconfiguration — a single key racing a sequence it prefixes — which the conflict detector is the right place to catch.
+
+Fix shape: extend `keybindingConflicts.ts` (which already buckets chords via the Phase-0 canonical key and warns on collisions) to also flag "binding X is a strict prefix of sequence Y in an overlapping context" as an intentional-shadow-style warning, so the author sees it in shortcut settings rather than discovering a dead sequence at runtime. Needs the sequence-aware `parseChord` (already landed in Phase 0) to compare press lists, not just the atomic key.
+
+Not reachable today: the repo has exactly one sequence binding (`g g`, vim normal mode) and no single-key `g` binding in any context, so no prefix/sequence collision exists. Build it when a real one appears (or when the conflict-UI work in the plan's "Opportunistic" section gets picked up).
+
 ### `rendererProp` silently no-ops on a misspelled renderer id
 
 [useRenderer](src/hooks/useRendererRegistry.tsx:26) reads `rendererProp` and only honors it via `if (rendererKey && registry[rendererKey])` — when the prop names a renderer id that isn't registered (typo, plugin not loaded, renderer renamed), the lookup silently fails and resolution falls through to the `canRender` predicate sort. The user's explicit override is lost with no signal.

--- a/src/extensions/api.ts
+++ b/src/extensions/api.ts
@@ -40,9 +40,8 @@ export {
 
 // --- Blessed core facets ---
 export {
-  actionDecoratorsFacet,
+  actionTransformsFacet,
   actionsFacet,
-  actionOverridesFacet,
   actionContextsFacet,
   appEffectsFacet,
   appMountsFacet,
@@ -113,8 +112,7 @@ export {
   type ActionContextConfig,
   type ActionContextType,
   type Action,
-  type ActionDecorator,
-  type ActionOverride,
+  type ActionTransform,
   type ShortcutBinding,
   type KeyCombination,
 } from '@/shortcuts/types.js'

--- a/src/extensions/core.ts
+++ b/src/extensions/core.ts
@@ -6,8 +6,7 @@ import {
   ActionConfig,
   ActionContextConfig,
   ActionContextType,
-  type ActionDecorator,
-  type ActionOverride,
+  type ActionTransform,
 } from '@/shortcuts/types.js'
 import { BlockRenderer, RendererRegistry } from '@/types.js'
 import type { ComponentType } from 'react'
@@ -121,17 +120,11 @@ export const isActionConfig = (value: unknown): value is ActionConfig =>
   typeof value.handler === 'function' &&
   (value.defaultBinding === undefined || isShortcutBindingInput(value.defaultBinding))
 
-const isActionOverride = (value: unknown): value is ActionOverride =>
+const isActionTransform = (value: unknown): value is ActionTransform =>
   isRecord(value) &&
   typeof value.actionId === 'string' &&
   (value.context === undefined || isActionContextType(value.context)) &&
   typeof value.apply === 'function'
-
-const isActionDecorator = (value: unknown): value is ActionDecorator =>
-  isRecord(value) &&
-  typeof value.actionId === 'string' &&
-  (value.context === undefined || isActionContextType(value.context)) &&
-  typeof value.decorate === 'function'
 
 export const createRendererRegistry = (
   contributions: readonly RendererContribution[],
@@ -160,14 +153,14 @@ export const actionsFacet = defineFacet<ActionConfig, readonly ActionConfig[]>({
   validate: isActionConfig,
 })
 
-export const actionOverridesFacet = defineFacet<ActionOverride, readonly ActionOverride[]>({
-  id: 'core.action-overrides',
-  validate: isActionOverride,
-})
-
-export const actionDecoratorsFacet = defineFacet<ActionDecorator, readonly ActionDecorator[]>({
-  id: 'core.action-decorators',
-  validate: isActionDecorator,
+/**
+ * The one facet for contributing action transforms (replace / wrap /
+ * unbind). The effective-actions pipeline runs every contribution in a
+ * single ordered pass.
+ */
+export const actionTransformsFacet = defineFacet<ActionTransform, readonly ActionTransform[]>({
+  id: 'core.action-transforms',
+  validate: isActionTransform,
 })
 
 export const isAppEffect = (value: unknown): value is AppEffect =>

--- a/src/extensions/test/api.test.ts
+++ b/src/extensions/test/api.test.ts
@@ -13,10 +13,9 @@ describe('@/extensions/api — public surface', () => {
     // Facet primitives
     'defineFacet',
     // Blessed core facets
-    'actionDecoratorsFacet',
+    'actionTransformsFacet',
     'actionsFacet',
     'actionContextsFacet',
-    'actionOverridesFacet',
     'appEffectsFacet',
     'appMountsFacet',
     'blockRenderersFacet',

--- a/src/plugins/backlinks/backlinkBreadcrumbShortcuts.ts
+++ b/src/plugins/backlinks/backlinkBreadcrumbShortcuts.ts
@@ -87,7 +87,7 @@ export const promoteClosestBreadcrumbAction: ActionConfig = {
     const deps = toBacklinkEntryShortcutDependencies(dependencies)
     deps.promoteClosestBreadcrumb?.()
   },
-  canRun: (dependencies) => {
+  isVisible: (dependencies) => {
     const deps = toBacklinkEntryShortcutDependencies(dependencies)
     return deps.hasBreadcrumb?.() === true
   },

--- a/src/plugins/block-tagging/test/plugin.test.ts
+++ b/src/plugins/block-tagging/test/plugin.test.ts
@@ -38,7 +38,7 @@ describe('blockTaggingPlugin', () => {
     expect(blocksAction?.context).toBe(ActionContextTypes.MULTI_SELECT_MODE)
     expect(blockAction?.icon).toBe(Tag)
     expect(blocksAction?.icon).toBe(Tag)
-    expect(typeof blocksAction?.canRun).toBe('function')
+    expect(typeof blocksAction?.isVisible).toBe('function')
   })
 
   it('contributes a grouped-backlinks header entry pointing at the multi-select action id', () => {

--- a/src/plugins/command-palette/test/useCommandPaletteActions.test.tsx
+++ b/src/plugins/command-palette/test/useCommandPaletteActions.test.tsx
@@ -30,8 +30,8 @@ const renderHookWithRuntime = (runtime: FacetRuntime) =>
     ),
   })
 
-describe('useCommandPaletteActions canRun filter', () => {
-  it('hides actions whose canRun returns false against the active context deps', () => {
+describe('useCommandPaletteActions isVisible filter', () => {
+  it('hides actions whose isVisible returns false against the active context deps', () => {
     const always: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
       id: 'always',
       description: 'Always',
@@ -42,7 +42,7 @@ describe('useCommandPaletteActions canRun filter', () => {
       id: 'gated',
       description: 'Gated',
       context: ActionContextTypes.NORMAL_MODE,
-      canRun: ({block}) => block.id === 'allowed',
+      isVisible: ({block}) => block.id === 'allowed',
       handler: vi.fn(),
     }
     const runtime = resolveFacetRuntimeSync([
@@ -92,7 +92,7 @@ describe('useCommandPaletteActions canRun filter', () => {
     expect(ids).not.toContain(commandPaletteForBlockAction.id)
   })
 
-  it('passes through actions without a canRun predicate (default visible)', () => {
+  it('passes through actions without a isVisible predicate (default visible)', () => {
     const noPred: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
       id: 'no-pred',
       description: 'No predicate',

--- a/src/plugins/command-palette/useCommandPaletteActions.ts
+++ b/src/plugins/command-palette/useCommandPaletteActions.ts
@@ -62,14 +62,14 @@ export function useCommandPaletteActions(): CommandPaletteActionsResult {
     const actions = allActions.filter(action => {
       if (!active.has(action.context)) return false
       if (PALETTE_HIDDEN_FROM_PALETTE.has(action.id)) return false
-      if (!action.canRun) return true
+      if (!action.isVisible) return true
       // The shortcut system stores the active context's dependencies
-      // exactly as the handler will receive them, so canRun can run
-      // against them directly. An action whose canRun returns false
+      // exactly as the handler will receive them, so isVisible can run
+      // against them directly. An action whose isVisible returns false
       // would silently no-op if shown — hide it instead.
       const deps = active.get(action.context)
       if (!deps) return true
-      return action.canRun(deps as never)
+      return action.isVisible(deps as never)
     })
 
     const activeContexts: ActiveContextInfo[] = Array.from(active.entries()).flatMap(

--- a/src/plugins/daily-notes/ReschedulePicker.tsx
+++ b/src/plugins/daily-notes/ReschedulePicker.tsx
@@ -140,7 +140,7 @@ export const ReschedulePicker = () => {
       const block = repo.block(detail.blockId)
       const adapter = pickBlockDateAdapter(runtime, block)
       if (!adapter) {
-        // The action's `canRun` already filters this out — log so a
+        // The action's `isVisible` already filters this out — log so a
         // misconfigured plugin (e.g. forgot to register the adapter) is
         // still visible.
         console.error(`[reschedule] no adapter handles block ${detail.blockId}`)

--- a/src/plugins/daily-notes/blockDateAdapter.ts
+++ b/src/plugins/daily-notes/blockDateAdapter.ts
@@ -7,7 +7,7 @@
  * - daily-notes can't import srs-rescheduling without a layering cycle
  *   (srs-rescheduling already depends on daily-notes for daily-note
  *   resolution).
- * - The existing `actionDecoratorsFacet` pattern only handles
+ * - The existing `actionTransformsFacet` pattern only handles
  *   parameter-less actions ("shift +1d"). Picking an absolute ISO from
  *   a calendar can't go through that channel without inventing a
  *   parameter passing mechanism.

--- a/src/plugins/daily-notes/blockDateAdapter.ts
+++ b/src/plugins/daily-notes/blockDateAdapter.ts
@@ -23,7 +23,7 @@ import { defineFacet, type FacetRuntime } from '@/extensions/facet.js'
 export interface BlockDateAdapter {
   /** Diagnostic id, also distinguishes adapters in tests. */
   readonly id: string
-  /** Sync predicate over `block.peek()` — used by `canRun` gates and
+  /** Sync predicate over `block.peek()` — used by `isVisible` gates and
    *  the swipe-menu visibility filter, which both run during render. */
   canHandle: (block: Block) => boolean
   /** Resolves the ISO (`YYYY-MM-DD`) the adapter is currently representing

--- a/src/plugins/daily-notes/rescheduleAction.ts
+++ b/src/plugins/daily-notes/rescheduleAction.ts
@@ -1,6 +1,6 @@
 /**
  * "Reschedule" quick-action — opens the calendar+strip sheet over the
- * swiped block. The base action's `canRun` gates on the regular
+ * swiped block. The base action's `isVisible` gates on the regular
  * date-reference adapter; the SRS plugin contributes a decorator that
  * extends the gate to SRS blocks. The picker itself looks up the right
  * adapter via `blockDateAdapterFacet` at commit time, so the handler
@@ -23,7 +23,7 @@ export const rescheduleBlockDateAction: ActionConfig<typeof ActionContextTypes.N
   description: 'Reschedule block date',
   context: ActionContextTypes.NORMAL_MODE,
   icon: CalendarRange,
-  canRun: ({block}) => referenceDateAdapter.canHandle(block),
+  isVisible: ({block}) => referenceDateAdapter.canHandle(block),
   handler: async ({block}: BlockShortcutDependencies) => {
     const data = block.peek() ?? await block.load()
     if (!data) return

--- a/src/plugins/daily-notes/spreadDatesAction.ts
+++ b/src/plugins/daily-notes/spreadDatesAction.ts
@@ -50,7 +50,7 @@ const pair = defineBlocksAction({
   blockDescription: 'Spread block date across upcoming days',
   blocksDescription: 'Spread dates across upcoming days',
   appliesTo: (block: Block) => {
-    // canRun runs sync during render; fall back to "permissive"
+    // isVisible runs sync during render; fall back to "permissive"
     // when the runtime isn't installed yet (test setups) so the
     // surface doesn't disappear unconditionally.
     const runtime = block.repo.facetRuntime

--- a/src/plugins/extract-type/action.ts
+++ b/src/plugins/extract-type/action.ts
@@ -45,8 +45,8 @@ export const findTypeInstancesAction: ActionConfig<typeof ActionContextTypes.NOR
   context: ActionContextTypes.NORMAL_MODE,
   icon: Users,
   // Only meaningful on a block-type block. Surfaces (command palette,
-  // swipe menu) hide the entry when canRun is false.
-  canRun: ({block}) => {
+  // swipe menu) hide the entry when isVisible is false.
+  isVisible: ({block}) => {
     const data = block.peek()
     return !!data && getBlockTypes(data).includes(BLOCK_TYPE_TYPE)
   },

--- a/src/plugins/grouped-backlinks/GroupHeaderActionButton.tsx
+++ b/src/plugins/grouped-backlinks/GroupHeaderActionButton.tsx
@@ -31,7 +31,7 @@ interface GroupHeaderActionButtonProps {
  *  Resolves the action from the runtime at render time rather than
  *  at facet-contribution time so contributions don't have to be
  *  ordered with the action registration. If the action isn't
- *  registered, or its `canRun` predicate rejects the synthesized
+ *  registered, or its `isVisible` predicate rejects the synthesized
  *  deps, the button renders nothing — same affordance-hiding
  *  contract as the command palette. */
 export const GroupHeaderActionButton = ({
@@ -65,7 +65,7 @@ export const GroupHeaderActionButton = ({
     anchorBlock: null,
     uiStateBlock,
   }
-  if (action.canRun && !action.canRun(deps)) return null
+  if (action.isVisible && !action.isVisible(deps)) return null
 
   const Icon = iconOverride ?? action.icon
   const label = labelOverride ?? action.description

--- a/src/plugins/merge-blocks/mergeAction.ts
+++ b/src/plugins/merge-blocks/mergeAction.ts
@@ -6,7 +6,7 @@
  * looking at the two blocks' types, so the kernel mutator stays
  * policy-free (see `core.merge`).
  *
- * Visible for any block (no `canRun` gate) per the design discussion:
+ * Visible for any block (no `isVisible` gate) per the design discussion:
  * for outline blocks the user gets a concat-style merge they could've
  * gotten with Backspace; for pages they get the type-aware page merge.
  */

--- a/src/plugins/spatial-navigation/actions.ts
+++ b/src/plugins/spatial-navigation/actions.ts
@@ -1,12 +1,12 @@
 import {
-  actionDecoratorsFacet,
+  actionTransformsFacet,
   actionsFacet,
 } from '@/extensions/core.js'
 import type { AppExtension } from '@/extensions/facet.js'
 import {
   ActionConfig,
   type BaseShortcutDependencies,
-  type ActionDecorator,
+  type ActionTransform,
   ActionContextTypes,
   type BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
@@ -298,10 +298,10 @@ const verticalDecorator = (
   actionId: 'move_down' | 'move_up',
   direction: 'down' | 'up',
   description: string,
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   context: ActionContextTypes.NORMAL_MODE,
-  decorate: action => ({
+  apply: action => ({
     ...action,
     description,
     handler: async (deps, trigger, dispatch) => {
@@ -315,10 +315,10 @@ const selectionVerticalDecorator = (
   actionId: 'extend_selection_down' | 'extend_selection_up' | 'multi_select.extend_selection_down' | 'multi_select.extend_selection_up',
   context: typeof ActionContextTypes.NORMAL_MODE | typeof ActionContextTypes.MULTI_SELECT_MODE,
   direction: 'down' | 'up',
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   context,
-  decorate: action => ({
+  apply: action => ({
     ...action,
     handler: async (deps, trigger, dispatch) => {
       if (await extendSelectionVertical(deps, direction)) return
@@ -327,7 +327,7 @@ const selectionVerticalDecorator = (
   }),
 })
 
-export function getSpatialNavigationActionDecorators(): ActionDecorator[] {
+export function getSpatialNavigationActionDecorators(): ActionTransform[] {
   return [
     verticalDecorator('move_down', 'down', 'Move focus down (next block, then stack-sibling panel below)'),
     verticalDecorator('move_up', 'up', 'Move focus up (previous block, then stack-sibling panel above)'),
@@ -345,5 +345,5 @@ export const spatialNavigationActionsExtension: AppExtension =
 
 export const spatialNavigationActionDecoratorsExtension: AppExtension =
   getSpatialNavigationActionDecorators().map(decorator =>
-    actionDecoratorsFacet.of(decorator as ActionDecorator, {source: 'spatial-navigation'}),
+    actionTransformsFacet.of(decorator, {source: 'spatial-navigation'}),
   )

--- a/src/plugins/spatial-navigation/test/actions.test.ts
+++ b/src/plugins/spatial-navigation/test/actions.test.ts
@@ -102,7 +102,7 @@ const decorateAction = <T extends typeof ActionContextTypes.NORMAL_MODE | typeof
     candidate.actionId === action.id && candidate.context === action.context,
   )
   if (!decorator) throw new Error(`Missing spatial decorator for ${action.context}:${action.id}`)
-  return decorator.decorate(action as ActionConfig) as ActionConfig<T>
+  return decorator.apply(action as ActionConfig) as ActionConfig<T>
 }
 
 let sharedDb: TestDb

--- a/src/plugins/srs-rescheduling/index.ts
+++ b/src/plugins/srs-rescheduling/index.ts
@@ -1,5 +1,5 @@
 import { Check, ClipboardPaste, ClockArrowDown, Gauge, RotateCcw, Scissors, Sparkles } from 'lucide-react'
-import { actionDecoratorsFacet, actionsFacet } from '@/extensions/core.js'
+import { actionTransformsFacet, actionsFacet } from '@/extensions/core.js'
 import type { AppExtension } from '@/extensions/facet.js'
 import { systemToggle } from '@/extensions/togglable.js'
 import type { Block } from '@/data/block'
@@ -591,10 +591,10 @@ export const srsReschedulingPlugin: AppExtension = systemToggle({
   srsReschedulingActions.map(action =>
     actionsFacet.of(action, {source: 'srs-rescheduling'}),
   ),
-  actionDecoratorsFacet.of(srsRescheduleDecorator, {source: 'srs-rescheduling'}),
-  actionDecoratorsFacet.of(srsSwipeRightDecorator, {source: 'srs-rescheduling'}),
+  actionTransformsFacet.of(srsRescheduleDecorator, {source: 'srs-rescheduling'}),
+  actionTransformsFacet.of(srsSwipeRightDecorator, {source: 'srs-rescheduling'}),
   srsTodoCycleDecorators.map(decorator =>
-    actionDecoratorsFacet.of(decorator, {source: 'srs-rescheduling'}),
+    actionTransformsFacet.of(decorator, {source: 'srs-rescheduling'}),
   ),
   // Negative precedence: SRS adapter sorts before the generic reference
   // adapter so a block that is BOTH an SRS card AND has an inline date

--- a/src/plugins/srs-rescheduling/index.ts
+++ b/src/plugins/srs-rescheduling/index.ts
@@ -456,7 +456,7 @@ const createScrubRescheduleAction = (
     description: `SRS: ${name} (Date Scrub)`,
     context: DATE_SCRUB_CONTEXT,
     icon: iconForSignal(signal),
-    canRun: (deps: BaseShortcutDependencies) => {
+    isVisible: (deps: BaseShortcutDependencies) => {
       const block = blockFromDependencies(deps)
       const data = block?.peek()
       return !!data && getBlockTypes(data).includes(SRS_SM25_TYPE)
@@ -488,7 +488,7 @@ const srsCutAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
   description: 'SRS: Cut state',
   context: ActionContextTypes.NORMAL_MODE,
   icon: Scissors,
-  canRun: ({block}) => {
+  isVisible: ({block}) => {
     const data = block.peek()
     return !!data && getBlockTypes(data).includes(SRS_SM25_TYPE)
   },
@@ -507,7 +507,7 @@ const srsPasteAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
   description: 'SRS: Paste state',
   context: ActionContextTypes.NORMAL_MODE,
   icon: ClipboardPaste,
-  canRun: ({block}) => {
+  isVisible: ({block}) => {
     const entry = getSrsClipboard()
     return entry !== null && entry.sourceBlockId !== block.id
   },
@@ -547,7 +547,7 @@ const srsQuickActionItems = srsSignals
 // Overflow keeps them out of the primary strip — these are rarer than
 // reschedule. Visibility (cut only on SRS blocks; paste only when
 // something is stashed and the target isn't the same block) is gated by
-// the `canRun` predicate on the actions themselves, so the same gating
+// the `isVisible` predicate on the actions themselves, so the same gating
 // applies to the command palette.
 const srsCutQuickAction = {
   actionId: 'srs.cut',

--- a/src/plugins/srs-rescheduling/rescheduleDecorator.ts
+++ b/src/plugins/srs-rescheduling/rescheduleDecorator.ts
@@ -10,14 +10,14 @@ import {
 } from '@/plugins/daily-notes/rescheduleAction.js'
 import type {
   ActionConfig,
-  ActionDecorator,
+  ActionTransform,
   BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
 import { srsBlockDateAdapter } from './srsBlockDateAdapter.ts'
 
-export const srsRescheduleDecorator: ActionDecorator = {
+export const srsRescheduleDecorator: ActionTransform = {
   actionId: RESCHEDULE_BLOCK_DATE_ACTION_ID,
-  decorate: (action: ActionConfig): ActionConfig => ({
+  apply: (action: ActionConfig): ActionConfig => ({
     ...action,
     isVisible: (deps) => {
       const block = (deps as BlockShortcutDependencies).block

--- a/src/plugins/srs-rescheduling/rescheduleDecorator.ts
+++ b/src/plugins/srs-rescheduling/rescheduleDecorator.ts
@@ -1,7 +1,7 @@
 /**
  * Extends the daily-notes "Reschedule" action so it stays visible on
  * SRS blocks that don't have an inline date reference (where the base
- * `canRun` would say "nope, no shiftable date here"). The handler is
+ * `isVisible` would say "nope, no shiftable date here"). The handler is
  * shared — it only opens the picker, and the picker resolves the right
  * adapter at commit time via `blockDateAdapterFacet`.
  */
@@ -19,10 +19,10 @@ export const srsRescheduleDecorator: ActionDecorator = {
   actionId: RESCHEDULE_BLOCK_DATE_ACTION_ID,
   decorate: (action: ActionConfig): ActionConfig => ({
     ...action,
-    canRun: (deps) => {
+    isVisible: (deps) => {
       const block = (deps as BlockShortcutDependencies).block
       if (block && srsBlockDateAdapter.canHandle(block)) return true
-      return action.canRun?.(deps as never) ?? true
+      return action.isVisible?.(deps as never) ?? true
     },
   }),
 }

--- a/src/plugins/srs-rescheduling/swipeRightDecorator.ts
+++ b/src/plugins/srs-rescheduling/swipeRightDecorator.ts
@@ -8,7 +8,7 @@ import {
 import type {
   ActionConfig,
   ActionContextType,
-  ActionDecorator,
+  ActionTransform,
   BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
 import { ActionContextTypes } from '@/shortcuts/types.js'
@@ -27,10 +27,10 @@ export const archiveSrsBlock = async (block: Block): Promise<boolean> => {
 const decorateActionToArchiveSrsBlock = (
   actionId: string,
   context?: ActionContextType,
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   ...(context ? {context} : {}),
-  decorate: (action: ActionConfig): ActionConfig => ({
+  apply: (action: ActionConfig): ActionConfig => ({
     ...action,
     handler: async (deps, trigger) => {
       const block = (deps as BlockShortcutDependencies).block
@@ -40,10 +40,10 @@ const decorateActionToArchiveSrsBlock = (
   }),
 })
 
-export const srsSwipeRightDecorator: ActionDecorator =
+export const srsSwipeRightDecorator: ActionTransform =
   decorateActionToArchiveSrsBlock(SWIPE_RIGHT_BLOCK_ACTION_ID)
 
-export const srsTodoCycleDecorators: readonly ActionDecorator[] = [
+export const srsTodoCycleDecorators: readonly ActionTransform[] = [
   decorateActionToArchiveSrsBlock(
     TODO_CYCLE_ACTION_ID,
     ActionContextTypes.NORMAL_MODE,

--- a/src/plugins/srs-rescheduling/test/plugin.test.ts
+++ b/src/plugins/srs-rescheduling/test/plugin.test.ts
@@ -262,8 +262,8 @@ describe('srsReschedulingPlugin', () => {
     const actions = runtime.read(actionsFacet)
     const cutAction = actions.find(it => it.id === 'srs.cut')
     const pasteAction = actions.find(it => it.id === 'srs.paste')
-    expect(typeof cutAction?.canRun).toBe('function')
-    expect(typeof pasteAction?.canRun).toBe('function')
+    expect(typeof cutAction?.isVisible).toBe('function')
+    expect(typeof pasteAction?.isVisible).toBe('function')
 
     expect(runtime.contributions(blockContentSurfacePropsFacet)).toHaveLength(1)
   })
@@ -514,8 +514,8 @@ describe('srsReschedulingPlugin', () => {
     })
 
     // "cut on a non-SRS block is a no-op" is enforced by surfaces via
-    // `canRun` (the gating test below) — the handler itself no longer
-    // re-checks. Direct programmatic invocation that bypasses canRun is
+    // `isVisible` (the gating test below) — the handler itself no longer
+    // re-checks. Direct programmatic invocation that bypasses isVisible is
     // out of contract.
 
     it('paste is a no-op when nothing is stashed', async () => {
@@ -532,7 +532,7 @@ describe('srsReschedulingPlugin', () => {
       expect(data?.properties.types ?? []).not.toContain(SRS_SM25_TYPE)
     })
 
-    it('canRun gates cut to SRS blocks and paste to non-source blocks with a stash', async () => {
+    it('isVisible gates cut to SRS blocks and paste to non-source blocks with a stash', async () => {
       const {repo, runtime} = setupRepo()
       await seedSrsBlock(repo, 'src', 5)
       await seedPlainBlock(repo, 'plain')
@@ -549,16 +549,16 @@ describe('srsReschedulingPlugin', () => {
       await plainBlock.load()
 
       // Cut visible on SRS blocks only.
-      expect(cutAction.canRun!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(true)
-      expect(cutAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
+      expect(cutAction.isVisible!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(true)
+      expect(cutAction.isVisible!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
 
       // Paste hidden until something is cut.
-      expect(pasteAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
+      expect(pasteAction.isVisible!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
 
       setSrsClipboard({sourceBlockId: 'src', sourceWorkspaceId: 'ws-1'})
-      expect(pasteAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(true)
+      expect(pasteAction.isVisible!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(true)
       // Paste hidden on the source block itself.
-      expect(pasteAction.canRun!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(false)
+      expect(pasteAction.isVisible!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(false)
     })
   })
 

--- a/src/plugins/srs-rescheduling/test/rescheduleDecorator.test.ts
+++ b/src/plugins/srs-rescheduling/test/rescheduleDecorator.test.ts
@@ -61,17 +61,17 @@ afterEach(async () => {
 })
 
 describe('reschedule action with SRS decorator', () => {
-  it('canRun is true on a regular block with one date reference (base predicate)', async () => {
+  it('isVisible is true on a regular block with one date reference (base predicate)', async () => {
     const runtime = setupRuntime()
     await repo.tx(tx => tx.create({id: 'b', workspaceId: WS, parentId: null, orderKey: 'a',
       content: 'due [[2026-05-15]]'}), {scope: ChangeScope.BlockDefault})
     const block = repo.block('b'); await block.load()
 
     const action = findRescheduleAction(runtime)
-    expect(action.canRun?.({block, uiStateBlock: block} as BlockShortcutDependencies)).toBe(true)
+    expect(action.isVisible?.({block, uiStateBlock: block} as BlockShortcutDependencies)).toBe(true)
   })
 
-  it('canRun is true on an SRS block without inline date (decorator extension)', async () => {
+  it('isVisible is true on an SRS block without inline date (decorator extension)', async () => {
     const runtime = setupRuntime()
     const may1 = await getOrCreateDailyNote(repo, WS, '2026-05-01')
     await repo.tx(tx => tx.create({id: 'srs', workspaceId: WS, parentId: null, orderKey: 'a',
@@ -84,16 +84,16 @@ describe('reschedule action with SRS decorator', () => {
 
     const block = repo.block('srs'); await block.load()
     const action = findRescheduleAction(runtime)
-    expect(action.canRun?.({block, uiStateBlock: block} as BlockShortcutDependencies)).toBe(true)
+    expect(action.isVisible?.({block, uiStateBlock: block} as BlockShortcutDependencies)).toBe(true)
   })
 
-  it('canRun is false on a plain block (no date, no SRS state)', async () => {
+  it('isVisible is false on a plain block (no date, no SRS state)', async () => {
     const runtime = setupRuntime()
     await repo.tx(tx => tx.create({id: 'plain', workspaceId: WS, parentId: null, orderKey: 'a',
       content: 'just notes'}), {scope: ChangeScope.BlockDefault})
     const block = repo.block('plain'); await block.load()
 
     const action = findRescheduleAction(runtime)
-    expect(action.canRun?.({block, uiStateBlock: block} as BlockShortcutDependencies)).toBe(false)
+    expect(action.isVisible?.({block, uiStateBlock: block} as BlockShortcutDependencies)).toBe(false)
   })
 })

--- a/src/plugins/srs-review/index.ts
+++ b/src/plugins/srs-review/index.ts
@@ -51,7 +51,7 @@ const srsArchiveAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
   description: 'SRS: Archive card',
   context: ActionContextTypes.NORMAL_MODE,
   icon: ArchiveX,
-  canRun: ({block}) => {
+  isVisible: ({block}) => {
     const data = block.peek()
     return !!data && getBlockTypes(data).includes(SRS_SM25_TYPE)
   },

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -353,7 +353,7 @@ export const SwipeActionMenu = () => {
     // panel's top-level block is the scope root — the same value the
     // structural handlers need (delete/indent/move).
     const deps = {block, uiStateBlock, scopeRootId: topLevelBlockId, ...(renderScopeId ? {renderScopeId} : {})}
-    if (action.canRun && !action.canRun(deps)) return false
+    if (action.isVisible && !action.isVisible(deps)) return false
 
     void Promise.resolve(action.handler(deps, trigger)).catch(error => {
       console.error(`[swipe-quick-actions] Action "${actionId}" failed`, error)
@@ -361,7 +361,7 @@ export const SwipeActionMenu = () => {
     return true
   }, [allActions, repo, uiStateBlock, topLevelBlockId])
   const actionItems = runtime.read(quickActionItemsFacet)
-  // Filter via the referenced action's `canRun` (the swipe surface is
+  // Filter via the referenced action's `isVisible` (the swipe surface is
   // presentational — semantic availability lives on the action). The
   // filter runs at menu-open time, not reactively. Items whose action
   // isn't registered fall through so the missing-action error is still
@@ -378,8 +378,8 @@ export const SwipeActionMenu = () => {
     return actionItems.filter(item => {
       const action = allActions.find(a => a.id === item.actionId)
       if (!action) return true
-      if (!action.canRun) return true
-      return action.canRun(deps)
+      if (!action.isVisible) return true
+      return action.isVisible(deps)
     })
   }, [
     actionItems, allActions,

--- a/src/plugins/swipe-quick-actions/actions.ts
+++ b/src/plugins/swipe-quick-actions/actions.ts
@@ -4,7 +4,7 @@ import { defineFacet } from '@/extensions/facet.js'
 
 /** Semantic action invoked by a right-swipe on a block content surface.
  *  The gesture plugin owns the trigger; another plugin owns the baseline
- *  handler and other plugins can decorate it through `actionDecoratorsFacet`. */
+ *  handler and other plugins can decorate it through `actionTransformsFacet`. */
 export const SWIPE_RIGHT_BLOCK_ACTION_ID = 'block.swipe-right'
 
 export interface QuickActionContext {

--- a/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
+++ b/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
@@ -251,7 +251,7 @@ describe('SwipeActionMenu', () => {
     })
   })
 
-  it('hides items whose action.canRun returns false for the swiped block', async () => {
+  it('hides items whose action.isVisible returns false for the swiped block', async () => {
     const alwaysAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
       id: 'always',
       description: 'Always',
@@ -262,7 +262,7 @@ describe('SwipeActionMenu', () => {
       id: 'gated',
       description: 'Gated',
       context: ActionContextTypes.NORMAL_MODE,
-      canRun: ({block}) => block.id !== 'block-1',
+      isVisible: ({block}) => block.id !== 'block-1',
       handler: vi.fn(),
     }
     runtime = resolveFacetRuntimeSync([
@@ -285,13 +285,13 @@ describe('SwipeActionMenu', () => {
     const handler = vi.fn((deps: BlockShortcutDependencies) => {
       expect(deps.block.id).toBe('block-1')
     })
-    const canRun = vi.fn((deps: BlockShortcutDependencies) => deps.block.id === 'block-1')
+    const isVisible = vi.fn((deps: BlockShortcutDependencies) => deps.block.id === 'block-1')
     runtime = resolveFacetRuntimeSync([
       actionsFacet.of({
         id: 'scoped_action',
         description: 'Scoped action',
         context: ActionContextTypes.NORMAL_MODE,
-        canRun,
+        isVisible,
         handler,
       }, {source: 'test'}),
       quickActionItemsFacet.of({actionId: 'scoped_action', label: 'Scoped'}, {source: 'test'}),
@@ -313,7 +313,7 @@ describe('SwipeActionMenu', () => {
     })
     fireEvent.click(await screen.findByRole('button', {name: 'Scoped'}))
 
-    expect(canRun.mock.calls.some(([deps]) => deps.renderScopeId === 'scope-b')).toBe(true)
+    expect(isVisible.mock.calls.some(([deps]) => deps.renderScopeId === 'scope-b')).toBe(true)
     const deps = handler.mock.calls[0]?.[0] as BlockShortcutDependencies | undefined
     expect(deps?.block.id).toBe('block-1')
     expect(deps?.uiStateBlock.id).toBe('panel-1')

--- a/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
+++ b/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
@@ -7,7 +7,7 @@ import { BlockCache } from '@/data/blockCache'
 import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import type { Block } from '@/data/block'
-import { actionDecoratorsFacet, actionsFacet } from '@/extensions/core'
+import { actionTransformsFacet, actionsFacet } from '@/extensions/core'
 import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext'
 import { type ActionConfig, ActionContextTypes, type BlockShortcutDependencies } from '@/shortcuts/types'
@@ -332,10 +332,10 @@ describe('SwipeActionMenu', () => {
     }
     runtime = resolveFacetRuntimeSync([
       actionsFacet.of(baseAction, {source: 'test'}),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: SWIPE_RIGHT_BLOCK_ACTION_ID,
         context: ActionContextTypes.NORMAL_MODE,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             const blockDeps = deps as BlockShortcutDependencies

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -148,7 +148,11 @@ export function HotkeyReconciler(): null {
   // always current. Torn down on unmount so stray callers fail loudly.
   useEffect(() => {
     setRunActionDispatcher((actionId: string, trigger: ActionTrigger) => {
-      const action = getActiveActionById(getEffectiveActions(runtime), activeRef.current, actionId)
+      const action = getActiveActionById(
+        getEffectiveActions(runtime),
+        {active: activeRef.current, contextConfigsByType: contextConfigsByTypeRef.current},
+        actionId,
+      )
       if (!action) {
         throw new Error(`[HotkeyReconciler] Active action with ID "${actionId}" not found.`)
       }

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -19,7 +19,7 @@ import {
   getEffectiveActions,
 } from './effectiveActions.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
-import { computeInstallableContexts } from './resolve.ts'
+import { compareContexts, computeInstallableContexts } from './resolve.ts'
 import {
   ActionConfig,
   ActionContextConfig,
@@ -31,8 +31,23 @@ import {
 } from '@/shortcuts/types.js'
 import { hasEditableTarget, isTypingKeyEvent, withRecoveredLetterKey } from '@/shortcuts/utils.js'
 
-interface InstalledBinding {
-  unsubscribe: () => void
+/**
+ * A non-hold keyboard binding's per-candidate tinykeys matcher. Fed every
+ * event of its phase so it keeps its own sequence state (`g g`); on a
+ * completed match its callback records the candidate for this event rather
+ * than running the handler directly — the coordinator picks the winner.
+ */
+interface KeyboardCandidate {
+  action: ActionConfig
+  binding: ShortcutBindingDefaults
+  phase: 'keydown' | 'keyup'
+  matcher: (event: KeyboardEvent) => void
+}
+
+/** A binding whose chord completed on the event currently being processed. */
+interface CompletedBinding {
+  action: ActionConfig
+  binding: ShortcutBindingDefaults
 }
 
 const normalizeKeys = (keys: string | string[]): readonly string[] =>
@@ -163,29 +178,40 @@ export function HotkeyReconciler(): null {
     return () => setRunActionDispatcher(null)
   }, [runtime])
 
-  // Track which actions currently have hotkeys installed.
-  // Each entry owns its own tinykeys subscription — calling its
-  // unsubscribe removes only that handler's listener.
+  // One coordinator per phase replaces the N per-action window listeners —
+  // that sibling-listener model was the double-fire (a binding's
+  // preventDefault can't stop a sibling listener). Each installable non-hold
+  // binding keeps its own tinykeys matcher so sequence state (`g g`) survives,
+  // but a completed match only RECORDS the candidate; the coordinator orders
+  // the recorded candidates and dispatches a single winner. Hold bindings keep
+  // their own observer (installHoldBinding) — duration isn't a tinykeys match.
   const installedRef = useRef<{
     actions: readonly ActionConfig[]
-    byActionId: Map<string, InstalledBinding>
-  }>({actions: [], byActionId: new Map()})
+    keyboard: Map<string, KeyboardCandidate>
+    hold: Map<string, {unsubscribe: () => void}>
+  }>({actions: [], keyboard: new Map(), hold: new Map()})
+  // Bindings whose chord completed on the event currently being processed.
+  // The coordinator clears it before feeding matchers, the match callbacks
+  // push into it, and it's read back synchronously after — tinykeys completion
+  // is synchronous within the dispatch, so there's no async-ordering hazard.
+  const completedRef = useRef<CompletedBinding[]>([])
 
   useEffect(() => {
     const state = installedRef.current
 
-    const uninstall = (actionId: string) => {
-      const entry = state.byActionId.get(actionId)
+    const uninstallHold = (actionKey: string) => {
+      const entry = state.hold.get(actionKey)
       if (!entry) return
       entry.unsubscribe()
-      state.byActionId.delete(actionId)
+      state.hold.delete(actionKey)
     }
 
     // If the action set identity changed (runtime regeneration), tear
-    // everything down first. Handlers close over the old action objects and
-    // would otherwise become stale.
+    // everything down first. Matchers/observers close over the old action
+    // objects and would otherwise run stale handlers.
     if (state.actions !== actions) {
-      for (const actionId of Array.from(state.byActionId.keys())) uninstall(actionId)
+      for (const actionKey of Array.from(state.hold.keys())) uninstallHold(actionKey)
+      state.keyboard.clear()
       state.actions = actions
     }
 
@@ -199,66 +225,105 @@ export function HotkeyReconciler(): null {
       const actionKey = actionRuntimeKey(action)
       desiredActionIds.add(actionKey)
 
-      if (state.byActionId.has(actionKey)) continue
-
       const binding = action.defaultBinding
-      const keys = normalizeKeys(binding.keys)
 
       if (binding.phase === 'hold') {
+        if (state.hold.has(actionKey)) continue
         const unsubscribe = installHoldBinding({
           action,
           binding,
-          keys,
+          keys: normalizeKeys(binding.keys),
           holdMs: binding.holdMs,
           activeRef,
           contextConfigsByTypeRef,
           dispatchRef,
         })
-        state.byActionId.set(actionKey, {unsubscribe})
+        state.hold.set(actionKey, {unsubscribe})
         continue
       }
 
-      const handler = makeHandler(action, binding, activeRef, contextConfigsByTypeRef, dispatchRef)
-      const bindingMap: Record<string, (event: KeyboardEvent) => void> = {}
-      for (const key of keys) bindingMap[key] = handler
-      // We use `createKeybindingsHandler` + a manual listener rather than
-      // tinykeys() directly so we can preprocess events with
-      // `withRecoveredLetterKey`. tinykeys' matcher reads event.key, which
-      // Mac's option-transformations and Linux compose-key setups can
-      // corrupt for letter chords (Alt+y → '¥' on Mac US). The wrapper
-      // restores the logical letter from event.keyCode before tinykeys
-      // sees it — matches hotkeys-js's pre-migration behavior, and works
-      // on Colemak/Dvorak where event.code lies about layout.
-      //
-      // `ignore: () => false` disables tinykeys' built-in editable-target
-      // filter; we run our own context-aware filter inside the handler so
-      // contexts like property-editing can opt in to events tinykeys
-      // would otherwise drop.
-      const tinykeysHandler = createKeybindingsHandler(bindingMap, {ignore: () => false})
-      const listener: EventListener = (event) => {
-        tinykeysHandler(withRecoveredLetterKey(event as KeyboardEvent))
-      }
-      const phase = binding.phase ?? 'keydown'
-      window.addEventListener(phase, listener)
-      const unsubscribe = () => window.removeEventListener(phase, listener)
-      state.byActionId.set(actionKey, {unsubscribe})
+      if (state.keyboard.has(actionKey)) continue
+      state.keyboard.set(actionKey, {
+        action,
+        binding,
+        phase: binding.phase ?? 'keydown',
+        matcher: makeMatcher(action, binding, completedRef),
+      })
     }
 
-    // Uninstall actions whose context deactivated (or that disappeared).
-    for (const actionId of Array.from(state.byActionId.keys())) {
-      if (!desiredActionIds.has(actionId)) uninstall(actionId)
+    // Drop candidates whose context deactivated, was shadowed, or disappeared.
+    for (const actionKey of Array.from(state.keyboard.keys())) {
+      if (!desiredActionIds.has(actionKey)) state.keyboard.delete(actionKey)
+    }
+    for (const actionKey of Array.from(state.hold.keys())) {
+      if (!desiredActionIds.has(actionKey)) uninstallHold(actionKey)
     }
   }, [actions, active, contextConfigsByType])
 
-  // Final teardown on unmount (test cleanup, HMR). Separate effect with
-  // empty deps so it only runs once on unmount, after all reconcile effects
-  // have stopped firing. Snapshot the ref into a local so the cleanup
-  // doesn't read a (potentially-mutated) installedRef.current at unmount.
+  // The single keydown/keyup coordinator. Installed once; reads refs so it
+  // always sees the current matcher set, active contexts, and configs without
+  // rebinding. (Per the note above, the useEffectEvent indirection broke
+  // delivery here — tinykeys fires from a global listener outside React's
+  // event scope — so the latest state must come through refs.)
+  useEffect(() => {
+    const dispatchPhase = (phase: 'keydown' | 'keyup', rawEvent: Event): void => {
+      const event = withRecoveredLetterKey(rawEvent as KeyboardEvent)
+      const completed = completedRef.current
+      completed.length = 0
+      // Feed every candidate of this phase so each advances its own sequence
+      // state; a completed match pushes the candidate into `completed`.
+      for (const candidate of installedRef.current.keyboard.values()) {
+        if (candidate.phase === phase) candidate.matcher(event)
+      }
+      if (completed.length === 0) return
+
+      const active = activeRef.current
+      const contextConfigsByType = contextConfigsByTypeRef.current
+      // The filter cascade gates dispatch, not matching — sequence state has
+      // already advanced above, matching tinykeys' per-listener behaviour.
+      if (!shouldHandleEvent(event, active, contextConfigsByType)) return
+
+      // Order best-first via the shared comparator, then dispatch the single
+      // winner: the first candidate whose context is still installable. That
+      // installability check is the canDispatch gate (a context can deactivate
+      // or get shadowed between matcher install and this event).
+      const ordered = completed.slice().sort((a, b) =>
+        compareContexts(a.action.context, b.action.context, {active, contextConfigsByType}),
+      )
+      for (const {action, binding} of ordered) {
+        const deps = getInstallableContextDeps(action.context, active, contextConfigsByType)
+        if (!deps) continue
+        applyEventOptions(event, action, binding, contextConfigsByType)
+        try {
+          void Promise.resolve(action.handler(deps, event, dispatchRef.current)).catch(error => {
+            console.error(`[HotkeyReconciler] Action ${action.id} rejected`, error)
+          })
+        } catch (error) {
+          console.error(`[HotkeyReconciler] Action ${action.id} threw`, error)
+        }
+        return // single winner (PR 1); PR 2 lets a declining handler fall through
+      }
+    }
+
+    const onKeydown = (event: Event) => dispatchPhase('keydown', event)
+    const onKeyup = (event: Event) => dispatchPhase('keyup', event)
+    window.addEventListener('keydown', onKeydown)
+    window.addEventListener('keyup', onKeyup)
+    return () => {
+      window.removeEventListener('keydown', onKeydown)
+      window.removeEventListener('keyup', onKeyup)
+    }
+  }, [])
+
+  // Final teardown on unmount (test cleanup, HMR). Separate effect with empty
+  // deps so it runs once on unmount, after reconcile effects have stopped.
+  // Snapshot the ref so cleanup doesn't read a mutated installedRef.current.
   useEffect(() => {
     const state = installedRef.current
     return () => {
-      for (const [, entry] of state.byActionId) entry.unsubscribe()
-      state.byActionId.clear()
+      for (const [, entry] of state.hold) entry.unsubscribe()
+      state.hold.clear()
+      state.keyboard.clear()
       state.actions = []
     }
   }, [])
@@ -428,44 +493,31 @@ const applyEventOptions = (
   if (options.preventDefault) event.preventDefault()
 }
 
-const makeHandler = (
+/**
+ * Build a candidate's tinykeys matcher. Every key in the binding maps to the
+ * same callback, which records the candidate in `completedRef` for the event
+ * in flight instead of running the handler — the coordinator orders the
+ * recorded candidates and runs the winner.
+ *
+ * `createKeybindingsHandler` (rather than `tinykeys()` directly) lets the
+ * coordinator preprocess each event with `withRecoveredLetterKey` before the
+ * matcher sees it: tinykeys reads event.key, which Mac option-transforms
+ * (Alt+y → '¥') and Linux compose setups corrupt for letter chords; the
+ * wrapper restores the logical letter from event.keyCode, and works on
+ * Colemak/Dvorak where event.code lies about layout. `ignore: () => false`
+ * disables tinykeys' built-in editable-target filter — the coordinator runs
+ * the context-aware cascade (`shouldHandleEvent`) itself, so contexts like
+ * property-editing can opt into events tinykeys would otherwise drop.
+ */
+const makeMatcher = (
   action: ActionConfig,
   binding: ShortcutBindingDefaults,
-  activeRef: { current: ActiveContextsMap },
-  contextConfigsByTypeRef: { current: ReadonlyMap<ActionContextType, ActionContextConfig> },
-  dispatchRef: { current: ActionDispatch },
-) => {
-  return (event: KeyboardEvent) => {
-    const active = activeRef.current
-    const contextConfigsByType = contextConfigsByTypeRef.current
-    if (!shouldHandleEvent(event, active, contextConfigsByType)) return
-
-    const deps = getInstallableContextDeps(action.context, active, contextConfigsByType)
-    // Context may have deactivated or become shadowed between install and callback.
-    if (!deps) return
-
-    const contextConfig = contextConfigsByType.get(action.context)
-    const options: EventOptions = {
-      preventDefault: true,
-      stopPropagation: false,
-      ...contextConfig?.defaultEventOptions,
-      ...binding.eventOptions,
-    }
-
-    if (options.stopPropagation) event.stopPropagation()
-    if (options.preventDefault) {
-      console.debug(
-        `[HotkeyReconciler] Preventing default for action: ${action.id}, context: ${action.context}`,
-      )
-      event.preventDefault()
-    }
-
-    try {
-      void Promise.resolve(action.handler(deps, event, dispatchRef.current)).catch(error => {
-        console.error(`[HotkeyReconciler] Action ${action.id} rejected`, error)
-      })
-    } catch (error) {
-      console.error(`[HotkeyReconciler] Action ${action.id} threw`, error)
-    }
+  completedRef: { current: CompletedBinding[] },
+): ((event: KeyboardEvent) => void) => {
+  const record = () => {
+    completedRef.current.push({action, binding})
   }
+  const bindingMap: Record<string, (event: KeyboardEvent) => void> = {}
+  for (const key of normalizeKeys(binding.keys)) bindingMap[key] = record
+  return createKeybindingsHandler(bindingMap, {ignore: () => false})
 }

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -19,11 +19,11 @@ import {
   getEffectiveActions,
 } from './effectiveActions.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
+import { computeInstallableContexts } from './resolve.ts'
 import {
   ActionConfig,
   ActionContextConfig,
   ActionContextType,
-  ActionContextTypes,
   ActionDispatch,
   ActionTrigger,
   EventOptions,
@@ -40,30 +40,6 @@ const normalizeKeys = (keys: string | string[]): readonly string[] =>
 
 const defaultEventFilter = (event: KeyboardEvent) =>
   !(isTypingKeyEvent(event) && hasEditableTarget(event))
-
-/**
- * When any active context is `modal: true`, the install set collapses to
- * `{global, <most-recent-modal>}`. Otherwise every active context's
- * bindings install. The `global` carve-out keeps app-wide chords
- * (Cmd+K, Escape, …) reachable while a modal is up — without it, opening
- * the command palette during scrub mode would do nothing.
- *
- * Most-recent-wins for modal stacking: `ActiveContextsMap` is insertion-
- * ordered with re-activations rotated to the end (see ActiveContexts.tsx),
- * so the last `set()` of a modal context wins. `canRun` is not considered
- * here — it's presentational, not an install gate ([types.ts]).
- */
-const computeInstallableContexts = (
-  active: ActiveContextsMap,
-  contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>,
-): ReadonlySet<ActionContextType> => {
-  const contexts = Array.from(active.keys())
-  const latestModal = contexts.toReversed().find(type =>
-    contextConfigsByType.get(type)?.modal === true,
-  )
-  if (!latestModal) return new Set(contexts)
-  return new Set([ActionContextTypes.GLOBAL, latestModal])
-}
 
 const getInstallableContextDeps = (
   context: ActionContextType,

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -19,7 +19,7 @@ import {
   getEffectiveActions,
 } from './effectiveActions.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
-import { compareContexts, computeInstallableContexts } from './resolve.ts'
+import { compareContexts, computeInstallableContexts, resolveDeps } from './resolve.ts'
 import {
   ActionConfig,
   ActionContextConfig,
@@ -56,15 +56,16 @@ const normalizeKeys = (keys: string | string[]): readonly string[] =>
 const defaultEventFilter = (event: KeyboardEvent) =>
   !(isTypingKeyEvent(event) && hasEditableTarget(event))
 
+// Keyboard-side deps gate: a candidate's context must still be installable
+// (modal shadowing / the activation race) AND have resolvable deps. Layers the
+// keyboard-only installable filter over the shared resolveDeps.
 const getInstallableContextDeps = (
-  context: ActionContextType,
+  action: ActionConfig,
   active: ActiveContextsMap,
   contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>,
 ) => {
-  const deps = active.get(context)
-  if (!deps) return null
-  if (!computeInstallableContexts(active, contextConfigsByType).has(context)) return null
-  return deps
+  if (!computeInstallableContexts(active, contextConfigsByType).has(action.context)) return null
+  return resolveDeps(action, active, contextConfigsByType)
 }
 
 /**
@@ -171,7 +172,7 @@ export function HotkeyReconciler(): null {
       if (!action) {
         throw new Error(`[HotkeyReconciler] Active action with ID "${actionId}" not found.`)
       }
-      const deps = activeRef.current.get(action.context)
+      const deps = resolveDeps(action, activeRef.current, contextConfigsByTypeRef.current)
       if (!deps) throw new Error(`[HotkeyReconciler] Context "${action.context}" is not active.`)
       return action.handler(deps, trigger, dispatchRef.current)
     })
@@ -284,15 +285,18 @@ export function HotkeyReconciler(): null {
       if (!shouldHandleEvent(event, active, contextConfigsByType)) return
 
       // Order best-first via the shared comparator, then dispatch the single
-      // winner: the first candidate whose context is still installable. That
-      // installability check is the canDispatch gate (a context can deactivate
-      // or get shadowed between matcher install and this event).
+      // winner: the first candidate that is still dispatchable. A candidate is
+      // skipped (try the next) when its context deactivated / got shadowed
+      // between matcher install and this event (deps null), or when its
+      // explicit canDispatch gate declines. PR 2 adds a third skip: a handler
+      // returning the not-handled sentinel.
       const ordered = completed.slice().sort((a, b) =>
         compareContexts(a.action.context, b.action.context, {active, contextConfigsByType}),
       )
       for (const {action, binding} of ordered) {
-        const deps = getInstallableContextDeps(action.context, active, contextConfigsByType)
+        const deps = getInstallableContextDeps(action, active, contextConfigsByType)
         if (!deps) continue
+        if (action.canDispatch && !action.canDispatch(deps)) continue
         applyEventOptions(event, action, binding, contextConfigsByType)
         try {
           void Promise.resolve(action.handler(deps, event, dispatchRef.current)).catch(error => {
@@ -405,7 +409,7 @@ const installHoldBinding = (config: HoldBindingInstall): (() => void) => {
 
   const fire = (originalEvent: KeyboardEvent): void => {
     const deps = getInstallableContextDeps(
-      action.context,
+      action,
       activeRef.current,
       contextConfigsByTypeRef.current,
     )
@@ -435,7 +439,7 @@ const installHoldBinding = (config: HoldBindingInstall): (() => void) => {
 
     const active = activeRef.current
     const contextConfigsByType = contextConfigsByTypeRef.current
-    if (!getInstallableContextDeps(action.context, active, contextConfigsByType)) return
+    if (!getInstallableContextDeps(action, active, contextConfigsByType)) return
     if (!shouldHandleEvent(event, active, contextConfigsByType)) return
 
     applyEventOptions(event, action, binding, contextConfigsByType)

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -19,7 +19,7 @@ import {
   getEffectiveActions,
 } from './effectiveActions.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
-import { compareContexts, computeInstallableContexts, resolveDeps } from './resolve.ts'
+import { computeInstallableContexts, resolve, resolveDeps } from './resolve.ts'
 import {
   ActionConfig,
   ActionContextConfig,
@@ -284,20 +284,23 @@ export function HotkeyReconciler(): null {
       // already advanced above, matching tinykeys' per-listener behaviour.
       if (!shouldHandleEvent(event, active, contextConfigsByType)) return
 
-      // Order best-first via the shared comparator, then dispatch the single
-      // winner: the first candidate that is still dispatchable. A candidate is
-      // skipped (try the next) when its context deactivated / got shadowed
-      // between matcher install and this event (deps null), or when its
-      // explicit canDispatch gate declines. PR 2 adds a third skip: a handler
-      // returning the not-handled sentinel.
-      const ordered = completed.slice().sort((a, b) =>
-        compareContexts(a.action.context, b.action.context, {active, contextConfigsByType}),
+      // Order + filter through the shared resolver (modal shadowing + the
+      // precedence comparator), so the keyboard path can't diverge from the
+      // imperative one. resolve drops candidates whose context deactivated or
+      // got shadowed between matcher install and this event (filter-before-
+      // sort), then orders best-first. Dispatch the single winner: the first
+      // candidate whose deps resolve and whose canDispatch gate doesn't
+      // decline. PR 2 adds a third skip: a handler returning the not-handled
+      // sentinel.
+      const bindings = new Map<ActionConfig, ShortcutBindingDefaults>(
+        completed.map(c => [c.action, c.binding]),
       )
-      for (const {action, binding} of ordered) {
-        const deps = getInstallableContextDeps(action, active, contextConfigsByType)
+      const ordered = resolve([...bindings.keys()], {active, contextConfigsByType}, {kind: 'keyboard'})
+      for (const action of ordered) {
+        const deps = resolveDeps(action, active, contextConfigsByType)
         if (!deps) continue
         if (action.canDispatch && !action.canDispatch(deps)) continue
-        applyEventOptions(event, action, binding, contextConfigsByType)
+        applyEventOptions(event, action, bindings.get(action)!, contextConfigsByType)
         try {
           void Promise.resolve(action.handler(deps, event, dispatchRef.current)).catch(error => {
             console.error(`[HotkeyReconciler] Action ${action.id} rejected`, error)

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -417,6 +417,11 @@ const installHoldBinding = (config: HoldBindingInstall): (() => void) => {
       contextConfigsByTypeRef.current,
     )
     if (!deps) return
+    // Hold dispatch happens here (timer fire), so the canDispatch gate is
+    // evaluated here too — same contract the keydown/keyup coordinator
+    // enforces: a declining predicate skips the handler rather than firing
+    // in a state the action opted out of.
+    if (action.canDispatch && !action.canDispatch(deps)) return
 
     try {
       void Promise.resolve(action.handler(deps, originalEvent, dispatchRef.current)).catch(error => {

--- a/src/shortcuts/applyKeybindingOverrides.ts
+++ b/src/shortcuts/applyKeybindingOverrides.ts
@@ -1,7 +1,7 @@
 /**
  * Pure pass that rewrites each action's `defaultBinding` from a list of
  * `KeybindingOverride` contributions. Invoked by `getEffectiveActions`
- * after the standard override/decorator pipeline.
+ * after the per-action transform pipeline.
  *
  * Rules:
  *

--- a/src/shortcuts/effectiveActions.test.ts
+++ b/src/shortcuts/effectiveActions.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  actionDecoratorsFacet,
-  actionOverridesFacet,
+  actionTransformsFacet,
   actionsFacet,
 } from '@/extensions/core.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
@@ -26,7 +25,7 @@ const baseAction = (overrides: Partial<ActionConfig> = {}): ActionConfig => ({
 } as ActionConfig)
 
 describe('getEffectiveActions', () => {
-  it('decorates a matching action handler without changing the raw action registry', async () => {
+  it('wraps a matching action handler without changing the raw action registry', async () => {
     const calls: string[] = []
     const action = baseAction({
       handler: async () => {
@@ -35,10 +34,10 @@ describe('getEffectiveActions', () => {
     })
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(action),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: action.id,
         context: ActionContextTypes.NORMAL_MODE,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             calls.push('before')
@@ -56,7 +55,7 @@ describe('getEffectiveActions', () => {
     expect(calls).toEqual(['before', 'base', 'after'])
   })
 
-  it('applies lower-precedence decorators innermost and higher-precedence decorators outermost', async () => {
+  it('applies lower-precedence transforms innermost and higher-precedence transforms outermost', async () => {
     const calls: string[] = []
     const action = baseAction({
       handler: async () => {
@@ -65,9 +64,9 @@ describe('getEffectiveActions', () => {
     })
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(action),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: action.id,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             calls.push('low-before')
@@ -76,9 +75,9 @@ describe('getEffectiveActions', () => {
           },
         }),
       }, {precedence: 0}),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: action.id,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             calls.push('high-before')
@@ -100,13 +99,13 @@ describe('getEffectiveActions', () => {
     ])
   })
 
-  it('lets overrides replace metadata and remove actions', () => {
+  it('lets a transform replace metadata and remove an action (apply → null unbinds)', () => {
     const kept = baseAction()
     const removed = baseAction({id: 'test.removed'})
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(kept),
       actionsFacet.of(removed),
-      actionOverridesFacet.of({
+      actionTransformsFacet.of({
         actionId: kept.id,
         apply: action => ({
           ...action,
@@ -114,7 +113,7 @@ describe('getEffectiveActions', () => {
           defaultBinding: {keys: 'y'},
         }),
       }),
-      actionOverridesFacet.of({
+      actionTransformsFacet.of({
         actionId: removed.id,
         apply: () => null,
       }),
@@ -138,9 +137,9 @@ describe('getEffectiveActions', () => {
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(first),
       actionsFacet.of(second),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: '*',
-        decorate: action => {
+        apply: action => {
           visited.push(action.id)
           return {...action, description: `seen:${action.id}`}
         },
@@ -163,10 +162,10 @@ describe('getEffectiveActions', () => {
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(normal),
       actionsFacet.of(edit),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: '*',
         context: ActionContextTypes.EDIT_MODE_CM,
-        decorate: action => ({...action, description: 'edit-only'}),
+        apply: action => ({...action, description: 'edit-only'}),
       }),
     ])
 
@@ -176,7 +175,7 @@ describe('getEffectiveActions', () => {
     ])
   })
 
-  it('matches context-specific decorators only against that action context', async () => {
+  it('matches context-specific transforms only against that action context', async () => {
     const normal = baseAction({
       handler: async () => undefined,
     })
@@ -187,19 +186,19 @@ describe('getEffectiveActions', () => {
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(normal),
       actionsFacet.of(edit),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: normal.id,
         context: ActionContextTypes.EDIT_MODE_CM,
-        decorate: action => ({
+        apply: action => ({
           ...action,
-          description: 'Decorated edit action',
+          description: 'Transformed edit action',
         }),
       }),
     ])
 
     expect(getEffectiveActions(runtime).map(action => action.description)).toEqual([
       'Base action',
-      'Decorated edit action',
+      'Transformed edit action',
     ])
   })
 })

--- a/src/shortcuts/effectiveActions.test.ts
+++ b/src/shortcuts/effectiveActions.test.ts
@@ -5,10 +5,14 @@ import {
   actionsFacet,
 } from '@/extensions/core.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
-import { getEffectiveActions } from '@/shortcuts/effectiveActions.js'
+import { getActiveActionById, getEffectiveActions } from '@/shortcuts/effectiveActions.js'
+import type { ResolutionContext } from '@/shortcuts/resolve.js'
 import {
   ActionConfig,
+  type ActionContextConfig,
+  type ActionContextType,
   ActionContextTypes,
+  type BaseShortcutDependencies,
   type BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
 
@@ -197,5 +201,37 @@ describe('getEffectiveActions', () => {
       'Base action',
       'Decorated edit action',
     ])
+  })
+})
+
+describe('getActiveActionById', () => {
+  const cfg = (type: ActionContextType): ActionContextConfig => ({
+    type,
+    displayName: type,
+    validateDependencies: (d): d is BaseShortcutDependencies =>
+      typeof d === 'object' && d !== null,
+  })
+
+  it('resolves a global-vs-scoped id collision to global (reserved top tier)', () => {
+    // Behaviour change vs the old reverse-activation lookup: when the same id
+    // is registered in both global and a more-recently-activated scoped
+    // context (e.g. undo/redo in global + vim normal-mode), the imperative
+    // path (runActionById / useRunAction) now resolves to global rather than
+    // to the newer scoped context. Recency alone would have picked NORMAL_MODE.
+    const globalUndo = baseAction({id: 'undo', context: ActionContextTypes.GLOBAL})
+    const scopedUndo = baseAction({id: 'undo', context: ActionContextTypes.NORMAL_MODE})
+    const ctx: ResolutionContext = {
+      active: new Map<ActionContextType, BaseShortcutDependencies>([
+        [ActionContextTypes.GLOBAL, {} as BaseShortcutDependencies],
+        [ActionContextTypes.NORMAL_MODE, {} as BaseShortcutDependencies],
+      ]),
+      contextConfigsByType: new Map([
+        [ActionContextTypes.GLOBAL, cfg(ActionContextTypes.GLOBAL)],
+        [ActionContextTypes.NORMAL_MODE, cfg(ActionContextTypes.NORMAL_MODE)],
+      ]),
+    }
+
+    expect(getActiveActionById([globalUndo, scopedUndo], ctx, 'undo')?.context)
+      .toBe(ActionContextTypes.GLOBAL)
   })
 })

--- a/src/shortcuts/effectiveActions.ts
+++ b/src/shortcuts/effectiveActions.ts
@@ -1,13 +1,11 @@
 import {
-  actionDecoratorsFacet,
-  actionOverridesFacet,
+  actionTransformsFacet,
   actionsFacet,
 } from '@/extensions/core.js'
 import type { FacetRuntime } from '@/extensions/facet.js'
 import type {
   ActionConfig,
-  ActionDecorator,
-  ActionOverride,
+  ActionTransform,
 } from '@/shortcuts/types.js'
 import { applyKeybindingOverrides } from './applyKeybindingOverrides.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
@@ -18,42 +16,42 @@ export const actionRuntimeKey = (
 ): string => `${action.context}:${action.id}`
 
 /** Sentinel `actionId` that matches every action. Use sparingly — most
- *  overrides/decorators target a specific id. The keybindings module
- *  ships one wildcard decorator that reads the
- *  `keybindingOverridesFacet` and rewrites whichever actions the user
- *  has remapped; that needs to inspect every action so it can also
- *  strip a default chord that lost a collision to a user override. */
+ *  transforms target a specific id. The cross-action keybinding-override
+ *  pass (`applyKeybindingOverrides`, run after this pipeline) is the main
+ *  whole-list consumer: it reads the `keybindingOverridesFacet` and
+ *  rewrites whichever actions the user has remapped, inspecting every
+ *  action so it can also strip a default chord that lost a collision to a
+ *  user override. */
 export const WILDCARD_ACTION_ID = '*'
 
 const matchesAction = (
-  target: Pick<ActionOverride | ActionDecorator, 'actionId' | 'context'>,
+  target: Pick<ActionTransform, 'actionId' | 'context'>,
   action: Pick<ActionConfig, 'id' | 'context'>,
 ): boolean =>
   (target.actionId === WILDCARD_ACTION_ID || target.actionId === action.id) &&
   (target.context === undefined || target.context === action.context)
 
-/** The action list after `actionOverridesFacet` and
- *  `actionDecoratorsFacet` have been applied but before any
- *  keybinding-override rewrites. Used by the settings UI so it can
- *  preview an unsaved `StoredKeybindingOverrides` map without waiting
- *  for the runtime rebuild that happens after the canonical prefs
- *  block subscription fires. */
+/** The action list after every `actionTransformsFacet` contribution has
+ *  been applied, but before any keybinding-override rewrites. Used by the
+ *  settings UI so it can preview an unsaved `StoredKeybindingOverrides`
+ *  map without waiting for the runtime rebuild that happens after the
+ *  canonical prefs block subscription fires.
+ *
+ *  Transforms run in the runtime's order (precedence asc, then
+ *  registration), so a later contribution wraps the earlier ones. */
 export const getActionsBeforeKeybindingOverrides = (runtime: FacetRuntime): readonly ActionConfig[] => {
-  const overrides = runtime.read(actionOverridesFacet)
-  const decorators = runtime.read(actionDecoratorsFacet)
+  const transforms = runtime.read(actionTransformsFacet)
   const out: ActionConfig[] = []
 
   for (const rawAction of runtime.read(actionsFacet)) {
     let action: ActionConfig | null = rawAction
 
-    for (const override of overrides) {
-      if (!action || !matchesAction(override, action)) continue
-      action = override.apply(action as never) as ActionConfig | null
-    }
-
-    for (const decorator of decorators) {
-      if (!action || !matchesAction(decorator, action)) continue
-      action = decorator.decorate(action as never) as ActionConfig
+    for (const transform of transforms) {
+      if (!action || !matchesAction(transform, action)) continue
+      // No cast: `ActionTransform` is erased, so `apply` is plain
+      // `ActionConfig → ActionConfig | null`. Contributors narrow at
+      // their own definition site.
+      action = transform.apply(action)
     }
 
     if (action) out.push(action)
@@ -66,7 +64,7 @@ export const getEffectiveActions = (runtime: FacetRuntime): readonly ActionConfi
   // Keybinding overrides run as a final pass — they need cross-action
   // visibility (the "default loses on chord collision" rule reads
   // every other action's effective binding), which the per-action
-  // override/decorator pipeline above can't express cleanly.
+  // transform pipeline above can't express cleanly.
   return applyKeybindingOverrides(
     getActionsBeforeKeybindingOverrides(runtime),
     runtime.read(keybindingOverridesFacet),

--- a/src/shortcuts/effectiveActions.ts
+++ b/src/shortcuts/effectiveActions.ts
@@ -6,13 +6,12 @@ import {
 import type { FacetRuntime } from '@/extensions/facet.js'
 import type {
   ActionConfig,
-  ActionContextType,
   ActionDecorator,
   ActionOverride,
 } from '@/shortcuts/types.js'
-import type { ActiveContextsMap } from './ActiveContexts.tsx'
 import { applyKeybindingOverrides } from './applyKeybindingOverrides.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
+import { resolve, type ResolutionContext } from './resolve.ts'
 
 export const actionRuntimeKey = (
   action: Pick<ActionConfig, 'context' | 'id'>,
@@ -74,20 +73,17 @@ export const getEffectiveActions = (runtime: FacetRuntime): readonly ActionConfi
   )
 }
 
+/**
+ * The active action for an id, resolved through the shared precedence core
+ * so this (the imperative `runActionById` / `useRunAction` path) and the
+ * keyboard path can't diverge. Behaviour change vs the old pure
+ * reverse-activation lookup: a `global`-vs-scoped id collision now resolves
+ * to `global` (reserved top tier) instead of to whichever was activated
+ * most recently. Modal shadowing is NOT applied here — imperative
+ * invocation finds an action in any active context (see `resolve`).
+ */
 export const getActiveActionById = (
   actions: readonly ActionConfig[],
-  active: ActiveContextsMap,
+  ctx: ResolutionContext,
   actionId: string,
-): ActionConfig | null => {
-  const byContext = new Map<ActionContextType, ActionConfig>()
-  for (const action of actions) {
-    if (action.id === actionId) byContext.set(action.context, action)
-  }
-
-  for (const context of Array.from(active.keys()).toReversed()) {
-    const action = byContext.get(context)
-    if (action) return action
-  }
-
-  return null
-}
+): ActionConfig | null => resolve(actions, ctx, {kind: 'action', actionId})[0] ?? null

--- a/src/shortcuts/keybindingOverrides.ts
+++ b/src/shortcuts/keybindingOverrides.ts
@@ -6,9 +6,10 @@
  * `keybindingOverridesFacet`. The keybindings-settings plugin
  * contributes one entry per user-remapped action at high precedence;
  * other plugins (or static config) can contribute entries at default
- * precedence to ship opinionated rebinds. A single wildcard
- * `ActionDecorator` (see `applyKeybindingOverrides`) consumes the
- * facet and rewrites each action's `defaultBinding` accordingly.
+ * precedence to ship opinionated rebinds. A dedicated cross-action pass
+ * (`applyKeybindingOverrides`, run by `getEffectiveActions` after the
+ * per-action transform pipeline) consumes the facet and rewrites each
+ * action's `defaultBinding` accordingly.
  *
  * Collision rule (matches "user override wins, default loses"):
  *

--- a/src/shortcuts/resolve.test.ts
+++ b/src/shortcuts/resolve.test.ts
@@ -152,6 +152,23 @@ describe('resolve precedence', () => {
     ])
     expect(ordered.every(a => a.id === 'save')).toBe(true)
   })
+
+  it('by actionId ignores modal shadowing (imperative invocation is not gated by the install filter)', () => {
+    // A modal is active and 'indent' lives in normal-mode, which the keyboard
+    // path shadows. runActionById must still find it — modal shadowing is a
+    // keyboard-install concern only.
+    const ctx = ctxOf(
+      [ActionContextTypes.NORMAL_MODE, 'multi'],
+      [config(ActionContextTypes.NORMAL_MODE), config('multi', {modal: true})],
+    )
+    const byKey = resolve([action('indent', ActionContextTypes.NORMAL_MODE)], ctx, KEY)
+    const byId = resolve([action('indent', ActionContextTypes.NORMAL_MODE)], ctx, {
+      kind: 'action',
+      actionId: 'indent',
+    })
+    expect(byKey).toEqual([]) // shadowed for the keyboard
+    expect(byId.map(a => a.context)).toEqual([ActionContextTypes.NORMAL_MODE]) // found by id
+  })
 })
 
 describe('compareContexts', () => {

--- a/src/shortcuts/resolve.test.ts
+++ b/src/shortcuts/resolve.test.ts
@@ -46,7 +46,7 @@ const action = (id: string, context: ActionContextType): ActionConfig => ({
   handler: () => {},
 })
 
-const KEY = {kind: 'key', key: 'x', mods: [], phase: 'keydown'} as const
+const KEY = {kind: 'keyboard'} as const
 
 describe('resolve precedence', () => {
   it('higher-priority context wins a collision even when activated earlier', () => {

--- a/src/shortcuts/resolve.test.ts
+++ b/src/shortcuts/resolve.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compareContexts,
+  computeInstallableContexts,
+  resolve,
+  type ResolutionContext,
+} from './resolve.ts'
+import {
+  ActionContextTypes,
+  type ActionConfig,
+  type ActionContextConfig,
+  type ActionContextType,
+  type BaseShortcutDependencies,
+  type Priority,
+} from './types.ts'
+import type { ActiveContextsMap } from './ActiveContexts.tsx'
+
+const config = (
+  type: ActionContextType,
+  opts: {modal?: boolean; priority?: Priority} = {},
+): ActionContextConfig => ({
+  type,
+  displayName: type,
+  ...opts,
+  validateDependencies: (deps: unknown): deps is BaseShortcutDependencies =>
+    typeof deps === 'object' && deps !== null,
+})
+
+// `order` is activation order: first = oldest, last = most-recently activated,
+// matching ActiveContextsMap insertion order.
+const ctxOf = (
+  order: ActionContextType[],
+  configs: ActionContextConfig[],
+): ResolutionContext => ({
+  active: new Map(order.map(t => [t, {} as BaseShortcutDependencies])) satisfies Map<
+    ActionContextType,
+    BaseShortcutDependencies
+  > as ActiveContextsMap,
+  contextConfigsByType: new Map(configs.map(c => [c.type, c])),
+})
+
+const action = (id: string, context: ActionContextType): ActionConfig => ({
+  id,
+  description: id,
+  context,
+  handler: () => {},
+})
+
+const KEY = {kind: 'key', key: 'x', mods: [], phase: 'keydown'} as const
+
+describe('resolve precedence', () => {
+  it('higher-priority context wins a collision even when activated earlier', () => {
+    // 'report' (high) was activated FIRST; normal-mode (default) LATER, so
+    // recency alone would pick normal-mode. Priority must override recency.
+    const ctx = ctxOf(
+      ['report', ActionContextTypes.NORMAL_MODE],
+      [config('report', {priority: 'high'}), config(ActionContextTypes.NORMAL_MODE)],
+    )
+    const ordered = resolve(
+      [action('x', 'report'), action('x', ActionContextTypes.NORMAL_MODE)],
+      ctx,
+      KEY,
+    )
+    expect(ordered.map(a => a.context)).toEqual(['report', ActionContextTypes.NORMAL_MODE])
+  })
+
+  it('equal priority falls back to the most-recently-activated context', () => {
+    const ctx = ctxOf(
+      [ActionContextTypes.NORMAL_MODE, 'other'],
+      [config(ActionContextTypes.NORMAL_MODE), config('other')],
+    )
+    const ordered = resolve(
+      [action('x', ActionContextTypes.NORMAL_MODE), action('x', 'other')],
+      ctx,
+      KEY,
+    )
+    expect(ordered[0]!.context).toBe('other')
+  })
+
+  it('global is a reserved top tier above any scoped context, regardless of priority/recency', () => {
+    // global activated first (older) and 'report' is high-priority + newer;
+    // global still wins because it sits above all priority tiers.
+    const ctx = ctxOf(
+      [ActionContextTypes.GLOBAL, 'report'],
+      [config(ActionContextTypes.GLOBAL), config('report', {priority: 'high'})],
+    )
+    const ordered = resolve(
+      [action('x', ActionContextTypes.GLOBAL), action('x', 'report')],
+      ctx,
+      KEY,
+    )
+    expect(ordered[0]!.context).toBe(ActionContextTypes.GLOBAL)
+  })
+
+  it('an active modal outranks global on a shared chord', () => {
+    const ctx = ctxOf(
+      [ActionContextTypes.GLOBAL, 'scrub'],
+      [config(ActionContextTypes.GLOBAL), config('scrub', {modal: true})],
+    )
+    const ordered = resolve(
+      [action('x', ActionContextTypes.GLOBAL), action('x', 'scrub')],
+      ctx,
+      KEY,
+    )
+    expect(ordered[0]!.context).toBe('scrub')
+  })
+
+  it('a modal shadows non-global scoped contexts so they contribute no candidates', () => {
+    const ctx = ctxOf(
+      [ActionContextTypes.NORMAL_MODE, 'scrub'],
+      [config(ActionContextTypes.NORMAL_MODE), config('scrub', {modal: true})],
+    )
+    const ordered = resolve(
+      [action('x', ActionContextTypes.NORMAL_MODE), action('x', 'scrub')],
+      ctx,
+      KEY,
+    )
+    expect(ordered.map(a => a.context)).toEqual(['scrub'])
+  })
+
+  it('global still contributes while a modal is active', () => {
+    const ctx = ctxOf(
+      [ActionContextTypes.GLOBAL, 'scrub'],
+      [config(ActionContextTypes.GLOBAL), config('scrub', {modal: true})],
+    )
+    const ordered = resolve([action('only-global', ActionContextTypes.GLOBAL)], ctx, KEY)
+    expect(ordered.map(a => a.id)).toEqual(['only-global'])
+  })
+
+  it('drops candidates whose context is not active', () => {
+    const ctx = ctxOf([ActionContextTypes.NORMAL_MODE], [config(ActionContextTypes.NORMAL_MODE)])
+    const ordered = resolve([action('x', 'report')], ctx, KEY)
+    expect(ordered).toEqual([])
+  })
+
+  it('by actionId filters to that id and orders best-first (global wins over scoped)', () => {
+    // Documents the behaviour change vs the old reverse-activation lookup:
+    // with same id in global + a newer scoped context, global now wins.
+    const ctx = ctxOf(
+      [ActionContextTypes.GLOBAL, ActionContextTypes.NORMAL_MODE],
+      [config(ActionContextTypes.GLOBAL), config(ActionContextTypes.NORMAL_MODE)],
+    )
+    const all = [
+      action('save', ActionContextTypes.GLOBAL),
+      action('save', ActionContextTypes.NORMAL_MODE),
+      action('other', ActionContextTypes.NORMAL_MODE),
+    ]
+    const ordered = resolve(all, ctx, {kind: 'action', actionId: 'save'})
+    expect(ordered.map(a => a.context)).toEqual([
+      ActionContextTypes.GLOBAL,
+      ActionContextTypes.NORMAL_MODE,
+    ])
+    expect(ordered.every(a => a.id === 'save')).toBe(true)
+  })
+})
+
+describe('compareContexts', () => {
+  it('is a stable comparator (antisymmetric on tier)', () => {
+    const ctx = ctxOf(
+      [ActionContextTypes.GLOBAL, ActionContextTypes.NORMAL_MODE],
+      [config(ActionContextTypes.GLOBAL), config(ActionContextTypes.NORMAL_MODE)],
+    )
+    const ab = compareContexts(ActionContextTypes.GLOBAL, ActionContextTypes.NORMAL_MODE, ctx)
+    const ba = compareContexts(ActionContextTypes.NORMAL_MODE, ActionContextTypes.GLOBAL, ctx)
+    expect(ab).toBeLessThan(0) // global first
+    expect(ba).toBeGreaterThan(0)
+  })
+})
+
+describe('computeInstallableContexts', () => {
+  it('collapses to {global, latest modal} when a modal is active', () => {
+    const {active, contextConfigsByType} = ctxOf(
+      [ActionContextTypes.GLOBAL, ActionContextTypes.NORMAL_MODE, 'scrub'],
+      [
+        config(ActionContextTypes.GLOBAL),
+        config(ActionContextTypes.NORMAL_MODE),
+        config('scrub', {modal: true}),
+      ],
+    )
+    const set = computeInstallableContexts(active, contextConfigsByType)
+    expect([...set].sort()).toEqual([ActionContextTypes.GLOBAL, 'scrub'].sort())
+  })
+
+  it('returns every active context when none is modal', () => {
+    const {active, contextConfigsByType} = ctxOf(
+      [ActionContextTypes.GLOBAL, ActionContextTypes.NORMAL_MODE],
+      [config(ActionContextTypes.GLOBAL), config(ActionContextTypes.NORMAL_MODE)],
+    )
+    const set = computeInstallableContexts(active, contextConfigsByType)
+    expect([...set].sort()).toEqual(
+      [ActionContextTypes.GLOBAL, ActionContextTypes.NORMAL_MODE].sort(),
+    )
+  })
+})

--- a/src/shortcuts/resolve.ts
+++ b/src/shortcuts/resolve.ts
@@ -1,0 +1,118 @@
+/**
+ * The resolution core: pure, DOM-free functions that decide which
+ * action(s) a trigger maps to, best-first. Shared by the keyboard
+ * coordinator (`HotkeyReconciler`) and the imperative
+ * `runActionById`/`useRunAction` paths so the two can never diverge on
+ * precedence — that divergence is the bug this core retires.
+ *
+ * `resolve` ORDERS candidates; it does not MATCH chords. Keyboard chord
+ * matching (including tinykeys sequence state for `g g`) stays in the
+ * coordinator, which feeds `resolve` the candidates that have already
+ * completed a match this event. The `ChordDescriptor` trigger is read as
+ * "the chord that just completed" — carried for dedup/logging, never used
+ * to match here. Reducing a keydown to one descriptor and matching on it
+ * is exactly how sequence chords went dead historically.
+ */
+import {
+  ActionContextTypes,
+  type ActionConfig,
+  type ActionContextConfig,
+  type ActionContextType,
+  type Priority,
+} from '@/shortcuts/types.js'
+import type { ActiveContextsMap } from './ActiveContexts.tsx'
+import type { ChordDescriptor } from './canonicalizeChord.ts'
+
+export type Trigger =
+  | { kind: 'action'; actionId: string }
+  | ChordDescriptor // keyboard now; mouse/touch descriptors in Phase 3
+
+/** Everything the comparator needs that isn't on the `ActionConfig`. */
+export interface ResolutionContext {
+  readonly active: ActiveContextsMap
+  readonly contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>
+}
+
+/**
+ * When any active context is `modal`, the contributing set collapses to
+ * `{global, <most-recent-modal>}`; otherwise every active context
+ * contributes. The `global` carve-out keeps app-wide chords (Cmd+K, …)
+ * reachable while a modal is up. Most-recent-modal wins because
+ * `ActiveContextsMap` is insertion-ordered with re-activations rotated to
+ * the end (see ActiveContexts.tsx).
+ *
+ * This is the install/gather filter (which contexts contribute candidates
+ * at all). Ordering the gathered candidates is `compareContexts`' job.
+ */
+export const computeInstallableContexts = (
+  active: ActiveContextsMap,
+  contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>,
+): ReadonlySet<ActionContextType> => {
+  const contexts = Array.from(active.keys())
+  const latestModal = contexts.toReversed().find(type =>
+    contextConfigsByType.get(type)?.modal === true,
+  )
+  if (!latestModal) return new Set(contexts)
+  return new Set([ActionContextTypes.GLOBAL, latestModal])
+}
+
+const PRIORITY_RANK: Record<Priority, number> = {low: 0, default: 1, high: 2}
+
+// Primary tier: an active `modal` outranks `global`, `global` outranks the
+// rest. Ordered ascending so a larger number wins.
+const TIER_SCOPED = 0
+const TIER_GLOBAL = 1
+const TIER_MODAL = 2
+
+const tierOf = (type: ActionContextType, config: ActionContextConfig | undefined): number =>
+  config?.modal === true ? TIER_MODAL
+    : type === ActionContextTypes.GLOBAL ? TIER_GLOBAL
+    : TIER_SCOPED
+
+/**
+ * Order two contexts best-first: modal-over-global, then priority desc,
+ * then activation-recency desc. Returns a negative number when `a` should
+ * rank before `b`. The single source of precedence — both the coordinator
+ * and `getActiveActionById` route through it so dispatch and keyboard
+ * paths can't disagree.
+ */
+export const compareContexts = (
+  a: ActionContextType,
+  b: ActionContextType,
+  {active, contextConfigsByType}: ResolutionContext,
+): number => {
+  const order = Array.from(active.keys())
+  const configA = contextConfigsByType.get(a)
+  const configB = contextConfigsByType.get(b)
+  return (
+    tierOf(b, configB) - tierOf(a, configA) ||
+    PRIORITY_RANK[configB?.priority ?? 'default'] - PRIORITY_RANK[configA?.priority ?? 'default'] ||
+    order.indexOf(b) - order.indexOf(a)
+  )
+}
+
+/**
+ * Order the actions a trigger could fire, best-first.
+ *
+ * For `{kind:'action'}` the input is the full effective-action list and
+ * `resolve` filters to the matching id. For a keyboard `ChordDescriptor`
+ * the coordinator passes the candidates that already completed a match, so
+ * the only filtering left is "is this context still active + installable".
+ * Either way the result is ordered by `compareContexts`; the caller takes
+ * the first (single-winner) or iterates (declinable fall-through, Phase 1
+ * PR 2).
+ */
+export const resolve = (
+  actions: readonly ActionConfig[],
+  ctx: ResolutionContext,
+  trigger: Trigger,
+): readonly ActionConfig[] => {
+  const installable = computeInstallableContexts(ctx.active, ctx.contextConfigsByType)
+  const candidates = actions.filter(action => {
+    if (!ctx.active.has(action.context)) return false
+    if (!installable.has(action.context)) return false
+    if (trigger.kind === 'action' && action.id !== trigger.actionId) return false
+    return true
+  })
+  return [...candidates].sort((x, y) => compareContexts(x.context, y.context, ctx))
+}

--- a/src/shortcuts/resolve.ts
+++ b/src/shortcuts/resolve.ts
@@ -18,6 +18,7 @@ import {
   type ActionConfig,
   type ActionContextConfig,
   type ActionContextType,
+  type BaseShortcutDependencies,
   type Priority,
 } from '@/shortcuts/types.js'
 import type { ActiveContextsMap } from './ActiveContexts.tsx'
@@ -122,4 +123,37 @@ export const resolve = (
       : installable!.has(action.context)
   })
   return [...candidates].sort((x, y) => compareContexts(x.context, y.context, ctx))
+}
+
+/**
+ * Resolve the dependency object an action's handler receives: the active
+ * context's deps merged with any caller-supplied deps, validated at this one
+ * boundary — the single widened→narrow cast point. Returns `null` when the
+ * context isn't active or the merged deps fail validation; in the run loop
+ * that means "skip this candidate, try the next", never abort.
+ *
+ * Deliberately NOT an installability check: modal shadowing is the keyboard
+ * gather filter (`computeInstallableContexts`), layered by the coordinator —
+ * so imperative `runActionById` still resolves deps for an action in any
+ * active context.
+ *
+ * `supplied` is plumbed for callers that hold deps the active map doesn't yet
+ * (Phase 3's swipe `runBlockAction` passing `{block, uiStateBlock}` instead of
+ * forking the dispatcher); it's unused for now. Validation runs only when deps
+ * are supplied — active-map deps were already validated at activation, so
+ * re-validating them would be redundant work.
+ */
+export const resolveDeps = (
+  action: ActionConfig,
+  active: ActiveContextsMap,
+  contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>,
+  supplied?: Partial<BaseShortcutDependencies>,
+): BaseShortcutDependencies | null => {
+  const base = active.get(action.context)
+  if (!base) return null
+  if (!supplied) return base
+  const merged = {...base, ...supplied}
+  const config = contextConfigsByType.get(action.context)
+  if (config && !config.validateDependencies(merged)) return null
+  return merged
 }

--- a/src/shortcuts/resolve.ts
+++ b/src/shortcuts/resolve.ts
@@ -107,12 +107,19 @@ export const resolve = (
   ctx: ResolutionContext,
   trigger: Trigger,
 ): readonly ActionConfig[] => {
-  const installable = computeInstallableContexts(ctx.active, ctx.contextConfigsByType)
+  // Modal shadowing is a keyboard-install concern only: imperative
+  // id-invocation (runActionById / useRunAction) finds an action in any
+  // active context, matching the old getActiveActionById. So the installable
+  // filter applies to keyboard triggers, not to `{kind:'action'}`.
+  const installable =
+    trigger.kind === 'action'
+      ? undefined
+      : computeInstallableContexts(ctx.active, ctx.contextConfigsByType)
   const candidates = actions.filter(action => {
     if (!ctx.active.has(action.context)) return false
-    if (!installable.has(action.context)) return false
-    if (trigger.kind === 'action' && action.id !== trigger.actionId) return false
-    return true
+    return trigger.kind === 'action'
+      ? action.id === trigger.actionId
+      : installable!.has(action.context)
   })
   return [...candidates].sort((x, y) => compareContexts(x.context, y.context, ctx))
 }

--- a/src/shortcuts/resolve.ts
+++ b/src/shortcuts/resolve.ts
@@ -8,10 +8,11 @@
  * `resolve` ORDERS candidates; it does not MATCH chords. Keyboard chord
  * matching (including tinykeys sequence state for `g g`) stays in the
  * coordinator, which feeds `resolve` the candidates that have already
- * completed a match this event. The `ChordDescriptor` trigger is read as
- * "the chord that just completed" — carried for dedup/logging, never used
- * to match here. Reducing a keydown to one descriptor and matching on it
- * is exactly how sequence chords went dead historically.
+ * completed a match this event (a `'keyboard'` trigger). Reducing a keydown
+ * to one descriptor and matching on it here is exactly how sequence chords
+ * went dead historically, so resolve never sees the chord — only the
+ * already-matched candidate set, which it filters (modal shadowing) and
+ * orders.
  */
 import {
   ActionContextTypes,
@@ -22,11 +23,21 @@ import {
   type Priority,
 } from '@/shortcuts/types.js'
 import type { ActiveContextsMap } from './ActiveContexts.tsx'
-import type { ChordDescriptor } from './canonicalizeChord.ts'
 
+/**
+ * What's being resolved. The kind selects the install-filter policy:
+ *  - `'action'` — imperative lookup by id (runActionById / useRunAction).
+ *    Modal shadowing is NOT applied; an action is found in any active context.
+ *  - `'keyboard'` — the coordinator's already-matched candidate set for a
+ *    chord. Modal shadowing IS applied (the keyboard gather filter).
+ * Phase 3 will extend the keyboard arm with a normalized pointer/touch
+ * descriptor when a caller actually constructs one (see `ChordDescriptor`,
+ * whose `kind` field stays open for that); resolve doesn't need the chord
+ * itself, only the policy + the candidate set.
+ */
 export type Trigger =
   | { kind: 'action'; actionId: string }
-  | ChordDescriptor // keyboard now; mouse/touch descriptors in Phase 3
+  | { kind: 'keyboard' }
 
 /** Everything the comparator needs that isn't on the `ActionConfig`. */
 export interface ResolutionContext {
@@ -61,6 +72,13 @@ const PRIORITY_RANK: Record<Priority, number> = {low: 0, default: 1, high: 2}
 
 // Primary tier: an active `modal` outranks `global`, `global` outranks the
 // rest. Ordered ascending so a larger number wins.
+//
+// `TIER_MODAL > TIER_GLOBAL` bakes in the modal-over-global default, which is
+// still an OPEN ledger item ("global vs active modal on the same chord —
+// needs explicit sign-off"; see docs/action-system-implementation-plan.html).
+// It's currently moot — nothing binds a global chord that an active modal
+// also claims (e.g. no global Escape) — but if that decision reverses, this
+// is the one line to change, and it routes through the single comparator.
 const TIER_SCOPED = 0
 const TIER_GLOBAL = 1
 const TIER_MODAL = 2

--- a/src/shortcuts/runAction.ts
+++ b/src/shortcuts/runAction.ts
@@ -1,10 +1,15 @@
 import { useCallback } from 'react'
+import { actionContextsFacet } from '@/extensions/core.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import {
   useActiveContextsDispatch,
   useActiveContextsState,
 } from '@/shortcuts/ActiveContexts.js'
-import { ActionTrigger } from '@/shortcuts/types.js'
+import {
+  ActionTrigger,
+  type ActionContextConfig,
+  type ActionContextType,
+} from '@/shortcuts/types.js'
 import { getActiveActionById, getEffectiveActions } from './effectiveActions.ts'
 
 export type RunActionByIdFn = (
@@ -48,7 +53,14 @@ export function useRunAction(): RunActionByIdFn {
 
   return useCallback<RunActionByIdFn>(
     (actionId, trigger) => {
-      const action = getActiveActionById(getEffectiveActions(runtime), active, actionId)
+      const contextConfigsByType = new Map<ActionContextType, ActionContextConfig>(
+        runtime.read(actionContextsFacet).map(c => [c.type, c]),
+      )
+      const action = getActiveActionById(
+        getEffectiveActions(runtime),
+        {active, contextConfigsByType},
+        actionId,
+      )
       if (!action) {
         throw new Error(`[useRunAction] Active action with ID "${actionId}" not found.`)
       }

--- a/src/shortcuts/runAction.ts
+++ b/src/shortcuts/runAction.ts
@@ -11,6 +11,7 @@ import {
   type ActionContextType,
 } from '@/shortcuts/types.js'
 import { getActiveActionById, getEffectiveActions } from './effectiveActions.ts'
+import { resolveDeps } from './resolve.ts'
 
 export type RunActionByIdFn = (
   actionId: string,
@@ -64,7 +65,7 @@ export function useRunAction(): RunActionByIdFn {
       if (!action) {
         throw new Error(`[useRunAction] Active action with ID "${actionId}" not found.`)
       }
-      const deps = active.get(action.context)
+      const deps = resolveDeps(action, active, contextConfigsByType)
       if (!deps) throw new Error(`[useRunAction] Context "${action.context}" is not active.`)
       return action.handler(deps, trigger, dispatch)
     },

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -7,7 +7,7 @@ import {
   useActiveContextsDispatch,
 } from '@/shortcuts/ActiveContexts.js'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext.js'
-import { actionContextsFacet, actionDecoratorsFacet, actionsFacet } from '@/extensions/core.js'
+import { actionContextsFacet, actionTransformsFacet, actionsFacet } from '@/extensions/core.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import {
   ActionConfig,
@@ -138,19 +138,19 @@ const LayoutKeydownWhenActive = ({
 
 const Harness = ({
   actions,
-  decorators = [],
+  transforms = [],
   contexts,
   children,
 }: {
   actions: readonly ActionConfig[]
-  decorators?: Parameters<typeof actionDecoratorsFacet.of>[0][]
+  transforms?: Parameters<typeof actionTransformsFacet.of>[0][]
   contexts: readonly ActionContextConfig[]
   children?: ReactNode
 }) => {
   const runtime = resolveFacetRuntimeSync([
     ...contexts.map(c => actionContextsFacet.of(c)),
     ...actions.map(a => actionsFacet.of(a)),
-    ...decorators.map(d => actionDecoratorsFacet.of(d)),
+    ...transforms.map(t => actionTransformsFacet.of(t)),
   ])
 
   return (
@@ -207,10 +207,10 @@ describe('HotkeyReconciler', () => {
     render(
       <Harness
         actions={[action]}
-        decorators={[{
+        transforms={[{
           actionId: action.id,
           context: TEST_CONTEXT,
-          decorate: current => ({
+          apply: current => ({
             ...current,
             handler: (deps, trigger) => {
               calls.push('decorated')

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -52,6 +52,15 @@ const secondModalContextConfig: ActionContextConfig = {
     typeof deps === 'object' && deps !== null,
 }
 
+const HIGH_CONTEXT = 'high-priority-mode' as ActionContextType
+const highContextConfig: ActionContextConfig = {
+  type: HIGH_CONTEXT,
+  displayName: 'High Priority Mode',
+  priority: 'high',
+  validateDependencies: (deps): deps is BaseShortcutDependencies =>
+    typeof deps === 'object' && deps !== null,
+}
+
 interface MockDeps extends BaseShortcutDependencies {
   marker: string
 }
@@ -449,6 +458,75 @@ describe('HotkeyReconciler', () => {
 
       act(() => dispatchKeydown('m'))
       expect(firstHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('single winner (no double-fire)', () => {
+    it('fires only the highest-precedence action when two contexts share a chord', () => {
+      // Both global and the base context bind 'k' and are active. The old
+      // per-action-listener model fired BOTH (the double-fire bug); the
+      // coordinator must dispatch exactly one — global, as the reserved top
+      // tier.
+      const globalHandler = vi.fn()
+      const baseHandler = vi.fn()
+      const globalAction = buildAction({
+        id: 'test.global-k',
+        context: GLOBAL_CONTEXT,
+        handler: globalHandler,
+        defaultBinding: {keys: 'k'},
+      })
+      const baseAction = buildAction({
+        id: 'test.base-k',
+        context: TEST_CONTEXT,
+        handler: baseHandler,
+        defaultBinding: {keys: 'k'},
+      })
+
+      render(
+        <Harness
+          actions={[globalAction, baseAction]}
+          contexts={[testContextConfig, globalContextConfig]}
+        >
+          <SequentialActivator contexts={[GLOBAL_CONTEXT, TEST_CONTEXT]}/>
+        </Harness>,
+      )
+
+      act(() => dispatchKeydown('k'))
+      expect(globalHandler).toHaveBeenCalledTimes(1)
+      expect(baseHandler).not.toHaveBeenCalled()
+    })
+
+    it('a higher-priority context wins a shared chord even when activated earlier', () => {
+      // The early/late inversion: the high-priority context is activated
+      // FIRST (older) and the default context LATER (newer). Recency alone
+      // would pick the newer one; priority must override it.
+      const highHandler = vi.fn()
+      const lowHandler = vi.fn()
+      const highAction = buildAction({
+        id: 'test.high-k',
+        context: HIGH_CONTEXT,
+        handler: highHandler,
+        defaultBinding: {keys: 'k'},
+      })
+      const lowAction = buildAction({
+        id: 'test.low-k',
+        context: TEST_CONTEXT,
+        handler: lowHandler,
+        defaultBinding: {keys: 'k'},
+      })
+
+      render(
+        <Harness
+          actions={[highAction, lowAction]}
+          contexts={[highContextConfig, testContextConfig]}
+        >
+          <SequentialActivator contexts={[HIGH_CONTEXT, TEST_CONTEXT]}/>
+        </Harness>,
+      )
+
+      act(() => dispatchKeydown('k'))
+      expect(highHandler).toHaveBeenCalledTimes(1)
+      expect(lowHandler).not.toHaveBeenCalled()
     })
   })
 

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -528,6 +528,39 @@ describe('HotkeyReconciler', () => {
       expect(highHandler).toHaveBeenCalledTimes(1)
       expect(lowHandler).not.toHaveBeenCalled()
     })
+
+    it('skips a candidate whose canDispatch declines and dispatches the next', () => {
+      // The high-priority context would win 'k', but its canDispatch returns
+      // false, so the coordinator falls through to the lower context's 'k'.
+      const declinedHandler = vi.fn()
+      const fallbackHandler = vi.fn()
+      const highAction = buildAction({
+        id: 'test.high-decline',
+        context: HIGH_CONTEXT,
+        handler: declinedHandler,
+        canDispatch: () => false,
+        defaultBinding: {keys: 'k'},
+      })
+      const lowAction = buildAction({
+        id: 'test.low-fallback',
+        context: TEST_CONTEXT,
+        handler: fallbackHandler,
+        defaultBinding: {keys: 'k'},
+      })
+
+      render(
+        <Harness
+          actions={[highAction, lowAction]}
+          contexts={[highContextConfig, testContextConfig]}
+        >
+          <SequentialActivator contexts={[HIGH_CONTEXT, TEST_CONTEXT]}/>
+        </Harness>,
+      )
+
+      act(() => dispatchKeydown('k'))
+      expect(declinedHandler).not.toHaveBeenCalled()
+      expect(fallbackHandler).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('observes the latest dependencies after the context re-activates with new ones', () => {

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -811,6 +811,34 @@ describe('HotkeyReconciler', () => {
         }
       })
 
+      it('does not fire when canDispatch declines, even after the threshold', () => {
+        // Hold dispatch must honour the same canDispatch gate the keydown/keyup
+        // coordinator enforces — otherwise hold bindings are the one path that
+        // fires in a state the action opted out of.
+        vi.useFakeTimers()
+        try {
+          const handler = vi.fn()
+          const action = buildAction({
+            id: 'test.hold-candispatch',
+            handler,
+            canDispatch: () => false,
+            defaultBinding: {keys: 's', phase: 'hold', holdMs: 200},
+          })
+
+          render(
+            <Harness actions={[action]} contexts={[testContextConfig]}>
+              <Activator context={TEST_CONTEXT}/>
+            </Harness>,
+          )
+
+          act(() => dispatchKeydown('s'))
+          act(() => vi.advanceTimersByTime(300))
+          expect(handler).not.toHaveBeenCalled()
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
       it('ignores OS-repeat keydowns while held', () => {
         vi.useFakeTimers()
         try {

--- a/src/shortcuts/test/defineBlocksAction.test.ts
+++ b/src/shortcuts/test/defineBlocksAction.test.ts
@@ -58,14 +58,14 @@ describe('defineBlocksAction', () => {
     expect(flow).toHaveBeenCalledWith(selectedBlocks)
   })
 
-  it('omits canRun on NORMAL_MODE when no per-block predicate is supplied', () => {
+  it('omits isVisible on NORMAL_MODE when no per-block predicate is supplied', () => {
     const pair = defineBlocksAction({
       id: 'test.op',
       blockDescription: 'block',
       blocksDescription: 'blocks',
       flow: async () => undefined,
     })
-    expect(pair.block.canRun).toBeUndefined()
+    expect(pair.block.isVisible).toBeUndefined()
   })
 
   it('routes appliesTo through both variants', () => {
@@ -82,24 +82,24 @@ describe('defineBlocksAction', () => {
     const no = fakeBlock('no')
 
     // NORMAL_MODE — predicate runs against the focused block.
-    expect(pair.block.canRun!({block: yes, uiStateBlock: yes})).toBe(true)
-    expect(pair.block.canRun!({block: no, uiStateBlock: no})).toBe(false)
+    expect(pair.block.isVisible!({block: yes, uiStateBlock: yes})).toBe(true)
+    expect(pair.block.isVisible!({block: no, uiStateBlock: no})).toBe(false)
 
     // MULTI_SELECT_MODE — true when at least one selected block
     // applies; false for empty selections; false when nothing in
     // the selection applies.
     expect(
-      pair.blocks.canRun!({selectedBlocks: [yes, no], anchorBlock: null, uiStateBlock: yes}),
+      pair.blocks.isVisible!({selectedBlocks: [yes, no], anchorBlock: null, uiStateBlock: yes}),
     ).toBe(true)
     expect(
-      pair.blocks.canRun!({selectedBlocks: [no, no], anchorBlock: null, uiStateBlock: no}),
+      pair.blocks.isVisible!({selectedBlocks: [no, no], anchorBlock: null, uiStateBlock: no}),
     ).toBe(false)
     expect(
-      pair.blocks.canRun!({selectedBlocks: [], anchorBlock: null, uiStateBlock: no}),
+      pair.blocks.isVisible!({selectedBlocks: [], anchorBlock: null, uiStateBlock: no}),
     ).toBe(false)
   })
 
-  it('MULTI_SELECT canRun rejects empty selections even without appliesTo', () => {
+  it('MULTI_SELECT isVisible rejects empty selections even without appliesTo', () => {
     const pair = defineBlocksAction({
       id: 'test.op',
       blockDescription: 'block',
@@ -107,14 +107,14 @@ describe('defineBlocksAction', () => {
       flow: async () => undefined,
     })
     expect(
-      pair.blocks.canRun!({
+      pair.blocks.isVisible!({
         selectedBlocks: [],
         anchorBlock: null,
         uiStateBlock: fakeBlock('ui'),
       }),
     ).toBe(false)
     expect(
-      pair.blocks.canRun!({
+      pair.blocks.isVisible!({
         selectedBlocks: [fakeBlock('a')],
         anchorBlock: null,
         uiStateBlock: fakeBlock('ui'),

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -10,6 +10,16 @@ export type ActionIcon = ComponentType<SVGProps<SVGSVGElement>>
 
 export type KeyCombination = string; // e.g. "ctrl+k", "meta+shift+z"
 
+/**
+ * Precedence tier for a context, used when two active contexts bind the
+ * same chord. Named tiers (CodeMirror `Prec` precedent), deliberately NOT
+ * raw integers — keep the set tiny and add a tier only when a real case
+ * needs it. Ordering among the remaining contexts is `high` ▸ `default` ▸
+ * `low`; `global` is a reserved tier above all of these and an active
+ * `modal` context outranks even `global`. Defaults to `'default'`.
+ */
+export type Priority = 'low' | 'default' | 'high';
+
 export interface EventOptions {
   preventDefault?: boolean;
   stopPropagation?: boolean;
@@ -40,6 +50,14 @@ export interface ActionContextConfig<T extends ActionContextType = ActionContext
    * installed so app-wide chords (Cmd+K, Escape) remain reachable.
    */
   modal?: boolean;
+  /**
+   * Precedence tier when two active contexts bind the same chord. Higher
+   * tiers win; ties fall back to activation recency. Orders the
+   * non-`global`, non-`modal` contexts among themselves — `global` sits
+   * above all priorities and an active `modal` above `global`. Defaults to
+   * `'default'`. See {@link Priority}.
+   */
+  priority?: Priority;
   /**
    * Type guard function to validate the dependencies provided when activating the context.
    */

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -177,15 +177,23 @@ export interface Action<T extends ActionContextType = ActionContextType> {
    *  swipe menus, eventual command-palette icon column). Surfaces that
    *  don't render icons just ignore the field. */
   icon?: ActionIcon;
-  /** Optional synchronous predicate for "is this action meaningfully
-   *  applicable to its current dependencies?". Surfaces that list
-   *  actions (command palette, swipe menu) hide the action when this
-   *  returns false, so the user doesn't see an entry that would silently
-   *  no-op. It is NOT a security gate on `handler` — direct callers can
-   *  still invoke a handler whose `canRun` is false; the contract is
-   *  presentational. Omit to mean "always applicable when the context is
-   *  active". */
-  canRun?: ActionCanRun<T>;
+  /** Optional synchronous predicate for "should this action be SHOWN as
+   *  applicable to its current dependencies?". Surfaces that list actions
+   *  (command palette, swipe menu) hide the action when this returns false,
+   *  so the user doesn't see an entry that would silently no-op. Purely
+   *  presentational — it does NOT gate dispatch: the keyboard path and direct
+   *  callers (`runActionById`) still invoke the handler when `isVisible` is
+   *  false. For a dispatch gate use `canDispatch`. Omit to mean "always
+   *  visible when the context is active". */
+  isVisible?: ActionCanRun<T>;
+  /** Optional synchronous predicate gating keyboard DISPATCH. When present and
+   *  it returns false for the resolved deps, the single-winner coordinator
+   *  SKIPS this action and tries the next candidate for the chord — it does
+   *  not swallow the chord. Distinct from `isVisible` (presentational) and
+   *  from imperative `runActionById`, which does not consult it. Must be
+   *  synchronous — the coordinator picks the winner within the event. Omit to
+   *  mean "always dispatchable when the context is active and deps resolve". */
+  canDispatch?: ActionCanRun<T>;
 }
 
 export type ActionConfig<T extends ActionContextType = ActionContextType> = Action<T>

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -198,16 +198,21 @@ export interface Action<T extends ActionContextType = ActionContextType> {
 
 export type ActionConfig<T extends ActionContextType = ActionContextType> = Action<T>
 
-export interface ActionOverride<T extends ActionContextType = ActionContextType> {
+/**
+ * The single contributor shape for rewriting actions before dispatch.
+ * `apply` maps an action to a new action, or to `null` to remove it (the
+ * unbind primitive). `actionId` may be {@link WILDCARD_ACTION_ID} (`'*'`)
+ * to match every action.
+ *
+ * Deliberately NOT generic in the context type. Erasing `T` keeps the
+ * pipeline cast-free — the one widened→narrow cast lives at the
+ * contributor's definition site (where it already narrows `deps`/`action`
+ * to its context), not scattered through `effectiveActions`.
+ */
+export interface ActionTransform {
   actionId: string;
-  context?: T;
-  apply: (action: ActionConfig<T>) => ActionConfig<T> | null;
-}
-
-export interface ActionDecorator<T extends ActionContextType = ActionContextType> {
-  actionId: string;
-  context?: T;
-  decorate: (action: ActionConfig<T>) => ActionConfig<T>;
+  context?: ActionContextType;
+  apply: (action: ActionConfig) => ActionConfig | null;
 }
 
 

--- a/src/shortcuts/utils.ts
+++ b/src/shortcuts/utils.ts
@@ -188,8 +188,8 @@ export interface DefineBlocksActionConfig {
    *  real multi-select and labels the group-header button. */
   blocksDescription: string
   /** Per-block applicability predicate. When provided, the
-   *  NORMAL_MODE variant's `canRun` gates on `appliesTo(block)`,
-   *  and the MULTI_SELECT_MODE variant's `canRun` gates on at
+   *  NORMAL_MODE variant's `isVisible` gates on `appliesTo(block)`,
+   *  and the MULTI_SELECT_MODE variant's `isVisible` gates on at
    *  least one selected block matching. Omit to mean "always". */
   appliesTo?: (block: Block) => boolean
   /** The actual operation. Both variants forward to this with the
@@ -245,7 +245,7 @@ export const defineBlocksAction = ({
     context: ActionContextTypes.NORMAL_MODE,
     ...(icon ? {icon} : {}),
     ...(appliesTo
-      ? {canRun: ({block}: BlockShortcutDependencies) => appliesTo(block)}
+      ? {isVisible: ({block}: BlockShortcutDependencies) => appliesTo(block)}
       : {}),
     handler: ({block}: BlockShortcutDependencies) => flow([block]),
   },
@@ -254,7 +254,7 @@ export const defineBlocksAction = ({
     description: blocksDescription,
     context: ActionContextTypes.MULTI_SELECT_MODE,
     ...(icon ? {icon} : {}),
-    canRun: ({selectedBlocks}: MultiSelectModeDependencies) => {
+    isVisible: ({selectedBlocks}: MultiSelectModeDependencies) => {
       if (selectedBlocks.length === 0) return false
       if (!appliesTo) return true
       return selectedBlocks.some(block => appliesTo(block))


### PR DESCRIPTION
Phase 1 PR 1 of the action-system plan (`docs/action-system-implementation-plan.html`): the resolution core + single-winner coordinator. **Closes the double-fire bug** and the early/late precedence inversion, and unifies the keyboard and imperative dispatch paths onto one comparator. Builds on the Phase 0 canonicalizer (#102, merged).

## The bug
Each active action installed its **own** `window` listener (`HotkeyReconciler`), so when two active contexts bound the same chord, **both fired** — a binding's `preventDefault` can't stop a sibling listener. There was also no fire-time precedence: a high-priority surface that activated *before* normal-mode couldn't win a shared chord (the "early/late inversion").

## What's in this PR (plan steps 1–6)

**Step 1 — pure resolution core** (`src/shortcuts/resolve.ts`)
- `compareContexts` — the single precedence comparator: active `modal` ▸ `global` ▸ everything else by **priority tier** then **activation recency**.
- `resolve(actions, ctx, trigger)` — orders candidates best-first. Matching is *not* here: for keyboard triggers the coordinator passes already-matched candidates (so `g g` sequence state lives with the matcher, not a reduced descriptor); `resolve` only orders.
- `priority` named tier (`'low' | 'default' | 'high'`) added to `ActionContextConfig`.

**Step 2 — `getActiveActionById` through the resolver.** `runActionById`/`useRunAction` now share `compareContexts`, so dispatch and keyboard can't diverge. *Intended behavior change:* a `global`-vs-scoped id collision now resolves to `global` (reserved top tier) rather than to the most-recently-activated context. Modal shadowing stays **keyboard-only** — imperative invocation still finds an action in any active context.

**Step 3 — split the overloaded `canRun`.** Rename the presentational predicate `canRun` → `isVisible` (public `Action` type; ~20 plugin authors + 3 reader surfaces — pure rename, no behavior change). Add `canDispatch`, a synchronous keyboard-dispatch gate: the single-winner loop skips a declining candidate and tries the next (it doesn't swallow the chord). Not consulted by `runActionById`. No action defines it yet — it's the hook PR 2's handler-return sentinel will join.

**Step 4 — single-winner coordinator** (`HotkeyReconciler`). One keydown + one keyup listener replace the N per-action listeners. Each installable non-hold binding keeps its own tinykeys matcher (sequence state preserved), but a completed match only **records** the candidate; the coordinator then orders the recorded set via `compareContexts` and dispatches a single winner — the first that's still dispatchable. tinykeys completion is synchronous within the dispatch, so collect-then-order has no async hazard. Hold bindings keep their separate observer; `withRecoveredLetterKey`, the `shouldHandleEvent` filter cascade (gates dispatch, not matching, so sequence state still advances), `eventOptions` precedence, and modal shadowing are all preserved.

**Step 5 — deps seam** (`resolveDeps`). One place builds the handler's deps (active-context deps + optional caller-supplied, validated at the single widened→narrow cast). `null` ⇒ skip the candidate. Routed through the coordinator loop, the `runActionById` dispatcher, and `useRunAction`. `supplied` is plumbed for Phase 3's swipe migration but unused now, so no behavior change.

**Step 6 — tests.** All 30 existing reconciler tests stay green (modal shadowing incl. the hold-fired/stale-listener activation races, sequences, phase, hold). Added: no-double-fire, priority-beats-recency (early/late inversion), `canDispatch` fall-through, and the `resolve`/`compareContexts` precedence unit tests.

## Out of scope (deliberately)
**PR 2 / Option D** (declinable handler-return sentinel) — the plan sequences it to land with the downstream spatial-selection branch that is its only fall-through consumer, which isn't in this checkout. The coordinator loop already has the skip-loop shape it slots into.

## Verification
`yarn run check`: tsc clean, lint 0 errors (only pre-existing warnings), **2788 tests pass**. (One run hit the repo's documented cycle-detection flake — `docs/cycle-detection-test-flake.md`; it didn't recur.)

https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg)_