### PR TITLE
Phase 2: unify the action transform pipeline behind one ActionTransform

### DIFF
--- a/agent-extensions/readwise.tsx
+++ b/agent-extensions/readwise.tsx
@@ -1,5 +1,5 @@
 import {
-  actionDecoratorsFacet, actionsFacet, ActionContextTypes, appEffectsFacet, appMountsFacet,
+  actionTransformsFacet, actionsFacet, ActionContextTypes, appEffectsFacet, appMountsFacet,
   blockContentDecoratorsFacet, ChangeScope, codecs, defineBlockType, defineProperty,
   definePropertyEditorOverride, getPluginPrefsBlock,
   keyBetween, keysBetween, pluginBlockId,
@@ -8,7 +8,7 @@ import {
   showSuccess, typesFacet, useRepo,
   type ActionConfig,
   type ActionContextType,
-  type ActionDecorator,
+  type ActionTransform,
   type BlockContentDecorator,
   type BlockContentDecoratorContribution,
   type PropertyEditorProps,
@@ -1017,10 +1017,10 @@ const toggleHighlightReviewed = async (block: any): Promise<boolean> => {
 const decorateActionToToggleReadwiseReview = (
   actionId: string,
   context?: ActionContextType,
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   ...(context ? { context } : {}),
-  decorate: (action: ActionConfig): ActionConfig => ({
+  apply: (action: ActionConfig): ActionConfig => ({
     ...action,
     handler: async (deps, trigger, dispatch) => {
       const block = (deps as BlockShortcutDependencies).block
@@ -1030,10 +1030,10 @@ const decorateActionToToggleReadwiseReview = (
   }),
 })
 
-const readwiseSwipeRightDecorator: ActionDecorator =
+const readwiseSwipeRightDecorator: ActionTransform =
   decorateActionToToggleReadwiseReview(SWIPE_RIGHT_BLOCK_ACTION_ID)
 
-const readwiseTodoCycleDecorators: readonly ActionDecorator[] = [
+const readwiseTodoCycleDecorators: readonly ActionTransform[] = [
   decorateActionToToggleReadwiseReview(
     TODO_CYCLE_ACTION_ID,
     ActionContextTypes.NORMAL_MODE,
@@ -1660,7 +1660,7 @@ export default [
   actionsFacet.of(openSettingsAction, { source }),
   actionsFacet.of(syncNowAction, { source }),
   actionsFacet.of(connectAction, { source }),
-  actionDecoratorsFacet.of(readwiseSwipeRightDecorator, { source }),
+  actionTransformsFacet.of(readwiseSwipeRightDecorator, { source }),
   ...readwiseTodoCycleDecorators.map(decorator =>
-    actionDecoratorsFacet.of(decorator, { source })),
+    actionTransformsFacet.of(decorator, { source })),
 ]

--- a/docs/action-system-implementation-plan.html
+++ b/docs/action-system-implementation-plan.html
@@ -368,6 +368,14 @@ type ActionTransform = {
       <code>spatial-navigation</code>'s decorators, plus the keybinding-override pass. There are <em>no</em> "vim
       skip-decorators" in this repo — those belong to the external agenda user and are out of scope here.</li>
 </ul>
+<p class="note"><strong>Shipped (supersedes the bullets above):</strong> the owner chose a
+   <strong>hard removal, no deprecation window</strong> — <code>ActionOverride</code>/<code>ActionDecorator</code>,
+   <code>actionOverridesFacet</code>/<code>actionDecoratorsFacet</code>, their guards, and their
+   <code>extensions/api.ts</code> exports are deleted outright rather than kept one release. Collapsed to
+   a <strong>single</strong> <code>actionTransformsFacet</code> (not two facet ids). Codemod inventory was
+   <strong>incomplete</strong>: it also had to migrate <code>agent-extensions/readwise.tsx</code> (the same
+   mark-complete/reviewed transforms as SRS), which is outside <code>tsconfig</code>/ESLint scope so
+   <code>yarn run check</code> did not flag it — a reviewer caught it.</p>
 </div>
 
 <div class="phase">

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -113,21 +113,21 @@ Lower-effort variant: leave the direct-call pattern, but lift the focus dance in
 
 Originally surfaced while debugging codex-flagged P2s on PR #21 (palette quick-action race + edit-mode latch). The handler-level workaround landed; this is the architectural cleanup.
 
-### Semantic action groups for decorator targets
+### Semantic action groups for transform targets
 
-SRS and Readwise both want to intercept the same user intent — "mark this block as complete/reviewed" — across three concrete actions: `todo.cycle`, `edit.cm.todo.cycle`, and `block.swipe-right`. Today each plugin contributes three decorators. That is locally simple and matches the current `actionDecoratorsFacet` contract, but it leaks the physical action list into every plugin that wants to specialize the semantic behavior.
+SRS and Readwise both want to intercept the same user intent — "mark this block as complete/reviewed" — across three concrete actions: `todo.cycle`, `edit.cm.todo.cycle`, and `block.swipe-right`. Today each plugin contributes three transforms. That is locally simple and matches the current `actionTransformsFacet` contract, but it leaks the physical action list into every plugin that wants to specialize the semantic behavior.
 
-Important distinction: the todo actions already delegate to one implementation function (`cycleTodoState`), but decorators do not wrap implementation calls. They wrap registered `ActionConfig` records by exact `action.id` plus optional context. So "decorate only todo cycle" would miss edit-mode and swipe-right unless those actions stopped being distinct action records.
+Important distinction: the todo actions already delegate to one implementation function (`cycleTodoState`), but transforms do not wrap implementation calls. They wrap registered `ActionConfig` records by exact `action.id` plus optional context. So "transform only todo cycle" would miss edit-mode and swipe-right unless those actions stopped being distinct action records.
 
-Explore adding semantic grouping metadata to actions, e.g. `groups: ['block.primary-complete']`, and letting decorators target a group as well as an id. Todo would mark all three concrete actions with the group; SRS/Readwise would contribute one group decorator that checks the block type and either consumes the action or falls through. Keep group membership as metadata during `getEffectiveActions` expansion — not a dispatch alias — so `block.swipe-right` remains a gesture-owned action and the swipe menu does not have to route through keyboard active-context dispatch.
+Explore adding semantic grouping metadata to actions, e.g. `groups: ['block.primary-complete']`, and letting transforms target a group as well as an id. Todo would mark all three concrete actions with the group; SRS/Readwise would contribute one group transform that checks the block type and either consumes the action or falls through. Keep group membership as metadata during `getEffectiveActions` expansion — not a dispatch alias — so `block.swipe-right` remains a gesture-owned action and the swipe menu does not have to route through keyboard active-context dispatch.
 
 Questions to answer before building:
 
-- Does `ActionDecorator` grow `groupId?: string`, or do actions expose `aliases?: readonly string[]` and decorators keep the single `actionId` field?
-- What is the ordering rule when both id-targeted and group-targeted decorators match the same action? Preserve contribution order if possible.
-- Should group decorators optionally constrain context, same as id decorators do today?
+- Does `ActionTransform` grow `groupId?: string`, or do actions expose `aliases?: readonly string[]` and transforms keep the single `actionId` field?
+- What is the ordering rule when both id-targeted and group-targeted transforms match the same action? Preserve contribution order if possible.
+- Should group transforms optionally constrain context, same as id transforms do today?
 - How should command palette / shortcut settings display grouped semantics without hiding the concrete action id that the user binds?
-- Is this worth a runtime semantic change, or is a helper like `decorateActions([ids...], factory)` enough until a third plugin needs the same pattern?
+- Is this worth a runtime semantic change, or is a helper like `transformActions([ids...], factory)` enough until a third plugin needs the same pattern?
 
 Acceptance for the exploration: produce a small design note or spike with tests around `getEffectiveActions`, compare it against the helper-only option, and only then migrate SRS/Readwise. Avoid making `block.swipe-right` delegate to `todo.cycle`; that would blur gesture deps with active keyboard contexts and make swipe behavior harder to reason about.
 

--- a/src/extensions/api.ts
+++ b/src/extensions/api.ts
@@ -40,9 +40,8 @@ export {
 
 // --- Blessed core facets ---
 export {
-  actionDecoratorsFacet,
+  actionTransformsFacet,
   actionsFacet,
-  actionOverridesFacet,
   actionContextsFacet,
   appEffectsFacet,
   appMountsFacet,
@@ -113,8 +112,7 @@ export {
   type ActionContextConfig,
   type ActionContextType,
   type Action,
-  type ActionDecorator,
-  type ActionOverride,
+  type ActionTransform,
   type ShortcutBinding,
   type KeyCombination,
 } from '@/shortcuts/types.js'

--- a/src/extensions/core.ts
+++ b/src/extensions/core.ts
@@ -6,8 +6,7 @@ import {
   ActionConfig,
   ActionContextConfig,
   ActionContextType,
-  type ActionDecorator,
-  type ActionOverride,
+  type ActionTransform,
 } from '@/shortcuts/types.js'
 import { BlockRenderer, RendererRegistry } from '@/types.js'
 import type { ComponentType } from 'react'
@@ -121,17 +120,11 @@ export const isActionConfig = (value: unknown): value is ActionConfig =>
   typeof value.handler === 'function' &&
   (value.defaultBinding === undefined || isShortcutBindingInput(value.defaultBinding))
 
-const isActionOverride = (value: unknown): value is ActionOverride =>
+const isActionTransform = (value: unknown): value is ActionTransform =>
   isRecord(value) &&
   typeof value.actionId === 'string' &&
   (value.context === undefined || isActionContextType(value.context)) &&
   typeof value.apply === 'function'
-
-const isActionDecorator = (value: unknown): value is ActionDecorator =>
-  isRecord(value) &&
-  typeof value.actionId === 'string' &&
-  (value.context === undefined || isActionContextType(value.context)) &&
-  typeof value.decorate === 'function'
 
 export const createRendererRegistry = (
   contributions: readonly RendererContribution[],
@@ -160,14 +153,14 @@ export const actionsFacet = defineFacet<ActionConfig, readonly ActionConfig[]>({
   validate: isActionConfig,
 })
 
-export const actionOverridesFacet = defineFacet<ActionOverride, readonly ActionOverride[]>({
-  id: 'core.action-overrides',
-  validate: isActionOverride,
-})
-
-export const actionDecoratorsFacet = defineFacet<ActionDecorator, readonly ActionDecorator[]>({
-  id: 'core.action-decorators',
-  validate: isActionDecorator,
+/**
+ * The one facet for contributing action transforms (replace / wrap /
+ * unbind). The effective-actions pipeline runs every contribution in a
+ * single ordered pass.
+ */
+export const actionTransformsFacet = defineFacet<ActionTransform, readonly ActionTransform[]>({
+  id: 'core.action-transforms',
+  validate: isActionTransform,
 })
 
 export const isAppEffect = (value: unknown): value is AppEffect =>

--- a/src/extensions/test/api.test.ts
+++ b/src/extensions/test/api.test.ts
@@ -13,10 +13,9 @@ describe('@/extensions/api — public surface', () => {
     // Facet primitives
     'defineFacet',
     // Blessed core facets
-    'actionDecoratorsFacet',
+    'actionTransformsFacet',
     'actionsFacet',
     'actionContextsFacet',
-    'actionOverridesFacet',
     'appEffectsFacet',
     'appMountsFacet',
     'blockRenderersFacet',

--- a/src/plugins/daily-notes/blockDateAdapter.ts
+++ b/src/plugins/daily-notes/blockDateAdapter.ts
@@ -7,7 +7,7 @@
  * - daily-notes can't import srs-rescheduling without a layering cycle
  *   (srs-rescheduling already depends on daily-notes for daily-note
  *   resolution).
- * - The existing `actionDecoratorsFacet` pattern only handles
+ * - The existing `actionTransformsFacet` pattern only handles
  *   parameter-less actions ("shift +1d"). Picking an absolute ISO from
  *   a calendar can't go through that channel without inventing a
  *   parameter passing mechanism.

--- a/src/plugins/spatial-navigation/actions.ts
+++ b/src/plugins/spatial-navigation/actions.ts
@@ -1,12 +1,12 @@
 import {
-  actionDecoratorsFacet,
+  actionTransformsFacet,
   actionsFacet,
 } from '@/extensions/core.js'
 import type { AppExtension } from '@/extensions/facet.js'
 import {
   ActionConfig,
   type BaseShortcutDependencies,
-  type ActionDecorator,
+  type ActionTransform,
   ActionContextTypes,
   type BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
@@ -298,10 +298,10 @@ const verticalDecorator = (
   actionId: 'move_down' | 'move_up',
   direction: 'down' | 'up',
   description: string,
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   context: ActionContextTypes.NORMAL_MODE,
-  decorate: action => ({
+  apply: action => ({
     ...action,
     description,
     handler: async (deps, trigger, dispatch) => {
@@ -315,10 +315,10 @@ const selectionVerticalDecorator = (
   actionId: 'extend_selection_down' | 'extend_selection_up' | 'multi_select.extend_selection_down' | 'multi_select.extend_selection_up',
   context: typeof ActionContextTypes.NORMAL_MODE | typeof ActionContextTypes.MULTI_SELECT_MODE,
   direction: 'down' | 'up',
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   context,
-  decorate: action => ({
+  apply: action => ({
     ...action,
     handler: async (deps, trigger, dispatch) => {
       if (await extendSelectionVertical(deps, direction)) return
@@ -327,7 +327,7 @@ const selectionVerticalDecorator = (
   }),
 })
 
-export function getSpatialNavigationActionDecorators(): ActionDecorator[] {
+export function getSpatialNavigationActionDecorators(): ActionTransform[] {
   return [
     verticalDecorator('move_down', 'down', 'Move focus down (next block, then stack-sibling panel below)'),
     verticalDecorator('move_up', 'up', 'Move focus up (previous block, then stack-sibling panel above)'),
@@ -345,5 +345,5 @@ export const spatialNavigationActionsExtension: AppExtension =
 
 export const spatialNavigationActionDecoratorsExtension: AppExtension =
   getSpatialNavigationActionDecorators().map(decorator =>
-    actionDecoratorsFacet.of(decorator as ActionDecorator, {source: 'spatial-navigation'}),
+    actionTransformsFacet.of(decorator, {source: 'spatial-navigation'}),
   )

--- a/src/plugins/spatial-navigation/test/actions.test.ts
+++ b/src/plugins/spatial-navigation/test/actions.test.ts
@@ -102,7 +102,7 @@ const decorateAction = <T extends typeof ActionContextTypes.NORMAL_MODE | typeof
     candidate.actionId === action.id && candidate.context === action.context,
   )
   if (!decorator) throw new Error(`Missing spatial decorator for ${action.context}:${action.id}`)
-  return decorator.decorate(action as ActionConfig) as ActionConfig<T>
+  return decorator.apply(action as ActionConfig) as ActionConfig<T>
 }
 
 let sharedDb: TestDb

--- a/src/plugins/srs-rescheduling/index.ts
+++ b/src/plugins/srs-rescheduling/index.ts
@@ -1,5 +1,5 @@
 import { Check, ClipboardPaste, ClockArrowDown, Gauge, RotateCcw, Scissors, Sparkles } from 'lucide-react'
-import { actionDecoratorsFacet, actionsFacet } from '@/extensions/core.js'
+import { actionTransformsFacet, actionsFacet } from '@/extensions/core.js'
 import type { AppExtension } from '@/extensions/facet.js'
 import { systemToggle } from '@/extensions/togglable.js'
 import type { Block } from '@/data/block'
@@ -591,10 +591,10 @@ export const srsReschedulingPlugin: AppExtension = systemToggle({
   srsReschedulingActions.map(action =>
     actionsFacet.of(action, {source: 'srs-rescheduling'}),
   ),
-  actionDecoratorsFacet.of(srsRescheduleDecorator, {source: 'srs-rescheduling'}),
-  actionDecoratorsFacet.of(srsSwipeRightDecorator, {source: 'srs-rescheduling'}),
+  actionTransformsFacet.of(srsRescheduleDecorator, {source: 'srs-rescheduling'}),
+  actionTransformsFacet.of(srsSwipeRightDecorator, {source: 'srs-rescheduling'}),
   srsTodoCycleDecorators.map(decorator =>
-    actionDecoratorsFacet.of(decorator, {source: 'srs-rescheduling'}),
+    actionTransformsFacet.of(decorator, {source: 'srs-rescheduling'}),
   ),
   // Negative precedence: SRS adapter sorts before the generic reference
   // adapter so a block that is BOTH an SRS card AND has an inline date

--- a/src/plugins/srs-rescheduling/rescheduleDecorator.ts
+++ b/src/plugins/srs-rescheduling/rescheduleDecorator.ts
@@ -10,14 +10,14 @@ import {
 } from '@/plugins/daily-notes/rescheduleAction.js'
 import type {
   ActionConfig,
-  ActionDecorator,
+  ActionTransform,
   BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
 import { srsBlockDateAdapter } from './srsBlockDateAdapter.ts'
 
-export const srsRescheduleDecorator: ActionDecorator = {
+export const srsRescheduleDecorator: ActionTransform = {
   actionId: RESCHEDULE_BLOCK_DATE_ACTION_ID,
-  decorate: (action: ActionConfig): ActionConfig => ({
+  apply: (action: ActionConfig): ActionConfig => ({
     ...action,
     isVisible: (deps) => {
       const block = (deps as BlockShortcutDependencies).block

--- a/src/plugins/srs-rescheduling/swipeRightDecorator.ts
+++ b/src/plugins/srs-rescheduling/swipeRightDecorator.ts
@@ -8,7 +8,7 @@ import {
 import type {
   ActionConfig,
   ActionContextType,
-  ActionDecorator,
+  ActionTransform,
   BlockShortcutDependencies,
 } from '@/shortcuts/types.js'
 import { ActionContextTypes } from '@/shortcuts/types.js'
@@ -27,10 +27,10 @@ export const archiveSrsBlock = async (block: Block): Promise<boolean> => {
 const decorateActionToArchiveSrsBlock = (
   actionId: string,
   context?: ActionContextType,
-): ActionDecorator => ({
+): ActionTransform => ({
   actionId,
   ...(context ? {context} : {}),
-  decorate: (action: ActionConfig): ActionConfig => ({
+  apply: (action: ActionConfig): ActionConfig => ({
     ...action,
     handler: async (deps, trigger) => {
       const block = (deps as BlockShortcutDependencies).block
@@ -40,10 +40,10 @@ const decorateActionToArchiveSrsBlock = (
   }),
 })
 
-export const srsSwipeRightDecorator: ActionDecorator =
+export const srsSwipeRightDecorator: ActionTransform =
   decorateActionToArchiveSrsBlock(SWIPE_RIGHT_BLOCK_ACTION_ID)
 
-export const srsTodoCycleDecorators: readonly ActionDecorator[] = [
+export const srsTodoCycleDecorators: readonly ActionTransform[] = [
   decorateActionToArchiveSrsBlock(
     TODO_CYCLE_ACTION_ID,
     ActionContextTypes.NORMAL_MODE,

--- a/src/plugins/swipe-quick-actions/actions.ts
+++ b/src/plugins/swipe-quick-actions/actions.ts
@@ -4,7 +4,7 @@ import { defineFacet } from '@/extensions/facet.js'
 
 /** Semantic action invoked by a right-swipe on a block content surface.
  *  The gesture plugin owns the trigger; another plugin owns the baseline
- *  handler and other plugins can decorate it through `actionDecoratorsFacet`. */
+ *  handler and other plugins can decorate it through `actionTransformsFacet`. */
 export const SWIPE_RIGHT_BLOCK_ACTION_ID = 'block.swipe-right'
 
 export interface QuickActionContext {

--- a/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
+++ b/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
@@ -7,7 +7,7 @@ import { BlockCache } from '@/data/blockCache'
 import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import type { Block } from '@/data/block'
-import { actionDecoratorsFacet, actionsFacet } from '@/extensions/core'
+import { actionTransformsFacet, actionsFacet } from '@/extensions/core'
 import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext'
 import { type ActionConfig, ActionContextTypes, type BlockShortcutDependencies } from '@/shortcuts/types'
@@ -332,10 +332,10 @@ describe('SwipeActionMenu', () => {
     }
     runtime = resolveFacetRuntimeSync([
       actionsFacet.of(baseAction, {source: 'test'}),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: SWIPE_RIGHT_BLOCK_ACTION_ID,
         context: ActionContextTypes.NORMAL_MODE,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             const blockDeps = deps as BlockShortcutDependencies

--- a/src/shortcuts/applyKeybindingOverrides.ts
+++ b/src/shortcuts/applyKeybindingOverrides.ts
@@ -1,7 +1,7 @@
 /**
  * Pure pass that rewrites each action's `defaultBinding` from a list of
  * `KeybindingOverride` contributions. Invoked by `getEffectiveActions`
- * after the standard override/decorator pipeline.
+ * after the per-action transform pipeline.
  *
  * Rules:
  *

--- a/src/shortcuts/effectiveActions.test.ts
+++ b/src/shortcuts/effectiveActions.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  actionDecoratorsFacet,
-  actionOverridesFacet,
+  actionTransformsFacet,
   actionsFacet,
 } from '@/extensions/core.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
@@ -26,7 +25,7 @@ const baseAction = (overrides: Partial<ActionConfig> = {}): ActionConfig => ({
 } as ActionConfig)
 
 describe('getEffectiveActions', () => {
-  it('decorates a matching action handler without changing the raw action registry', async () => {
+  it('wraps a matching action handler without changing the raw action registry', async () => {
     const calls: string[] = []
     const action = baseAction({
       handler: async () => {
@@ -35,10 +34,10 @@ describe('getEffectiveActions', () => {
     })
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(action),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: action.id,
         context: ActionContextTypes.NORMAL_MODE,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             calls.push('before')
@@ -56,7 +55,7 @@ describe('getEffectiveActions', () => {
     expect(calls).toEqual(['before', 'base', 'after'])
   })
 
-  it('applies lower-precedence decorators innermost and higher-precedence decorators outermost', async () => {
+  it('applies lower-precedence transforms innermost and higher-precedence transforms outermost', async () => {
     const calls: string[] = []
     const action = baseAction({
       handler: async () => {
@@ -65,9 +64,9 @@ describe('getEffectiveActions', () => {
     })
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(action),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: action.id,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             calls.push('low-before')
@@ -76,9 +75,9 @@ describe('getEffectiveActions', () => {
           },
         }),
       }, {precedence: 0}),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: action.id,
-        decorate: current => ({
+        apply: current => ({
           ...current,
           handler: async (deps, trigger) => {
             calls.push('high-before')
@@ -100,13 +99,13 @@ describe('getEffectiveActions', () => {
     ])
   })
 
-  it('lets overrides replace metadata and remove actions', () => {
+  it('lets a transform replace metadata and remove an action (apply → null unbinds)', () => {
     const kept = baseAction()
     const removed = baseAction({id: 'test.removed'})
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(kept),
       actionsFacet.of(removed),
-      actionOverridesFacet.of({
+      actionTransformsFacet.of({
         actionId: kept.id,
         apply: action => ({
           ...action,
@@ -114,7 +113,7 @@ describe('getEffectiveActions', () => {
           defaultBinding: {keys: 'y'},
         }),
       }),
-      actionOverridesFacet.of({
+      actionTransformsFacet.of({
         actionId: removed.id,
         apply: () => null,
       }),
@@ -138,9 +137,9 @@ describe('getEffectiveActions', () => {
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(first),
       actionsFacet.of(second),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: '*',
-        decorate: action => {
+        apply: action => {
           visited.push(action.id)
           return {...action, description: `seen:${action.id}`}
         },
@@ -163,10 +162,10 @@ describe('getEffectiveActions', () => {
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(normal),
       actionsFacet.of(edit),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: '*',
         context: ActionContextTypes.EDIT_MODE_CM,
-        decorate: action => ({...action, description: 'edit-only'}),
+        apply: action => ({...action, description: 'edit-only'}),
       }),
     ])
 
@@ -176,7 +175,7 @@ describe('getEffectiveActions', () => {
     ])
   })
 
-  it('matches context-specific decorators only against that action context', async () => {
+  it('matches context-specific transforms only against that action context', async () => {
     const normal = baseAction({
       handler: async () => undefined,
     })
@@ -187,19 +186,19 @@ describe('getEffectiveActions', () => {
     const runtime = resolveFacetRuntimeSync([
       actionsFacet.of(normal),
       actionsFacet.of(edit),
-      actionDecoratorsFacet.of({
+      actionTransformsFacet.of({
         actionId: normal.id,
         context: ActionContextTypes.EDIT_MODE_CM,
-        decorate: action => ({
+        apply: action => ({
           ...action,
-          description: 'Decorated edit action',
+          description: 'Transformed edit action',
         }),
       }),
     ])
 
     expect(getEffectiveActions(runtime).map(action => action.description)).toEqual([
       'Base action',
-      'Decorated edit action',
+      'Transformed edit action',
     ])
   })
 })

--- a/src/shortcuts/effectiveActions.ts
+++ b/src/shortcuts/effectiveActions.ts
@@ -1,13 +1,11 @@
 import {
-  actionDecoratorsFacet,
-  actionOverridesFacet,
+  actionTransformsFacet,
   actionsFacet,
 } from '@/extensions/core.js'
 import type { FacetRuntime } from '@/extensions/facet.js'
 import type {
   ActionConfig,
-  ActionDecorator,
-  ActionOverride,
+  ActionTransform,
 } from '@/shortcuts/types.js'
 import { applyKeybindingOverrides } from './applyKeybindingOverrides.ts'
 import { keybindingOverridesFacet } from './keybindingOverrides.ts'
@@ -18,42 +16,42 @@ export const actionRuntimeKey = (
 ): string => `${action.context}:${action.id}`
 
 /** Sentinel `actionId` that matches every action. Use sparingly — most
- *  overrides/decorators target a specific id. The keybindings module
- *  ships one wildcard decorator that reads the
- *  `keybindingOverridesFacet` and rewrites whichever actions the user
- *  has remapped; that needs to inspect every action so it can also
- *  strip a default chord that lost a collision to a user override. */
+ *  transforms target a specific id. The cross-action keybinding-override
+ *  pass (`applyKeybindingOverrides`, run after this pipeline) is the main
+ *  whole-list consumer: it reads the `keybindingOverridesFacet` and
+ *  rewrites whichever actions the user has remapped, inspecting every
+ *  action so it can also strip a default chord that lost a collision to a
+ *  user override. */
 export const WILDCARD_ACTION_ID = '*'
 
 const matchesAction = (
-  target: Pick<ActionOverride | ActionDecorator, 'actionId' | 'context'>,
+  target: Pick<ActionTransform, 'actionId' | 'context'>,
   action: Pick<ActionConfig, 'id' | 'context'>,
 ): boolean =>
   (target.actionId === WILDCARD_ACTION_ID || target.actionId === action.id) &&
   (target.context === undefined || target.context === action.context)
 
-/** The action list after `actionOverridesFacet` and
- *  `actionDecoratorsFacet` have been applied but before any
- *  keybinding-override rewrites. Used by the settings UI so it can
- *  preview an unsaved `StoredKeybindingOverrides` map without waiting
- *  for the runtime rebuild that happens after the canonical prefs
- *  block subscription fires. */
+/** The action list after every `actionTransformsFacet` contribution has
+ *  been applied, but before any keybinding-override rewrites. Used by the
+ *  settings UI so it can preview an unsaved `StoredKeybindingOverrides`
+ *  map without waiting for the runtime rebuild that happens after the
+ *  canonical prefs block subscription fires.
+ *
+ *  Transforms run in the runtime's order (precedence asc, then
+ *  registration), so a later contribution wraps the earlier ones. */
 export const getActionsBeforeKeybindingOverrides = (runtime: FacetRuntime): readonly ActionConfig[] => {
-  const overrides = runtime.read(actionOverridesFacet)
-  const decorators = runtime.read(actionDecoratorsFacet)
+  const transforms = runtime.read(actionTransformsFacet)
   const out: ActionConfig[] = []
 
   for (const rawAction of runtime.read(actionsFacet)) {
     let action: ActionConfig | null = rawAction
 
-    for (const override of overrides) {
-      if (!action || !matchesAction(override, action)) continue
-      action = override.apply(action as never) as ActionConfig | null
-    }
-
-    for (const decorator of decorators) {
-      if (!action || !matchesAction(decorator, action)) continue
-      action = decorator.decorate(action as never) as ActionConfig
+    for (const transform of transforms) {
+      if (!action || !matchesAction(transform, action)) continue
+      // No cast: `ActionTransform` is erased, so `apply` is plain
+      // `ActionConfig → ActionConfig | null`. Contributors narrow at
+      // their own definition site.
+      action = transform.apply(action)
     }
 
     if (action) out.push(action)
@@ -66,7 +64,7 @@ export const getEffectiveActions = (runtime: FacetRuntime): readonly ActionConfi
   // Keybinding overrides run as a final pass — they need cross-action
   // visibility (the "default loses on chord collision" rule reads
   // every other action's effective binding), which the per-action
-  // override/decorator pipeline above can't express cleanly.
+  // transform pipeline above can't express cleanly.
   return applyKeybindingOverrides(
     getActionsBeforeKeybindingOverrides(runtime),
     runtime.read(keybindingOverridesFacet),

--- a/src/shortcuts/keybindingOverrides.ts
+++ b/src/shortcuts/keybindingOverrides.ts
@@ -6,9 +6,10 @@
  * `keybindingOverridesFacet`. The keybindings-settings plugin
  * contributes one entry per user-remapped action at high precedence;
  * other plugins (or static config) can contribute entries at default
- * precedence to ship opinionated rebinds. A single wildcard
- * `ActionDecorator` (see `applyKeybindingOverrides`) consumes the
- * facet and rewrites each action's `defaultBinding` accordingly.
+ * precedence to ship opinionated rebinds. A dedicated cross-action pass
+ * (`applyKeybindingOverrides`, run by `getEffectiveActions` after the
+ * per-action transform pipeline) consumes the facet and rewrites each
+ * action's `defaultBinding` accordingly.
  *
  * Collision rule (matches "user override wins, default loses"):
  *

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -7,7 +7,7 @@ import {
   useActiveContextsDispatch,
 } from '@/shortcuts/ActiveContexts.js'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext.js'
-import { actionContextsFacet, actionDecoratorsFacet, actionsFacet } from '@/extensions/core.js'
+import { actionContextsFacet, actionTransformsFacet, actionsFacet } from '@/extensions/core.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import {
   ActionConfig,
@@ -138,19 +138,19 @@ const LayoutKeydownWhenActive = ({
 
 const Harness = ({
   actions,
-  decorators = [],
+  transforms = [],
   contexts,
   children,
 }: {
   actions: readonly ActionConfig[]
-  decorators?: Parameters<typeof actionDecoratorsFacet.of>[0][]
+  transforms?: Parameters<typeof actionTransformsFacet.of>[0][]
   contexts: readonly ActionContextConfig[]
   children?: ReactNode
 }) => {
   const runtime = resolveFacetRuntimeSync([
     ...contexts.map(c => actionContextsFacet.of(c)),
     ...actions.map(a => actionsFacet.of(a)),
-    ...decorators.map(d => actionDecoratorsFacet.of(d)),
+    ...transforms.map(t => actionTransformsFacet.of(t)),
   ])
 
   return (
@@ -207,10 +207,10 @@ describe('HotkeyReconciler', () => {
     render(
       <Harness
         actions={[action]}
-        decorators={[{
+        transforms={[{
           actionId: action.id,
           context: TEST_CONTEXT,
-          decorate: current => ({
+          apply: current => ({
             ...current,
             handler: (deps, trigger) => {
               calls.push('decorated')

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -198,16 +198,21 @@ export interface Action<T extends ActionContextType = ActionContextType> {
 
 export type ActionConfig<T extends ActionContextType = ActionContextType> = Action<T>
 
-export interface ActionOverride<T extends ActionContextType = ActionContextType> {
+/**
+ * The single contributor shape for rewriting actions before dispatch.
+ * `apply` maps an action to a new action, or to `null` to remove it (the
+ * unbind primitive). `actionId` may be {@link WILDCARD_ACTION_ID} (`'*'`)
+ * to match every action.
+ *
+ * Deliberately NOT generic in the context type. Erasing `T` keeps the
+ * pipeline cast-free — the one widened→narrow cast lives at the
+ * contributor's definition site (where it already narrows `deps`/`action`
+ * to its context), not scattered through `effectiveActions`.
+ */
+export interface ActionTransform {
   actionId: string;
-  context?: T;
-  apply: (action: ActionConfig<T>) => ActionConfig<T> | null;
-}
-
-export interface ActionDecorator<T extends ActionContextType = ActionContextType> {
-  actionId: string;
-  context?: T;
-  decorate: (action: ActionConfig<T>) => ActionConfig<T>;
+  context?: ActionContextType;
+  apply: (action: ActionConfig) => ActionConfig | null;
 }
 
 


### PR DESCRIPTION
Phase 2 of the action-system plan (`docs/action-system-implementation-plan.html`): **unify the transform pipeline.** Collapses the two contributor types — `ActionOverride` (replace/remove) and `ActionDecorator` (wrap) — into one erased `ActionTransform`, retiring the critique's weakness 2 (the "which do I use?" override/decorator asymmetry).

> **Stacked on #103** (Phase 1). Base is `claude/action-resolver-coordinator` so the diff shows only Phase 2; GitHub will retarget to `master` when #103 merges. Review #103 first.

## What changed

**One erased transform type** (`src/shortcuts/types.ts`)
```ts
interface ActionTransform {
  actionId: string          // '*' matches every action
  context?: ActionContextType
  apply: (action: ActionConfig) => ActionConfig | null   // null = unbind
}
```
- **No generic `T`.** Erasing it makes the `effectiveActions` pass **cast-free** — the one widened→narrow cast moves to each contributor's definition site (where it already narrows `deps`), instead of `as never` scattered through the shared pipeline.
- **`null` is the genuine unbind primitive** the old `decorate` never had (parity with the old `apply`).
- One blessed `actionTransformsFacet`; one ordered pass (precedence asc, then registration → later contribution wraps outermost). The cross-action `applyKeybindingOverrides` pass is **untouched** — it stays the one pass that needs whole-list visibility.

**Legacy removed outright (no deprecation shim, per request).** `ActionOverride`, `ActionDecorator`, `actionOverridesFacet`, `actionDecoratorsFacet`, their type guards, and their `extensions/api.ts` exports are deleted. `actionOverridesFacet` had **zero** in-repo `.of()` callers; the override path existed only as machinery.

**Codemod** of every in-repo contributor: srs-rescheduling (reschedule / swipe-right / todo-cycle), spatial-navigation (vertical / selection), and `agent-extensions/readwise.tsx`.

## Review (three lenses) — addressed

Spun up three independent reviewers (correctness, API/architecture, migration-completeness). All three converged on **one blocking item**, now fixed:

- **`agent-extensions/readwise.tsx` was an unmigrated contributor.** It imports `actionDecoratorsFacet`/`ActionDecorator` from the public API and contributes the same mark-reviewed transforms as SRS. It lives **outside `tsconfig`'s `include: ["src"]` and is ESLint-ignored**, so `yarn run check` passed green while the extension would have thrown at load. The plan's "verified inventory" missed it too. → codemodded; plan doc annotated with the corrected inventory.
- **Should-fix (done):** a stale `WILDCARD_ACTION_ID` comment that still called `applyKeybindingOverrides` a "wildcard decorator" (the same error already fixed in `keybindingOverrides.ts`); two more "override/decorator pipeline" comments; and `docs/follow-ups.md` describing the removed types as the *current* contract. The analysis docs (`action-system-critique.html`, `shortcut-context-precedence.html`) keep their references as pre-refactor history.
- **Verified clean:** flattening the old two-phase (overrides→decorators) ordering into one pass changes nothing in-repo (all contributor `actionId` targets are disjoint); the `null`-drop short-circuit matches the old behavior; the codemod handler/`isVisible` bodies are byte-identical; test coverage (incl. the unbind path) is preserved.

**Deferred (NIT, noted by 2 reviewers):** the migrated spatial/srs symbols keep "Decorator" in their names (`getSpatialNavigationActionDecorators`, `srsRescheduleDecorator`, …) while returning `ActionTransform`. Left as a cosmetic follow-up to keep this PR's blast radius tight — happy to finish the rename if you'd prefer.

## Verification
`yarn run check`: tsc clean, lint 0 errors (only pre-existing warnings), **2788 tests pass**. Note: `agent-extensions/` is outside the typecheck/lint scope, so the readwise migration is validated by structural equivalence with the (compiled) srs codemod, not the toolchain.

https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPiQ2XD9xiXcX4uJN1MDLg)_