### PR TITLE
E2EE Phase D+E: activate per-workspace encryption (create + unlock + gate)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -460,6 +460,31 @@ const App = () => {
     repo.setReadOnly(activeRole === 'viewer')
   }, [initial.kind, activeRole, repo])
 
+  // Always watch the URL hash so navigating to a different workspace (Back
+  // button / manual hash edit) re-resolves the layout — even while a gate or
+  // loading screen is shown. In those states there's no layout, so the
+  // projection effect above is inactive and isn't registering the hashchange
+  // listener; without this a user who opened a locked workspace would be stuck
+  // until a full reload. Safe to run alongside the projection's own listener
+  // when ready: the reducer only bumps on a workspace change, so the second
+  // handler in a batch sees the already-updated hash and no-ops.
+  useEffect(() => {
+    const onHashChange = () => {
+      const nextHash = getCurrentHash()
+      setHashSnapshot(current =>
+        layoutWorkspaceChanged(current.hash, nextHash)
+          ? {hash: nextHash, version: current.version + 1}
+          : current,
+      )
+    }
+    window.addEventListener('hashchange', onHashChange)
+    window.addEventListener('popstate', onHashChange)
+    return () => {
+      window.removeEventListener('hashchange', onHashChange)
+      window.removeEventListener('popstate', onHashChange)
+    }
+  }, [])
+
   // Re-resolve the initial layout (bumping the version busts the cache) — used
   // when a gate is resolved or a pending workspace row finally replicates.
   const reResolve = useCallback(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,17 @@ const initialLayoutCache = new Map<string, Promise<InitialLayout>>()
 const getCurrentHash = (): string =>
   typeof window === 'undefined' ? '' : window.location.hash
 
+// Pin a workspace plaintext, best-effort: a blocked/quota localStorage write
+// must not abort bootstrap (the create dialog catches the same failure). Worst
+// case the workspace shows the quarantine gate once on next load.
+const pinPlaintextBestEffort = (userId: string, workspaceId: string): void => {
+  try {
+    setModePin(userId, workspaceId, 'plaintext')
+  } catch (err) {
+    console.warn(`[App] plaintext pin failed for ${workspaceId} (will quarantine on next load)`, err)
+  }
+}
+
 const resolveWorkspace = async (
   repo: Repo,
   requestedWorkspaceId: string | undefined,
@@ -149,7 +160,7 @@ const resolveWorkspace = async (
     // A workspace WE just created is plaintext-confirmed (§8.1) — pin it so the
     // §6 gate never quarantines it. An already-existing personal workspace
     // (inserted=false) is left for the seed/gate to resolve.
-    if (result.inserted) setModePin(repo.user.id, result.workspace.id, 'plaintext')
+    if (result.inserted) pinPlaintextBestEffort(repo.user.id, result.workspace.id)
     return {id: result.workspace.id, freshlyCreated: result.inserted}
   }
 
@@ -163,7 +174,7 @@ const resolveWorkspace = async (
   const local = await ensureLocalPersonalWorkspace(repo)
   // Same plaintext-confirm as the remote path (§8.1) so the gate stays out of
   // the way in local-only mode.
-  if (local.inserted) setModePin(repo.user.id, local.workspace.id, 'plaintext')
+  if (local.inserted) pinPlaintextBestEffort(repo.user.id, local.workspace.id)
   return {id: local.workspace.id, freshlyCreated: local.inserted}
 }
 
@@ -241,8 +252,6 @@ const resolveInitialLayout = async (
   const role = await getLocalMemberRole(repo, workspaceId, repo.user.id)
   repo.setReadOnly(role === 'viewer')
 
-  rememberWorkspace(workspaceId)
-
   // §6 rule 3 access gate. Resolve whether this workspace can be materialized
   // for us right now BEFORE any bootstrap write below — those writes (daily
   // note, properties/types/recents pages, ui-state) would otherwise write
@@ -283,6 +292,11 @@ const resolveInitialLayout = async (
       canary: gateWorkspace?.wkCanary ?? null,
     }
   }
+
+  // Ready — only NOW remember it as the default. Remembering a locked/waiting
+  // workspace would make the next empty-hash visit re-select it and render only
+  // the key gate (no switcher), trapping the user away from accessible spaces.
+  rememberWorkspace(workspaceId)
 
   // Freshly inserted personal workspace: install the starter tutorial
   // as its own parent-less page. The [[Tutorial]] bullet on today's

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BlockComponent } from './components/BlockComponent'
 import { BlockContextProvider } from '@/context/block.js'
-import { use, useEffect, useState } from 'react'
+import { use, useCallback, useEffect, useState } from 'react'
+import { useQuery } from '@powersync/react'
 import type { Block } from './data/block'
 import { useRepo } from '@/context/repo.js'
 import { useSearchParam } from 'react-use'
@@ -44,7 +45,7 @@ import { ChangeScope } from '@/data/api'
 import { hasSafeModeSearchParam } from '@/utils/safeMode.js'
 import { getModePin, setModePin } from '@/sync/keys/modePin.js'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
-import { resolveWorkspaceAccess } from '@/sync/keys/workspaceAccess.js'
+import { decideWorkspaceEntry } from '@/sync/keys/workspaceAccess.js'
 import { WorkspaceKeyGate } from '@/components/workspace/WorkspaceKeyGate.js'
 
 // Resolved-workspace bundle. `freshlyCreated` is true only when this run
@@ -61,7 +62,9 @@ interface ResolvedWorkspace {
 // `ready`: the workspace materialized and bootstrapped normally. `locked`: the
 // §6 gate intercepted before any bootstrap write — the workspace is e2ee
 // without its key, or never-pinned (quarantine) — and App renders the
-// WorkspaceKeyGate instead of the layout.
+// WorkspaceKeyGate. `waiting`: access can't be decided until the workspaces row
+// replicates (opened by URL before sync delivered encryption_mode/wk_canary);
+// App shows a neutral loader and re-resolves when the row lands.
 type InitialLayout =
   | {kind: 'ready'; workspaceId: string; layoutSessionBlock: Block}
   | {
@@ -71,6 +74,7 @@ type InitialLayout =
       reason: 'key-required' | 'quarantine'
       canary: string | null
     }
+  | {kind: 'waiting'; workspaceId: string}
 
 interface HashSnapshot {
   hash: string
@@ -247,25 +251,24 @@ const resolveInitialLayout = async (
   // rollout seed has already pinned pre-existing plaintext workspaces, so only
   // genuinely locked/never-pinned workspaces land here.
   const pin = getModePin(repo.user.id, workspaceId)
+  const hasKey = (await getWorkspaceKeyStore().get(repo.user.id, workspaceId)) !== null
   const gateWorkspace = await getLocalWorkspace(repo, workspaceId)
-  // Only gate when we actually know something: a durable pin (authoritative even
-  // without the row) or a synced local row (real server flag). If both are
-  // absent the workspace simply hasn't replicated yet — proceed and let blocks
-  // poll in, matching pre-e2ee behavior. This avoids mis-quarantining (and
-  // worse, offering plaintext-confirm for) an e2ee workspace whose row hasn't
-  // arrived, which would default its encryption_mode to 'none'.
-  if (pin !== null || gateWorkspace !== null) {
-    const hasKey = (await getWorkspaceKeyStore().get(repo.user.id, workspaceId)) !== null
-    const access = resolveWorkspaceAccess(pin, gateWorkspace?.encryptionMode ?? 'none', hasKey)
-    if (access.kind === 'locked') {
-      repo.setReadOnly(true)
-      return {
-        kind: 'locked',
-        workspaceId,
-        workspaceName: gateWorkspace?.name ?? null,
-        reason: access.reason,
-        canary: gateWorkspace?.wkCanary ?? null,
-      }
+  const entry = decideWorkspaceEntry(pin, hasKey, gateWorkspace)
+  if (entry.kind === 'waiting') {
+    // The workspaces row hasn't replicated yet and the pin can't settle access
+    // without it. Don't bootstrap (would write plaintext into a possibly-e2ee
+    // workspace) and don't gate with a null canary — wait for the row.
+    repo.setReadOnly(true)
+    return {kind: 'waiting', workspaceId}
+  }
+  if (entry.kind === 'locked') {
+    repo.setReadOnly(true)
+    return {
+      kind: 'locked',
+      workspaceId,
+      workspaceName: gateWorkspace?.name ?? null,
+      reason: entry.reason,
+      canary: gateWorkspace?.wkCanary ?? null,
     }
   }
 
@@ -439,9 +442,21 @@ const App = () => {
   const {rolesByWorkspaceId} = useMyWorkspaceRoles()
   const activeRole = rolesByWorkspaceId.get(activeWorkspaceId)
   useEffect(() => {
-    if (!activeRole) return
+    // Don't override the gate/waiting read-only lock with the role-derived flag
+    // (an owner/editor of a *locked* workspace must stay read-only).
+    if (initial.kind !== 'ready' || !activeRole) return
     repo.setReadOnly(activeRole === 'viewer')
-  }, [activeRole, repo])
+  }, [initial.kind, activeRole, repo])
+
+  // Re-resolve the initial layout (bumping the version busts the cache) — used
+  // when a gate is resolved or a pending workspace row finally replicates.
+  const reResolve = useCallback(() => {
+    setHashSnapshot(current => ({hash: current.hash, version: current.version + 1}))
+  }, [])
+
+  if (initial.kind === 'waiting') {
+    return <WorkspaceSyncWaiting workspaceId={initial.workspaceId} onReady={reResolve}/>
+  }
 
   if (initial.kind === 'locked') {
     return (
@@ -451,11 +466,12 @@ const App = () => {
         workspaceName={initial.workspaceName ?? undefined}
         reason={initial.reason}
         canary={initial.canary}
-        onResolved={() => {
-          // Now materializable — re-drain its staged rows and re-resolve the
-          // layout (bumping the version busts the initial-layout cache).
-          void repo.drainSyncWorkspace(initial.workspaceId)
-          setHashSnapshot(current => ({hash: current.hash, version: current.version + 1}))
+        onResolved={async () => {
+          // Re-materialize the now-decryptable staged rows BEFORE re-resolving,
+          // so the bootstrap getOrCreate*s no-op against the synced content
+          // rather than racing it.
+          await repo.drainSyncWorkspace(initial.workspaceId)
+          reResolve()
         }}
       />
     )
@@ -467,6 +483,33 @@ const App = () => {
         <BlockComponent blockId={initial.layoutSessionBlock.id}/>
       </AppRuntimeProvider>
     </BlockContextProvider>
+  )
+}
+
+// Shown while a workspace's row hasn't replicated yet (opened by URL before
+// sync delivered encryption_mode/wk_canary). Reactively watches for the row and
+// re-resolves the layout the moment it lands — no bootstrap writes happen until
+// then, so we never write plaintext into a workspace that may turn out e2ee.
+function WorkspaceSyncWaiting({
+  workspaceId,
+  onReady,
+}: {
+  workspaceId: string
+  onReady: () => void
+}) {
+  const {data} = useQuery<{id: string}>(
+    'SELECT id FROM workspaces WHERE id = ? LIMIT 1',
+    [workspaceId],
+  )
+  const present = data.length > 0
+  useEffect(() => {
+    if (present) onReady()
+  }, [present, onReady])
+
+  return (
+    <div className="flex min-h-svh items-center justify-center p-6">
+      <p className="text-sm text-muted-foreground">Loading workspace…</p>
+    </div>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,10 @@ import {
 import { keyAtEnd } from '@/data/orderKey.js'
 import { ChangeScope } from '@/data/api'
 import { hasSafeModeSearchParam } from '@/utils/safeMode.js'
+import { getModePin, setModePin } from '@/sync/keys/modePin.js'
+import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
+import { resolveWorkspaceAccess } from '@/sync/keys/workspaceAccess.js'
+import { WorkspaceKeyGate } from '@/components/workspace/WorkspaceKeyGate.js'
 
 // Resolved-workspace bundle. `freshlyCreated` is true only when this run
 // inserted a brand-new personal workspace via ensure_personal_workspace;
@@ -54,10 +58,19 @@ interface ResolvedWorkspace {
   freshlyCreated: boolean
 }
 
-interface InitialLayout {
-  workspaceId: string
-  layoutSessionBlock: Block
-}
+// `ready`: the workspace materialized and bootstrapped normally. `locked`: the
+// §6 gate intercepted before any bootstrap write — the workspace is e2ee
+// without its key, or never-pinned (quarantine) — and App renders the
+// WorkspaceKeyGate instead of the layout.
+type InitialLayout =
+  | {kind: 'ready'; workspaceId: string; layoutSessionBlock: Block}
+  | {
+      kind: 'locked'
+      workspaceId: string
+      workspaceName: string | null
+      reason: 'key-required' | 'quarantine'
+      canary: string | null
+    }
 
 interface HashSnapshot {
   hash: string
@@ -129,6 +142,10 @@ const resolveWorkspace = async (
     // leave two membership rows in local sqlite, since the raw table has
     // no (workspace_id, user_id) UNIQUE constraint.
     await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
+    // A workspace WE just created is plaintext-confirmed (§8.1) — pin it so the
+    // §6 gate never quarantines it. An already-existing personal workspace
+    // (inserted=false) is left for the seed/gate to resolve.
+    if (result.inserted) setModePin(repo.user.id, result.workspace.id, 'plaintext')
     return {id: result.workspace.id, freshlyCreated: result.inserted}
   }
 
@@ -140,6 +157,9 @@ const resolveWorkspace = async (
   // workspace + owner membership locally so the rest of bootstrap
   // (seedTutorial, daily note, Tutorial bullet) can run unchanged.
   const local = await ensureLocalPersonalWorkspace(repo)
+  // Same plaintext-confirm as the remote path (§8.1) so the gate stays out of
+  // the way in local-only mode.
+  if (local.inserted) setModePin(repo.user.id, local.workspace.id, 'plaintext')
   return {id: local.workspace.id, freshlyCreated: local.inserted}
 }
 
@@ -219,6 +239,36 @@ const resolveInitialLayout = async (
 
   rememberWorkspace(workspaceId)
 
+  // §6 rule 3 access gate. Resolve whether this workspace can be materialized
+  // for us right now BEFORE any bootstrap write below — those writes (daily
+  // note, properties/types/recents pages, ui-state) would otherwise write
+  // plaintext into an encrypted-but-locked workspace. If it can't, return a
+  // `locked` layout and App renders the WorkspaceKeyGate. Safe because the
+  // rollout seed has already pinned pre-existing plaintext workspaces, so only
+  // genuinely locked/never-pinned workspaces land here.
+  const pin = getModePin(repo.user.id, workspaceId)
+  const gateWorkspace = await getLocalWorkspace(repo, workspaceId)
+  // Only gate when we actually know something: a durable pin (authoritative even
+  // without the row) or a synced local row (real server flag). If both are
+  // absent the workspace simply hasn't replicated yet — proceed and let blocks
+  // poll in, matching pre-e2ee behavior. This avoids mis-quarantining (and
+  // worse, offering plaintext-confirm for) an e2ee workspace whose row hasn't
+  // arrived, which would default its encryption_mode to 'none'.
+  if (pin !== null || gateWorkspace !== null) {
+    const hasKey = (await getWorkspaceKeyStore().get(repo.user.id, workspaceId)) !== null
+    const access = resolveWorkspaceAccess(pin, gateWorkspace?.encryptionMode ?? 'none', hasKey)
+    if (access.kind === 'locked') {
+      repo.setReadOnly(true)
+      return {
+        kind: 'locked',
+        workspaceId,
+        workspaceName: gateWorkspace?.name ?? null,
+        reason: access.reason,
+        canary: gateWorkspace?.wkCanary ?? null,
+      }
+    }
+  }
+
   // Freshly inserted personal workspace: install the starter tutorial
   // as its own parent-less page. The [[Tutorial]] bullet on today's
   // daily note (added below) makes it discoverable from the landing
@@ -285,7 +335,7 @@ const resolveInitialLayout = async (
     }
   }
 
-  return {workspaceId, layoutSessionBlock}
+  return {kind: 'ready', workspaceId, layoutSessionBlock}
 }
 
 const initialLayoutCacheKey = (
@@ -340,11 +390,15 @@ const App = () => {
   const localOnly = useIsLocalOnly()
   const useRemoteSync = hasRemoteSyncConfig && !localOnly
 
-  const {workspaceId: activeWorkspaceId, layoutSessionBlock} = use(
+  const initial = use(
     getInitialLayout(repo, hashSnapshot.hash, useRemoteSync, hashSnapshot.version),
   )
+  const activeWorkspaceId = initial.workspaceId
+  // null while the workspace is locked (gate shown) — there's no layout yet.
+  const layoutSessionBlock = initial.kind === 'ready' ? initial.layoutSessionBlock : null
 
   useEffect(() => {
+    if (!layoutSessionBlock) return
     const projection = new PanelLayoutProjection({
       repo,
       workspaceId: activeWorkspaceId,
@@ -389,10 +443,28 @@ const App = () => {
     repo.setReadOnly(activeRole === 'viewer')
   }, [activeRole, repo])
 
+  if (initial.kind === 'locked') {
+    return (
+      <WorkspaceKeyGate
+        userId={repo.user.id}
+        workspaceId={initial.workspaceId}
+        workspaceName={initial.workspaceName ?? undefined}
+        reason={initial.reason}
+        canary={initial.canary}
+        onResolved={() => {
+          // Now materializable — re-drain its staged rows and re-resolve the
+          // layout (bumping the version busts the initial-layout cache).
+          void repo.drainSyncWorkspace(initial.workspaceId)
+          setHashSnapshot(current => ({hash: current.hash, version: current.version + 1}))
+        }}
+      />
+    )
+  }
+
   return (
     <BlockContextProvider initialValue={{layoutBoundary: true, safeMode}}>
       <AppRuntimeProvider safeMode={safeMode}>
-        <BlockComponent blockId={layoutSessionBlock.id}/>
+        <BlockComponent blockId={initial.layoutSessionBlock.id}/>
       </AppRuntimeProvider>
     </BlockContextProvider>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -251,7 +251,19 @@ const resolveInitialLayout = async (
   // rollout seed has already pinned pre-existing plaintext workspaces, so only
   // genuinely locked/never-pinned workspaces land here.
   const pin = getModePin(repo.user.id, workspaceId)
-  const hasKey = (await getWorkspaceKeyStore().get(repo.user.id, workspaceId)) !== null
+  // Only an e2ee pin actually uses the workspace key. Reading the key store for
+  // plaintext/unpinned workspaces is unnecessary and — if IndexedDB is
+  // unavailable (private mode, disabled/corrupt storage) — would block an
+  // otherwise-plaintext user from loading the app. A read failure is treated as
+  // "no key" (→ locked, key-required) rather than aborting the bootstrap.
+  let hasKey = false
+  if (pin === 'e2ee') {
+    try {
+      hasKey = (await getWorkspaceKeyStore().get(repo.user.id, workspaceId)) !== null
+    } catch (err) {
+      console.warn(`[App] workspace key read failed for ${workspaceId}; treating as locked`, err)
+    }
+  }
   const gateWorkspace = await getLocalWorkspace(repo, workspaceId)
   const entry = decideWorkspaceEntry(pin, hasKey, gateWorkspace)
   if (entry.kind === 'waiting') {

--- a/src/components/workspace/CreateWorkspaceDialog.tsx
+++ b/src/components/workspace/CreateWorkspaceDialog.tsx
@@ -11,6 +11,9 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { createWorkspace, primeLocalWorkspaceAndMember } from '@/data/workspaces'
+import { createEncryptedWorkspace } from '@/sync/keys/flows/createEncryptedWorkspace'
+import { getWorkspaceKeyStore } from '@/sync/keys/keyStore'
+import { setModePin } from '@/sync/keys/modePin'
 import { useRepo } from '@/context/repo'
 import type { Workspace } from '@/types'
 
@@ -20,16 +23,28 @@ interface Props {
   onCreated: (workspace: Workspace) => void
 }
 
+// How many trailing WK characters the user must retype to confirm they saved
+// it (design §8.1). The WK has no recovery, so this is a deliberate friction
+// step before the only-shown-once key is dismissed.
+const CONFIRM_SUFFIX_LEN = 6
+
 export function CreateWorkspaceDialog({open, onOpenChange, onCreated}: Props) {
   const repo = useRepo()
   const [name, setName] = useState('')
+  const [encrypted, setEncrypted] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Set once an e2ee workspace is created: the dialog switches to the
+  // reveal-the-key phase and won't dismiss until the user confirms they saved
+  // it. Holds the created workspace so `onCreated` can navigate on confirm.
+  const [reveal, setReveal] = useState<{workspace: Workspace; workspaceKey: string} | null>(null)
 
   const reset = () => {
     setName('')
+    setEncrypted(false)
     setError(null)
     setSubmitting(false)
+    setReveal(null)
   }
 
   const handleSubmit = async (event: FormEvent) => {
@@ -40,18 +55,30 @@ export function CreateWorkspaceDialog({open, onOpenChange, onCreated}: Props) {
     setSubmitting(true)
 
     try {
-      const result = await createWorkspace(trimmed)
-      // Optimistically write to local SQLite so the new workspace shows up
-      // in the switcher before PowerSync replicates it. We use the
-      // canonical member row returned by the RPC (real id) so we don't
-      // collide with the row PowerSync will later sync down.
-      await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
+      if (encrypted) {
+        // Mints the WK + canary, creates the server row, stores the key, and
+        // pins this workspace e2ee. No key bytes reach the server.
+        const result = await createEncryptedWorkspace(trimmed, {
+          userId: repo.user.id,
+          keyStore: getWorkspaceKeyStore(),
+          createWorkspace,
+        })
+        await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
+        // Don't navigate yet — show the key once and require confirmation.
+        setReveal({workspace: result.workspace, workspaceKey: result.workspaceKey})
+        setSubmitting(false)
+        return
+      }
 
-      // No daily-note seed here: navigateToWorkspace updates the hash,
-      // App.tsx re-runs getInitialLayout for the new workspace, and
-      // getOrCreateDailyNote creates today's note client-side. Doing
-      // it again here would just race with that path.
-      /* repo.flush dropped — no write queue in new layer */
+      const result = await createWorkspace(trimmed)
+      // Plaintext create confirms plaintext (§8.1): pin so first-encounter
+      // handling never later quarantines a workspace we created ourselves.
+      setModePin(repo.user.id, result.workspace.id, 'plaintext')
+      // Optimistically write to local SQLite so the new workspace shows up
+      // in the switcher before PowerSync replicates it. We use the canonical
+      // member row returned by the RPC (real id) so we don't collide with the
+      // row PowerSync will later sync down.
+      await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
       onCreated(result.workspace)
       reset()
       onOpenChange(false)
@@ -61,35 +88,145 @@ export function CreateWorkspaceDialog({open, onOpenChange, onCreated}: Props) {
     }
   }
 
+  const finishReveal = () => {
+    if (!reveal) return
+    onCreated(reveal.workspace)
+    reset()
+    onOpenChange(false)
+  }
+
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next) reset(); onOpenChange(next) }}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Block dismissal while the key is being revealed — the user must
+        // confirm they saved it (there's no recovery).
+        if (!next && reveal) return
+        if (!next) reset()
+        onOpenChange(next)
+      }}
+    >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>New workspace</DialogTitle>
-          <DialogDescription>
-            Workspaces are independent block trees. You start as the owner; invite others via Settings.
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="workspace-name">Name</Label>
-            <Input
-              id="workspace-name"
-              autoFocus
-              placeholder="My workspace"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={submitting}
-            />
-          </div>
-          {error && <p className="text-sm text-destructive">{error}</p>}
-          <DialogFooter>
-            <Button type="submit" disabled={submitting || !name.trim()}>
-              {submitting ? 'Creating…' : 'Create workspace'}
-            </Button>
-          </DialogFooter>
-        </form>
+        {reveal ? (
+          <RevealWorkspaceKey workspaceKey={reveal.workspaceKey} onConfirm={finishReveal}/>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>New workspace</DialogTitle>
+              <DialogDescription>
+                Workspaces are independent block trees. You start as the owner; invite others via Settings.
+              </DialogDescription>
+            </DialogHeader>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="workspace-name">Name</Label>
+                <Input
+                  id="workspace-name"
+                  autoFocus
+                  placeholder="My workspace"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+              <label className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 size-4"
+                  checked={encrypted}
+                  onChange={(e) => setEncrypted(e.target.checked)}
+                  disabled={submitting}
+                />
+                <span>
+                  <span className="font-medium">End-to-end encrypted</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Content is encrypted with a key only you hold. You'll get a key to save —
+                    there's no recovery if you lose it. Share it out-of-band to collaborate.
+                  </span>
+                </span>
+              </label>
+              {error && <p className="text-sm text-destructive">{error}</p>}
+              <DialogFooter>
+                <Button type="submit" disabled={submitting || !name.trim()}>
+                  {submitting
+                    ? 'Creating…'
+                    : encrypted
+                      ? 'Create encrypted workspace'
+                      : 'Create workspace'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </>
+        )}
       </DialogContent>
     </Dialog>
+  )
+}
+
+function RevealWorkspaceKey({
+  workspaceKey,
+  onConfirm,
+}: {
+  workspaceKey: string
+  onConfirm: () => void
+}) {
+  const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle')
+  const [confirmInput, setConfirmInput] = useState('')
+
+  const suffix = workspaceKey.slice(-CONFIRM_SUFFIX_LEN)
+  // Case/whitespace tolerant, mirroring parseWorkspaceKey's leniency.
+  const confirmed = confirmInput.trim().toUpperCase() === suffix.toUpperCase()
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(workspaceKey)
+      setCopyState('copied')
+      window.setTimeout(() => setCopyState('idle'), 1500)
+    } catch (err) {
+      console.error('Clipboard write failed', err)
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Save your workspace key</DialogTitle>
+        <DialogDescription>
+          This is the only time this key is shown. Save it securely — a password manager is
+          recommended. There is <span className="font-medium text-foreground">no recovery</span> if
+          you lose it: the data becomes permanently unreadable.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="min-w-0 space-y-2 rounded-md border bg-muted/40 p-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <code className="min-w-0 flex-1 break-all font-mono text-xs">{workspaceKey}</code>
+          <Button type="button" variant="secondary" size="sm" className="shrink-0" onClick={copy}>
+            {copyState === 'copied' ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="wk-confirm">
+          Confirm you saved it — retype the last {CONFIRM_SUFFIX_LEN} characters
+        </Label>
+        <Input
+          id="wk-confirm"
+          autoComplete="off"
+          autoFocus
+          placeholder={suffix.replace(/./g, '•')}
+          value={confirmInput}
+          onChange={(e) => setConfirmInput(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && confirmed) onConfirm() }}
+        />
+      </div>
+
+      <DialogFooter>
+        <Button type="button" disabled={!confirmed} onClick={onConfirm}>
+          I've saved it
+        </Button>
+      </DialogFooter>
+    </>
   )
 }

--- a/src/components/workspace/CreateWorkspaceDialog.tsx
+++ b/src/components/workspace/CreateWorkspaceDialog.tsx
@@ -63,17 +63,30 @@ export function CreateWorkspaceDialog({open, onOpenChange, onCreated}: Props) {
           keyStore: getWorkspaceKeyStore(),
           createWorkspace,
         })
-        await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
-        // Don't navigate yet — show the key once and require confirmation.
+        // Reveal the one-time WK IMMEDIATELY — the server workspace now exists
+        // and this key is its only recovery. Priming local state is just an
+        // optimization (the workspace syncs down regardless), so it must NOT be
+        // able to abort the reveal — best-effort, after the reveal is set.
         setReveal({workspace: result.workspace, workspaceKey: result.workspaceKey})
         setSubmitting(false)
+        try {
+          await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
+        } catch (err) {
+          console.warn('Failed to prime new encrypted workspace locally (will sync down)', err)
+        }
         return
       }
 
       const result = await createWorkspace(trimmed)
       // Plaintext create confirms plaintext (§8.1): pin so first-encounter
       // handling never later quarantines a workspace we created ourselves.
-      setModePin(repo.user.id, result.workspace.id, 'plaintext')
+      // Best-effort — a blocked localStorage write shouldn't fail the create
+      // (worst case the workspace quarantines once on next load).
+      try {
+        setModePin(repo.user.id, result.workspace.id, 'plaintext')
+      } catch (err) {
+        console.warn('Failed to pin new workspace plaintext (will quarantine on next load)', err)
+      }
       // Optimistically write to local SQLite so the new workspace shows up
       // in the switcher before PowerSync replicates it. We use the canonical
       // member row returned by the RPC (real id) so we don't collide with the

--- a/src/components/workspace/WorkspaceKeyGate.tsx
+++ b/src/components/workspace/WorkspaceKeyGate.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore'
-import { setModePin } from '@/sync/keys/modePin'
+import { confirmPlaintextForSession, setModePin } from '@/sync/keys/modePin'
 import { unlockWorkspaceWithKey } from '@/sync/keys/flows/unlockWorkspaceWithKey'
 
 interface Props {
@@ -80,10 +80,12 @@ export function WorkspaceKeyGate({
     try {
       setModePin(userId, workspaceId, 'plaintext')
     } catch (err) {
-      // Unreachable today (quarantine only renders when unpinned), but a future
-      // regression must not surface as an unhandled throw.
-      setError(err instanceof Error ? err.message : 'Could not confirm plaintext')
-      return
+      // localStorage can't persist the pin (writes blocked / quota) while the
+      // rest of the app still works. Fall back to a session-only confirmation so
+      // a plaintext user isn't trapped on the gate; it re-quarantines on next
+      // load (where storage may have recovered).
+      console.warn('[gate] plaintext pin persist failed; confirming for this session only', err)
+      confirmPlaintextForSession(userId, workspaceId)
     }
     try {
       await onResolved()

--- a/src/components/workspace/WorkspaceKeyGate.tsx
+++ b/src/components/workspace/WorkspaceKeyGate.tsx
@@ -65,7 +65,14 @@ export function WorkspaceKeyGate({
   }
 
   const confirmPlaintext = () => {
-    setModePin(userId, workspaceId, 'plaintext')
+    try {
+      setModePin(userId, workspaceId, 'plaintext')
+    } catch (err) {
+      // Unreachable today (quarantine only renders when unpinned), but a future
+      // regression must not surface as an unhandled throw.
+      setError(err instanceof Error ? err.message : 'Could not confirm plaintext')
+      return
+    }
     onResolved()
   }
 

--- a/src/components/workspace/WorkspaceKeyGate.tsx
+++ b/src/components/workspace/WorkspaceKeyGate.tsx
@@ -45,23 +45,31 @@ export function WorkspaceKeyGate({
     if (!trimmed || busy) return
     setBusy(true)
     setError(null)
-    const result = await unlockWorkspaceWithKey({
-      userId,
-      workspaceId,
-      canary: canary ?? '',
-      pastedKey: trimmed,
-      keyStore: getWorkspaceKeyStore(),
-    })
-    if (result.ok) {
-      onResolved()
-      return
+    try {
+      const result = await unlockWorkspaceWithKey({
+        userId,
+        workspaceId,
+        canary: canary ?? '',
+        pastedKey: trimmed,
+        keyStore: getWorkspaceKeyStore(),
+      })
+      if (result.ok) {
+        onResolved()
+        return
+      }
+      setBusy(false)
+      setError(
+        result.reason === 'format'
+          ? "That doesn't look like a workspace key (expected kmp-wk-1:…)."
+          : result.reason === 'storage'
+            ? "Your key is correct, but it couldn't be saved on this device (storage may be full or blocked). Try again."
+            : "That key doesn't decrypt this workspace's data.",
+      )
+    } catch (err) {
+      // Defensive: never leave the button stuck on "Unlocking…" with no message.
+      setBusy(false)
+      setError(err instanceof Error ? err.message : 'Could not unlock this workspace.')
     }
-    setBusy(false)
-    setError(
-      result.reason === 'format'
-        ? "That doesn't look like a workspace key (expected kmp-wk-1:…)."
-        : "That key doesn't decrypt this workspace's data.",
-    )
   }
 
   const confirmPlaintext = () => {

--- a/src/components/workspace/WorkspaceKeyGate.tsx
+++ b/src/components/workspace/WorkspaceKeyGate.tsx
@@ -17,8 +17,9 @@ interface Props {
    *  genuinely-plaintext workspace (then only confirm-plaintext can resolve it). */
   canary: string | null
   /** Called after the gate is resolved (WK accepted, or plaintext confirmed) so
-   *  the host can re-resolve the workspace and run its bootstrap. */
-  onResolved: () => void
+   *  the host can re-materialize + re-resolve the workspace. May be async (the
+   *  host awaits a drain); the gate awaits it so a failure resets the button. */
+  onResolved: () => void | Promise<void>
 }
 
 /**
@@ -54,7 +55,10 @@ export function WorkspaceKeyGate({
         keyStore: getWorkspaceKeyStore(),
       })
       if (result.ok) {
-        onResolved()
+        // Await — the host's onResolved drains/materializes, which can fail
+        // (local DB / decryption). If it rejects, the catch below resets `busy`
+        // and surfaces the error instead of leaving the button stuck.
+        await onResolved()
         return
       }
       setBusy(false)
@@ -72,7 +76,7 @@ export function WorkspaceKeyGate({
     }
   }
 
-  const confirmPlaintext = () => {
+  const confirmPlaintext = async () => {
     try {
       setModePin(userId, workspaceId, 'plaintext')
     } catch (err) {
@@ -81,7 +85,11 @@ export function WorkspaceKeyGate({
       setError(err instanceof Error ? err.message : 'Could not confirm plaintext')
       return
     }
-    onResolved()
+    try {
+      await onResolved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load this workspace.')
+    }
   }
 
   const name = workspaceName ? `"${workspaceName}"` : 'This workspace'
@@ -133,7 +141,7 @@ export function WorkspaceKeyGate({
               No key because it's not encrypted? Confirm to load it as a plain workspace. This
               choice is permanent for this workspace on every device.
             </p>
-            <Button type="button" variant="secondary" className="w-full" onClick={confirmPlaintext}>
+            <Button type="button" variant="secondary" className="w-full" onClick={() => void confirmPlaintext()}>
               This workspace is not encrypted
             </Button>
           </div>

--- a/src/components/workspace/WorkspaceKeyGate.tsx
+++ b/src/components/workspace/WorkspaceKeyGate.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { getWorkspaceKeyStore } from '@/sync/keys/keyStore'
+import { setModePin } from '@/sync/keys/modePin'
+import { unlockWorkspaceWithKey } from '@/sync/keys/flows/unlockWorkspaceWithKey'
+
+interface Props {
+  userId: string
+  workspaceId: string
+  workspaceName?: string
+  /** key-required: server says e2ee or an e2ee pin whose WK was wiped (branch a
+   *  / locked). quarantine: unpinned + server says none — uncertain (branch b). */
+  reason: 'key-required' | 'quarantine'
+  /** workspaces.wk_canary — needed to validate a pasted WK. May be null on a
+   *  genuinely-plaintext workspace (then only confirm-plaintext can resolve it). */
+  canary: string | null
+  /** Called after the gate is resolved (WK accepted, or plaintext confirmed) so
+   *  the host can re-resolve the workspace and run its bootstrap. */
+  onResolved: () => void
+}
+
+/**
+ * §6 rule 3 / §8.2 — the read-only gate shown in place of a workspace whose
+ * content can't be rendered yet: an E2EE workspace missing its key, or an
+ * unverified (never-pinned, server-says-none) workspace. The user resolves it
+ * by pasting the out-of-band workspace key, or — only in the quarantine case —
+ * by confirming the workspace really is plaintext.
+ */
+export function WorkspaceKeyGate({
+  userId,
+  workspaceId,
+  workspaceName,
+  reason,
+  canary,
+  onResolved,
+}: Props) {
+  const [pasted, setPasted] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const submitKey = async () => {
+    const trimmed = pasted.trim()
+    if (!trimmed || busy) return
+    setBusy(true)
+    setError(null)
+    const result = await unlockWorkspaceWithKey({
+      userId,
+      workspaceId,
+      canary: canary ?? '',
+      pastedKey: trimmed,
+      keyStore: getWorkspaceKeyStore(),
+    })
+    if (result.ok) {
+      onResolved()
+      return
+    }
+    setBusy(false)
+    setError(
+      result.reason === 'format'
+        ? "That doesn't look like a workspace key (expected kmp-wk-1:…)."
+        : "That key doesn't decrypt this workspace's data.",
+    )
+  }
+
+  const confirmPlaintext = () => {
+    setModePin(userId, workspaceId, 'plaintext')
+    onResolved()
+  }
+
+  const name = workspaceName ? `"${workspaceName}"` : 'This workspace'
+
+  return (
+    <div className="flex min-h-svh items-center justify-center p-6">
+      <div className="w-full max-w-md space-y-5 rounded-lg border bg-background p-6 shadow-sm">
+        <div className="space-y-1.5">
+          <h1 className="text-lg font-semibold">
+            {reason === 'key-required' ? `${name} needs its key` : `${name} isn't verified`}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {reason === 'key-required' ? (
+              <>
+                Its content is end-to-end encrypted. Paste the workspace key you saved (or were
+                sent) to unlock it on this device. It stays on this device only.
+              </>
+            ) : (
+              <>
+                We can't confirm whether this workspace is encrypted. If you have a workspace key
+                for it, paste it to unlock. Otherwise, if you know it's a plain (unencrypted)
+                workspace, you can confirm that below.
+              </>
+            )}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="wk-paste">Workspace key</Label>
+          <Input
+            id="wk-paste"
+            autoFocus
+            autoComplete="off"
+            placeholder="kmp-wk-1:…"
+            value={pasted}
+            disabled={busy}
+            onChange={(e) => setPasted(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') void submitKey() }}
+          />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <Button type="button" className="w-full" disabled={busy || !pasted.trim()} onClick={() => void submitKey()}>
+            {busy ? 'Unlocking…' : 'Unlock'}
+          </Button>
+        </div>
+
+        {reason === 'quarantine' && (
+          <div className="border-t pt-4">
+            <p className="mb-2 text-xs text-muted-foreground">
+              No key because it's not encrypted? Confirm to load it as a plain workspace. This
+              choice is permanent for this workspace on every device.
+            </p>
+            <Button type="button" variant="secondary" className="w-full" onClick={confirmPlaintext}>
+              This workspace is not encrypted
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/context/repo.tsx
+++ b/src/context/repo.tsx
@@ -7,7 +7,6 @@ import { useIsLocalOnly, useUser } from '@/components/Login'
 import { ensurePowerSyncReady, getPowerSyncDb } from '@/data/repoProvider'
 import { createSyncResolver } from '@/sync/keys/resolver.js'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
-import { seedModePinsFromWorkspaces } from '@/sync/keys/rolloutSeed.js'
 import { User } from '@/types.js'
 import { memoize } from 'lodash'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
@@ -20,13 +19,11 @@ import { surfaceProcessorRejectionFor } from '@/utils/processorRejectionToast.js
 // correctly keeps the contract honest.
 const initRepo = memoize(
   async (user: User, useRemoteSync: boolean): Promise<Repo> => {
+    // ensurePowerSyncReady runs the §6 rollout pin-seed between db.init() and
+    // db.connect(), so pins are settled (from pre-connect on-disk rows only)
+    // before the observer/gate read them below.
     await ensurePowerSyncReady(user.id, useRemoteSync)
     const db = getPowerSyncDb(user.id)
-    // §6 rollout pin-seed: pin pre-existing memberships from the server flag
-    // ONCE, before the observer/gate read pins, so established devices keep
-    // materializing plaintext workspaces (which would otherwise read as
-    // unpinned → deferred/quarantined).
-    await seedModePinsFromWorkspaces(db, user.id)
     // §6 mode/key resolver — shared store + pins drive both the observer
     // (decrypt/copy/defer) and (via the connector) encrypt-on-upload.
     const resolver = createSyncResolver(() => user.id, getWorkspaceKeyStore())

--- a/src/context/repo.tsx
+++ b/src/context/repo.tsx
@@ -5,6 +5,9 @@ import { Repo } from '../data/repo'
 import { BlockCache } from '@/data/blockCache'
 import { useIsLocalOnly, useUser } from '@/components/Login'
 import { ensurePowerSyncReady, getPowerSyncDb } from '@/data/repoProvider'
+import { createSyncResolver } from '@/sync/keys/resolver.js'
+import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
+import { seedModePinsFromWorkspaces } from '@/sync/keys/rolloutSeed.js'
 import { User } from '@/types.js'
 import { memoize } from 'lodash'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
@@ -19,8 +22,24 @@ const initRepo = memoize(
   async (user: User, useRemoteSync: boolean): Promise<Repo> => {
     await ensurePowerSyncReady(user.id, useRemoteSync)
     const db = getPowerSyncDb(user.id)
+    // §6 rollout pin-seed: pin pre-existing memberships from the server flag
+    // ONCE, before the observer/gate read pins, so established devices keep
+    // materializing plaintext workspaces (which would otherwise read as
+    // unpinned → deferred/quarantined).
+    await seedModePinsFromWorkspaces(db, user.id)
+    // §6 mode/key resolver — shared store + pins drive both the observer
+    // (decrypt/copy/defer) and (via the connector) encrypt-on-upload.
+    const resolver = createSyncResolver(() => user.id, getWorkspaceKeyStore())
     const cache = new BlockCache()
-    const repo = new Repo({db, cache, user: {id: user.id, name: user.name}})
+    const repo = new Repo({
+      db,
+      cache,
+      user: {id: user.id, name: user.name},
+      syncObserverDeps: {
+        getMaterializability: resolver.getMaterializability,
+        getCek: resolver.getCek,
+      },
+    })
     repo.setFacetRuntime(resolveFacetRuntimeSync(staticDataExtensions, {
       repo,
       workspaceId: null,

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -88,7 +88,7 @@ import {
   type BlocksSyncedObserver,
   type BlocksSyncedObserverArgs,
 } from '@/sync/observer/observer'
-import type { Materializability } from '@/sync/observer/materialize'
+import type { Materializability, MaterializeDeps } from '@/sync/observer/materialize'
 import {
   CLEAR_REPROJECT_REF_MARKER_SQL,
   RECORD_REPROJECT_REF_MARKER_SQL,
@@ -351,6 +351,12 @@ export interface RepoOptions {
   startSyncObserver?: boolean
   /** Options forwarded to the sync observer when started. */
   syncObserverOptions?: SyncObserverOptions
+  /** Layout B materialization deps — the §6 mode/key resolver (getCek +
+   *  getMaterializability). Production (initRepo) passes the real resolver so
+   *  e2ee rows decrypt, plaintext copies through, and locked/unpinned
+   *  workspaces defer. Omitted in tests, which fall back to the plaintext
+   *  copy-through stub below (no key). */
+  syncObserverDeps?: MaterializeDeps
 }
 
 /** Repo-level knobs for the Layout B sync observer. `db` / `cache` /
@@ -618,6 +624,8 @@ export class Repo {
    *  created on first start, replaced on subsequent starts. Tests can
    *  `dispose()` and re-`start` for deterministic flushing. */
   private syncObserver: BlocksSyncedObserver | null = null
+  /** §6 mode/key resolver for the observer (undefined ⇒ plaintext stub). */
+  private readonly syncObserverDeps?: MaterializeDeps
   /** Backing field for `activeWorkspaceId` (see getter/setter below). */
   private _activeWorkspaceId: string | null = null
   /** Instance discriminator for memoization keys that need to vary
@@ -748,6 +756,7 @@ export class Repo {
     // route through it). The wrapper has the same shape, so existing
     // type contracts hold.
     this.db = wrapDbWithMetrics(opts.db, this.dbMetrics) as PowerSyncDb
+    this.syncObserverDeps = opts.syncObserverDeps
     this.cache = opts.cache
     this.user = opts.user
     this.isReadOnly = opts.isReadOnly ?? false
@@ -838,11 +847,11 @@ export class Repo {
       db: this.db,
       cache: this.cache,
       handleStore: this.handleStore,
-      // No e2ee workspaces exist until e2ee creation ships (gated on the
-      // full deploy), so every downloaded row is plaintext → copy-through
-      // with no key. The §6 mode-pin resolver + IndexedDB key-store bridge
-      // replace these baked-in plaintext defaults when e2ee lands.
-      deps: { getMaterializability: (): Materializability => 'copy', getCek: async () => null },
+      // Production passes the §6 mode/key resolver (initRepo). Tests omit it
+      // and fall back to plaintext copy-through with no key — the historical
+      // behavior, so non-e2ee tests are unaffected.
+      deps: this.syncObserverDeps
+        ?? { getMaterializability: (): Materializability => 'copy', getCek: async () => null },
       getInvalidationRules: () => this.invalidationRules,
       onCycleDetected: options?.onCycleDetected,
       throttleMs: options?.throttleMs,
@@ -866,6 +875,13 @@ export class Repo {
    *  barrier (awaits every drain enqueued before it). */
   async flushSyncObserver(): Promise<void> {
     if (this.syncObserver) await this.syncObserver.flush()
+  }
+
+  /** Re-materialize a workspace's staged `blocks_synced` rows after it becomes
+   *  materializable (WK pasted / plaintext confirmed via the §8.2 gate). No-op
+   *  if the observer isn't running. */
+  async drainSyncWorkspace(workspaceId: string): Promise<void> {
+    if (this.syncObserver) await this.syncObserver.drainWorkspace(workspaceId)
   }
 
   /** Frozen snapshot of internal data-layer counters + timings

--- a/src/data/repoProvider.ts
+++ b/src/data/repoProvider.ts
@@ -31,6 +31,8 @@
 
 import { PowerSyncDatabase, Schema, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web'
 import { createPowerSyncConnector, hasRemoteSyncConfig } from '@/services/powersync.js'
+import { createSyncResolver } from '@/sync/keys/resolver.js'
+import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
 import {
   BLOCKS_SYNCED_RAW_TABLE,
   CREATE_BLOCKS_PARENT_ORDER_INDEX_SQL,
@@ -189,7 +191,14 @@ export const ensurePowerSyncReady = async (
           await previousDb.disconnect()
         }
       }
-      await db.connect(createPowerSyncConnector())
+      // Encrypt-on-upload (§9.2): bind the connector's mode/key lookups to this
+      // user's mode pins + shared workspace-key store. Plaintext workspaces
+      // resolve mode 'none' (no-op); e2ee workspaces seal content columns.
+      const resolver = createSyncResolver(() => userId, getWorkspaceKeyStore())
+      await db.connect(createPowerSyncConnector({
+        getWorkspaceMode: resolver.getMode,
+        getCek: resolver.getCek,
+      }))
     })
     .catch((error) => {
       console.error(`PowerSync background connect failed for ${userId}:`, error)

--- a/src/data/repoProvider.ts
+++ b/src/data/repoProvider.ts
@@ -33,6 +33,7 @@ import { PowerSyncDatabase, Schema, WASQLiteOpenFactory, WASQLiteVFS } from '@po
 import { createPowerSyncConnector, hasRemoteSyncConfig } from '@/services/powersync.js'
 import { createSyncResolver } from '@/sync/keys/resolver.js'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
+import { seedModePinsFromWorkspaces } from '@/sync/keys/rolloutSeed.js'
 import {
   BLOCKS_SYNCED_RAW_TABLE,
   CREATE_BLOCKS_PARENT_ORDER_INDEX_SQL,
@@ -168,6 +169,16 @@ export const ensurePowerSyncReady = async (
     initPromises.set(userId, initPromise)
   }
   await initPromise
+
+  // §6 rollout pin-seed — run BEFORE db.connect() (below) so it only ever sees
+  // rows persisted on disk by a prior, pre-this-release session. Those predate
+  // e2ee existing at all, so trusting their server `encryption_mode` is safe by
+  // construction — none can be a downgraded e2ee workspace. A fresh device /
+  // profile has no on-disk workspaces here, so it seeds nothing and sends every
+  // later-synced workspace through the first-encounter gate instead of trusting
+  // a possibly-stale/downgraded server flag delivered after connect. Runs once
+  // (arePinsSeeded), for both remote and local-only sessions.
+  await seedModePinsFromWorkspaces(db, userId)
 
   if (!useRemoteSync) {
     return

--- a/src/data/workspaces.ts
+++ b/src/data/workspaces.ts
@@ -216,9 +216,26 @@ export const ensurePersonalWorkspace = async (): Promise<EnsuredPersonalWorkspac
   }
 }
 
-export const createWorkspace = async (name: string): Promise<CreatedWorkspace> => {
+/** E2EE create params (§8.1). Omitted ⇒ a plaintext workspace, identical to
+ *  the original single-arg call (the server defaults `p_encryption_mode` to
+ *  'none' and generates the id). For e2ee, the client picks the id and mints
+ *  the canary so the canary's AAD lines up with the server's stored row. */
+export interface CreateWorkspaceOptions {
+  readonly encryptionMode?: 'none' | 'e2ee'
+  readonly workspaceId?: string
+  readonly wkCanary?: string
+}
+
+export const createWorkspace = async (
+  name: string,
+  options: CreateWorkspaceOptions = {},
+): Promise<CreatedWorkspace> => {
   const client = assertSupabase()
-  const {data, error} = await client.rpc('create_workspace', {p_name: name})
+  const params: Record<string, unknown> = {p_name: name}
+  if (options.encryptionMode) params.p_encryption_mode = options.encryptionMode
+  if (options.workspaceId) params.p_workspace_id = options.workspaceId
+  if (options.wkCanary) params.p_wk_canary = options.wkCanary
+  const {data, error} = await client.rpc('create_workspace', params)
   if (error) throw error
   if (!data) throw new Error('create_workspace returned no payload')
   return parseCreatedWorkspace(data as WorkspaceCreationPayload)

--- a/src/services/powersync.test.ts
+++ b/src/services/powersync.test.ts
@@ -440,6 +440,44 @@ describe('uploadTransactionsWithFallback', () => {
     expect(recordRejection).not.toHaveBeenCalled()
   })
 
+  it('un-encryptable tx (missing e2ee key) does not jam the batch: drains the OK prefix, stops at it', async () => {
+    // tx1 is plaintext (encryptable); tx2 is an e2ee workspace whose key is
+    // momentarily unavailable, so encryptOps throws for any batch containing it.
+    // The guard must NOT abort the whole batch preflight: tx1 (the OK prefix)
+    // drains, and we stop at tx2 (throw → PowerSync retries it once the key is
+    // back). tx2 is NOT recorded as a rejection — a missing key is transient, so
+    // discarding the edit would be data loss.
+    const tx1 = fakeTx(1, [
+      new CrudEntry(1, UpdateType.PUT, 'blocks', 'b1', 1, {workspace_id: 'w-ok', content: 'A'}),
+    ])
+    const tx2 = fakeTx(2, [
+      new CrudEntry(2, UpdateType.PUT, 'blocks', 'b2', 2, {workspace_id: 'w-locked', content: 'B'}),
+    ])
+    const {applyOperations, recordRejection} = collectCalls()
+    const encryptOps = vi.fn(async (ops: readonly CompactedBlockOperation[]) => {
+      if (
+        ops.some(
+          o => o.kind !== 'delete' && (o.payload as {workspace_id?: string}).workspace_id === 'w-locked',
+        )
+      ) {
+        throw new Error('sync transform: no workspace key available for w-locked')
+      }
+      return ops as CompactedBlockOperation[]
+    })
+
+    await expect(
+      __uploadTransactionsWithFallbackForTest(
+        fakeDb,
+        [tx1, tx2] as unknown as CrudTransaction[],
+        {applyOperations, recordRejection, encryptOps},
+      ),
+    ).rejects.toThrow(/workspace key/)
+
+    expect(tx1.completed).toBe(true) // plaintext prefix drained
+    expect(tx2.completed).toBe(false) // un-encryptable tx left queued for retry
+    expect(recordRejection).not.toHaveBeenCalled()
+  })
+
   it('per-tx fallback applies within-tx compaction (PUT + same-tx PATCH still fuse)', async () => {
     // Correctness check: when we drop from batched into per-tx, the
     // create+patch fusion that the original handler relies on for

--- a/src/services/powersync.ts
+++ b/src/services/powersync.ts
@@ -471,10 +471,13 @@ const crudEntryEnvelope = (entry: CrudEntry): Record<string, unknown> => {
     : {op: opName, type: entry.table, id: entry.id, data}
 }
 
-const defaultUploadDeps = (): UploadDeps => ({
+const makeUploadDeps = (
+  getWorkspaceMode: GetWorkspaceMode,
+  getCek: GetCek,
+): UploadDeps => ({
   applyOperations: applyCompactedBlockOperations,
   recordRejection: recordRejectionToTable,
-  encryptOps: ops => encryptUploadOps(ops, defaultGetWorkspaceMode, defaultUploadGetCek),
+  encryptOps: ops => encryptUploadOps(ops, getWorkspaceMode, getCek),
 })
 
 /** Optimistic-batch / pessimistic-per-tx upload orchestrator.
@@ -537,8 +540,10 @@ const uploadTransactionsWithFallback = async (
   }
 }
 
-const uploadData = async (database: AbstractPowerSyncDatabase) => {
-  const deps = defaultUploadDeps()
+const runUploadLoop = async (
+  database: AbstractPowerSyncDatabase,
+  deps: UploadDeps,
+): Promise<void> => {
   while (true) {
     const transactions = await collectUploadBatch(database)
     if (transactions.length === 0) return
@@ -546,42 +551,61 @@ const uploadData = async (database: AbstractPowerSyncDatabase) => {
   }
 }
 
-export const createPowerSyncConnector = (): PowerSyncBackendConnector => ({
-  fetchCredentials: async () => {
-    const client = assertSupabase()
+const fetchCredentials = async () => {
+  const client = assertSupabase()
 
-    // getSession() refreshes an expired token before resolving; offline
-    // that fails (and can hang on retries). Fall back to the last
-    // persisted session so we still hand PowerSync a token to retry the
-    // connection with once the network returns — and return null instead
-    // of throwing when there's truly nothing, so an offline boot doesn't
-    // spam the console with refresh failures.
-    let session = readPersistedSession()
-    try {
-      const {data, error} = await client.auth.getSession()
-      if (error) throw error
-      if (data.session) session = data.session
-    } catch (error) {
-      if (!session) {
-        console.debug('[powersync] fetchCredentials: no session available (offline?)', error)
-        return null
-      }
-    }
-
-    if (!session?.access_token || !powerSyncUrl) {
+  // getSession() refreshes an expired token before resolving; offline
+  // that fails (and can hang on retries). Fall back to the last
+  // persisted session so we still hand PowerSync a token to retry the
+  // connection with once the network returns — and return null instead
+  // of throwing when there's truly nothing, so an offline boot doesn't
+  // spam the console with refresh failures.
+  let session = readPersistedSession()
+  try {
+    const {data, error} = await client.auth.getSession()
+    if (error) throw error
+    if (data.session) session = data.session
+  } catch (error) {
+    if (!session) {
+      console.debug('[powersync] fetchCredentials: no session available (offline?)', error)
       return null
     }
+  }
 
-    return {
-      endpoint: powerSyncUrl,
-      token: session.access_token,
-      expiresAt: session.expires_at
-        ? new Date(session.expires_at * 1000)
-        : undefined,
-    }
-  },
-  uploadData,
-})
+  if (!session?.access_token || !powerSyncUrl) {
+    return null
+  }
+
+  return {
+    endpoint: powerSyncUrl,
+    token: session.access_token,
+    expiresAt: session.expires_at
+      ? new Date(session.expires_at * 1000)
+      : undefined,
+  }
+}
+
+/** §9.2 encrypt-on-upload wiring. The mode/key resolvers are injected so the
+ *  app binds them to the signed-in user's mode pins + workspace-key store;
+ *  omitted (e.g. in tests, or before e2ee is wired) they default to plaintext
+ *  pass-through. */
+export interface PowerSyncConnectorOptions {
+  readonly getWorkspaceMode?: GetWorkspaceMode
+  readonly getCek?: GetCek
+}
+
+export const createPowerSyncConnector = (
+  options: PowerSyncConnectorOptions = {},
+): PowerSyncBackendConnector => {
+  const deps = makeUploadDeps(
+    options.getWorkspaceMode ?? defaultGetWorkspaceMode,
+    options.getCek ?? defaultUploadGetCek,
+  )
+  return {
+    fetchCredentials,
+    uploadData: database => runUploadLoop(database, deps),
+  }
+}
 
 export const __encryptUploadOpsForTest = encryptUploadOps
 export const __compactBlockCrudEntriesForTest = compactBlockCrudEntries

--- a/src/services/powersync.ts
+++ b/src/services/powersync.ts
@@ -492,28 +492,50 @@ const makeUploadDeps = (
  *  each tx individually, completing on success, recording-then-completing
  *  on permanent failure, re-throwing on transient. This way one bad tx
  *  no longer jams the bucket — the rest of the queue drains and the
- *  bad one lands in ps_crud_rejected for inspection. */
+ *  bad one lands in ps_crud_rejected for inspection.
+ *
+ *  Encrypt-on-upload (§9.2) is part of that isolation: a tx for an e2ee
+ *  workspace whose key is momentarily missing/unreadable makes `encryptOps`
+ *  throw. The BATCH encryption is guarded so that failure DOESN'T abort the
+ *  whole preflight — it falls through to the per-tx loop, which drains every
+ *  earlier (encryptable) tx and then stops at the un-encryptable one (its
+ *  per-tx `encryptOps` throws out of the loop). `complete()` is a checkpoint
+ *  that drains all PRECEDING txs, so we can't skip the bad tx and complete a
+ *  later one — instead PowerSync retries from it once the key is back. A
+ *  missing key is treated as transient (retry), never a rejection (which would
+ *  discard the edit). */
 const uploadTransactionsWithFallback = async (
   database: AbstractPowerSyncDatabase,
   transactions: readonly CrudTransaction[],
   deps: UploadDeps,
 ): Promise<void> => {
   const encryptOps = deps.encryptOps ?? (async ops => ops)
-  const batchOps = await encryptOps(compactBlockCrudEntries(transactions.flatMap(t => t.crud)))
 
+  // Guard the batch encryption: if a tx in the batch can't be encrypted (e2ee
+  // key unavailable), fall through to the per-tx fallback rather than aborting
+  // the whole batch before any of it can drain.
+  let batchOps: readonly CompactedBlockOperation[] | null = null
   try {
-    await deps.applyOperations(database, batchOps)
-    await transactions[transactions.length - 1]?.complete()
-    return
+    batchOps = await encryptOps(compactBlockCrudEntries(transactions.flatMap(t => t.crud)))
   } catch (err) {
-    if (classifyUploadError(err) === 'transient') {
-      console.error('[powersync] upload failed (transient, will retry)', err)
-      throw err
+    console.warn('[powersync] batch encryption failed — isolating per tx', err)
+  }
+
+  if (batchOps) {
+    try {
+      await deps.applyOperations(database, batchOps)
+      await transactions[transactions.length - 1]?.complete()
+      return
+    } catch (err) {
+      if (classifyUploadError(err) === 'transient') {
+        console.error('[powersync] upload failed (transient, will retry)', err)
+        throw err
+      }
+      console.warn(
+        `[powersync] batch upload rejected permanently — isolating ${transactions.length} tx(s)`,
+        err,
+      )
     }
-    console.warn(
-      `[powersync] batch upload rejected permanently — isolating ${transactions.length} tx(s)`,
-      err,
-    )
   }
 
   // Per-tx fallback. Within-tx compaction still runs so the bootstrap

--- a/src/sync/keys/flows/createEncryptedWorkspace.test.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.test.ts
@@ -87,23 +87,29 @@ describe('createEncryptedWorkspace (§8.1)', () => {
     expect(getModePin(USER, 'ws-nokey')).toBe('e2ee')
   })
 
-  it('still returns the WK when the mode-pin write fails (localStorage blocked)', async () => {
-    // The server row exists, so the one-time WK MUST reach the caller even if
-    // the pin write throws — otherwise it's lost on the stack and the workspace
-    // is orphaned. The key store write (separate) still succeeds here.
+  it('refuses to create (no server row, no local key) when pin storage is unavailable', async () => {
+    // E2EE needs durable pin storage. If localStorage can't persist, the flow
+    // must refuse BEFORE creating the server row — otherwise the user would have
+    // a server-side encrypted workspace this device can never open.
     const keyStore = new InMemoryWorkspaceKeyStore()
+    let rpcCalled = false
     const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('localStorage is blocked')
     })
     try {
-      const result = await createEncryptedWorkspace('Secret', {
-        userId: USER,
-        keyStore,
-        newWorkspaceId: () => 'ws-nopin',
-        createWorkspace: async (_name, options) => ({ workspaceId: options.workspaceId }),
-      })
-      expect(result.workspaceKey.startsWith(WK_PREFIX)).toBe(true)
-      expect(await keyStore.get(USER, 'ws-nopin')).not.toBeNull()
+      await expect(
+        createEncryptedWorkspace('Secret', {
+          userId: USER,
+          keyStore,
+          newWorkspaceId: () => 'ws-nostore',
+          createWorkspace: async (_name, options) => {
+            rpcCalled = true
+            return { workspaceId: options.workspaceId }
+          },
+        }),
+      ).rejects.toThrow(/storage/i)
+      expect(rpcCalled).toBe(false)
+      expect(await keyStore.get(USER, 'ws-nostore')).toBeNull()
     } finally {
       spy.mockRestore()
     }

--- a/src/sync/keys/flows/createEncryptedWorkspace.test.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.test.ts
@@ -65,6 +65,28 @@ describe('createEncryptedWorkspace (§8.1)', () => {
     expect(getModePin(USER, 'ws-fail')).toBeNull()
   })
 
+  it('still pins e2ee and reveals the WK when the key store write fails (locked, not orphaned)', async () => {
+    // A device where IndexedDB put fails (quota / private mode). The workspace
+    // must end up e2ee-pinned-but-locked, with the WK returned so the user can
+    // save it and re-paste — never an orphaned workspace whose mode is unknown.
+    const failingStore = {
+      get: async () => null,
+      put: async () => {
+        throw new Error('QuotaExceededError')
+      },
+      delete: async () => {},
+      clearAll: async () => {},
+    }
+    const result = await createEncryptedWorkspace('Secret', {
+      userId: USER,
+      keyStore: failingStore,
+      newWorkspaceId: () => 'ws-nokey',
+      createWorkspace: async (_name, options) => ({ workspaceId: options.workspaceId }),
+    })
+    expect(result.workspaceKey.startsWith(WK_PREFIX)).toBe(true)
+    expect(getModePin(USER, 'ws-nokey')).toBe('e2ee')
+  })
+
   it('generates a distinct random WK per call by default', async () => {
     const keyStore = new InMemoryWorkspaceKeyStore()
     const make = (id: string) =>

--- a/src/sync/keys/flows/createEncryptedWorkspace.test.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { InMemoryWorkspaceKeyStore } from '../keyStore.js'
 import { getModePin } from '../modePin.js'
 import { importWorkspaceKey, parseWorkspaceKey, WK_PREFIX } from '../../crypto/workspaceKey.js'
@@ -85,6 +85,28 @@ describe('createEncryptedWorkspace (§8.1)', () => {
     })
     expect(result.workspaceKey.startsWith(WK_PREFIX)).toBe(true)
     expect(getModePin(USER, 'ws-nokey')).toBe('e2ee')
+  })
+
+  it('still returns the WK when the mode-pin write fails (localStorage blocked)', async () => {
+    // The server row exists, so the one-time WK MUST reach the caller even if
+    // the pin write throws — otherwise it's lost on the stack and the workspace
+    // is orphaned. The key store write (separate) still succeeds here.
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('localStorage is blocked')
+    })
+    try {
+      const result = await createEncryptedWorkspace('Secret', {
+        userId: USER,
+        keyStore,
+        newWorkspaceId: () => 'ws-nopin',
+        createWorkspace: async (_name, options) => ({ workspaceId: options.workspaceId }),
+      })
+      expect(result.workspaceKey.startsWith(WK_PREFIX)).toBe(true)
+      expect(await keyStore.get(USER, 'ws-nopin')).not.toBeNull()
+    } finally {
+      spy.mockRestore()
+    }
   })
 
   it('generates a distinct random WK per call by default', async () => {

--- a/src/sync/keys/flows/createEncryptedWorkspace.test.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.test.ts
@@ -65,10 +65,12 @@ describe('createEncryptedWorkspace (§8.1)', () => {
     expect(getModePin(USER, 'ws-fail')).toBeNull()
   })
 
-  it('still pins e2ee and reveals the WK when the key store write fails (locked, not orphaned)', async () => {
-    // A device where IndexedDB put fails (quota / private mode). The workspace
-    // must end up e2ee-pinned-but-locked, with the WK returned so the user can
-    // save it and re-paste — never an orphaned workspace whose mode is unknown.
+  it('refuses (no server row, no pin) when the key store write fails — never an unopenable workspace', async () => {
+    // IndexedDB unwritable (quota / corruption / private mode) while localStorage
+    // works. The key-store preflight probe must refuse BEFORE creating the server
+    // row, rather than producing an e2ee workspace with a pin but no key that
+    // this device could never open (the gate would loop on re-paste).
+    let rpcCalled = false
     const failingStore = {
       get: async () => null,
       put: async () => {
@@ -77,14 +79,19 @@ describe('createEncryptedWorkspace (§8.1)', () => {
       delete: async () => {},
       clearAll: async () => {},
     }
-    const result = await createEncryptedWorkspace('Secret', {
-      userId: USER,
-      keyStore: failingStore,
-      newWorkspaceId: () => 'ws-nokey',
-      createWorkspace: async (_name, options) => ({ workspaceId: options.workspaceId }),
-    })
-    expect(result.workspaceKey.startsWith(WK_PREFIX)).toBe(true)
-    expect(getModePin(USER, 'ws-nokey')).toBe('e2ee')
+    await expect(
+      createEncryptedWorkspace('Secret', {
+        userId: USER,
+        keyStore: failingStore,
+        newWorkspaceId: () => 'ws-nokey',
+        createWorkspace: async (_name, options) => {
+          rpcCalled = true
+          return { workspaceId: options.workspaceId }
+        },
+      }),
+    ).rejects.toThrow(/storage/i)
+    expect(rpcCalled).toBe(false)
+    expect(getModePin(USER, 'ws-nokey')).toBeNull()
   })
 
   it('refuses to create (no server row, no local key) when pin storage is unavailable', async () => {

--- a/src/sync/keys/flows/createEncryptedWorkspace.test.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryWorkspaceKeyStore } from '../keyStore.js'
+import { getModePin } from '../modePin.js'
+import { importWorkspaceKey, parseWorkspaceKey, WK_PREFIX } from '../../crypto/workspaceKey.js'
+import { validateCanary } from '../../crypto/canary.js'
+import { createEncryptedWorkspace } from './createEncryptedWorkspace.js'
+
+const USER = 'user-1'
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+describe('createEncryptedWorkspace (§8.1)', () => {
+  it('mints a canary the shown WK can validate, calls the RPC with e2ee params, and stores key + pin', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    let rpcArgs: { name: string; options: { encryptionMode: string; workspaceId: string; wkCanary: string } } | null =
+      null
+
+    const result = await createEncryptedWorkspace('Secret', {
+      userId: USER,
+      keyStore,
+      newWorkspaceId: () => 'ws-fixed',
+      createWorkspace: async (name, options) => {
+        rpcArgs = { name, options }
+        return { workspaceId: options.workspaceId }
+      },
+    })
+
+    // The user is shown a paste-friendly WK string.
+    expect(result.workspaceKey.startsWith(WK_PREFIX)).toBe(true)
+
+    // RPC got the e2ee mode, the client-chosen id, and a canary.
+    expect(rpcArgs).not.toBeNull()
+    expect(rpcArgs!.name).toBe('Secret')
+    expect(rpcArgs!.options.encryptionMode).toBe('e2ee')
+    expect(rpcArgs!.options.workspaceId).toBe('ws-fixed')
+
+    // The invariant that matters: a future device pasting the shown WK can open
+    // the canary the server stored — i.e. §8.2 validation will succeed.
+    const pastedKey = await importWorkspaceKey(parseWorkspaceKey(result.workspaceKey))
+    expect(await validateCanary(pastedKey, rpcArgs!.options.wkCanary, 'ws-fixed')).toBe(true)
+
+    // Key persisted on this device + workspace pinned e2ee.
+    expect(await keyStore.get(USER, 'ws-fixed')).not.toBeNull()
+    expect(getModePin(USER, 'ws-fixed')).toBe('e2ee')
+
+    // The pass-through workspace payload is preserved on the result.
+    expect(result.workspaceId).toBe('ws-fixed')
+  })
+
+  it('leaves no local key or pin when the create RPC fails (server row first)', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    await expect(
+      createEncryptedWorkspace('Secret', {
+        userId: USER,
+        keyStore,
+        newWorkspaceId: () => 'ws-fail',
+        createWorkspace: async () => {
+          throw new Error('rpc boom')
+        },
+      }),
+    ).rejects.toThrow('rpc boom')
+
+    expect(await keyStore.get(USER, 'ws-fail')).toBeNull()
+    expect(getModePin(USER, 'ws-fail')).toBeNull()
+  })
+
+  it('generates a distinct random WK per call by default', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const make = (id: string) =>
+      createEncryptedWorkspace('WS', {
+        userId: USER,
+        keyStore,
+        newWorkspaceId: () => id,
+        createWorkspace: async (_name, options) => ({ workspaceId: options.workspaceId }),
+      })
+    const a = await make('ws-a')
+    const b = await make('ws-b')
+    expect(a.workspaceKey).not.toBe(b.workspaceKey)
+  })
+})

--- a/src/sync/keys/flows/createEncryptedWorkspace.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.ts
@@ -1,0 +1,76 @@
+/**
+ * §8.1 — create an encrypted workspace (the key-minting flow).
+ *
+ * The one flow that brings an E2EE workspace into existence: it generates the
+ * workspace key (WK), mints the canary the server stores, creates the server
+ * row, and — only after the server row exists — persists the WK on this device
+ * and pins the workspace `e2ee` (§6 rule 1). It returns the `kmp-wk-1:` string
+ * to show the user ONCE; no WK bytes are ever sent to the server (only the
+ * canary, which is opaque ciphertext).
+ *
+ * Decoupled from the data layer by construction: the workspace-create RPC is
+ * INJECTED (`deps.createWorkspace`) and the flow only owns crypto + key store +
+ * pin. It passes the RPC's result straight through (spread onto the return), so
+ * it never needs to know the workspace row's shape — the UI gets
+ * `CreatedWorkspace & { workspaceKey }`.
+ */
+
+import { validateCanary, mintCanary } from '../../crypto/canary.js'
+import {
+  formatWorkspaceKey,
+  generateWorkspaceKeyBytes,
+  importWorkspaceKey,
+} from '../../crypto/workspaceKey.js'
+import type { WorkspaceKeyStore } from '../keyStore.js'
+import { setModePin } from '../modePin.js'
+
+export interface CreateEncryptedWorkspaceDeps<T> {
+  /** The signed-in user — keys and pins are per (user, workspace). */
+  readonly userId: string
+  /** Where the imported non-extractable WK is stored on this device (§5). */
+  readonly keyStore: WorkspaceKeyStore
+  /** Injected workspace-create RPC. Must send the e2ee params to the server
+   *  and return whatever the caller wants passed back (e.g. CreatedWorkspace). */
+  readonly createWorkspace: (
+    name: string,
+    options: { encryptionMode: 'e2ee'; workspaceId: string; wkCanary: string },
+  ) => Promise<T>
+  /** Injectable for deterministic tests; defaults to a v4 UUID. */
+  readonly newWorkspaceId?: () => string
+  /** Injectable for deterministic tests; defaults to the CSPRNG. */
+  readonly generateKeyBytes?: () => Uint8Array<ArrayBuffer>
+}
+
+export const createEncryptedWorkspace = async <T extends object>(
+  name: string,
+  deps: CreateEncryptedWorkspaceDeps<T>,
+): Promise<T & { workspaceKey: string }> => {
+  const workspaceId = (deps.newWorkspaceId ?? (() => crypto.randomUUID()))()
+  const keyBytes = (deps.generateKeyBytes ?? generateWorkspaceKeyBytes)()
+  // The paste-friendly string is the ONLY place the raw key ever leaves this
+  // function; show it once, then it lives only as a non-extractable handle.
+  const workspaceKey = formatWorkspaceKey(keyBytes)
+  const cryptoKey = await importWorkspaceKey(keyBytes)
+  keyBytes.fill(0) // drop the raw bytes once imported (the handle is enough)
+
+  const wkCanary = await mintCanary(cryptoKey, workspaceId)
+  // Self-check (§8.1): the canary we're about to store must validate against
+  // the key that minted it. A failure means a crypto/env bug — fail before
+  // creating a server row whose canary no device could ever open.
+  if (!(await validateCanary(cryptoKey, wkCanary, workspaceId))) {
+    throw new Error('createEncryptedWorkspace: freshly minted canary failed self-validation')
+  }
+
+  // Server row first: if the RPC throws, we've written no local key or pin for
+  // a workspace that doesn't exist.
+  const created = await deps.createWorkspace(name, {
+    encryptionMode: 'e2ee',
+    workspaceId,
+    wkCanary,
+  })
+
+  await deps.keyStore.put(deps.userId, workspaceId, cryptoKey)
+  setModePin(deps.userId, workspaceId, 'e2ee')
+
+  return { ...created, workspaceKey }
+}

--- a/src/sync/keys/flows/createEncryptedWorkspace.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.ts
@@ -23,7 +23,7 @@ import {
   parseWorkspaceKey,
 } from '../../crypto/workspaceKey.js'
 import type { WorkspaceKeyStore } from '../keyStore.js'
-import { setModePin } from '../modePin.js'
+import { canPersistPins, setModePin } from '../modePin.js'
 
 export interface CreateEncryptedWorkspaceDeps<T> {
   /** The signed-in user — keys and pins are per (user, workspace). */
@@ -46,6 +46,18 @@ export const createEncryptedWorkspace = async <T extends object>(
   name: string,
   deps: CreateEncryptedWorkspaceDeps<T>,
 ): Promise<T & { workspaceKey: string }> => {
+  // Preflight: e2ee needs durable pin storage (the pin is the wipe-surviving
+  // authority and the §6 gate keys off it). If localStorage can't persist,
+  // refuse BEFORE creating the server row — otherwise we'd mint a server-side
+  // encrypted workspace this device could never open (the pin would be lost and
+  // re-pasting the WK would loop on the same failed write). Plaintext is fine.
+  if (!canPersistPins()) {
+    throw new Error(
+      'Encrypted workspaces need browser storage that is currently unavailable ' +
+        '(private mode or storage disabled). You can still create a regular workspace.',
+    )
+  }
+
   const workspaceId = (deps.newWorkspaceId ?? (() => crypto.randomUUID()))()
   const keyBytes = (deps.generateKeyBytes ?? generateWorkspaceKeyBytes)()
   // The paste-friendly string is the ONLY place the raw key ever leaves this

--- a/src/sync/keys/flows/createEncryptedWorkspace.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.ts
@@ -42,6 +42,10 @@ export interface CreateEncryptedWorkspaceDeps<T> {
   readonly generateKeyBytes?: () => Uint8Array<ArrayBuffer>
 }
 
+// Sentinel workspace id used only to probe key-store writability before
+// creating the server row. Never a real workspace id; written then deleted.
+const KEY_STORE_PROBE_ID = '__e2ee_keystore_probe__'
+
 export const createEncryptedWorkspace = async <T extends object>(
   name: string,
   deps: CreateEncryptedWorkspaceDeps<T>,
@@ -77,8 +81,25 @@ export const createEncryptedWorkspace = async <T extends object>(
     throw new Error('createEncryptedWorkspace: minted canary failed round-trip self-validation')
   }
 
+  // Preflight the KEY store (IndexedDB) too — symmetric with the pin-store
+  // (localStorage) preflight above. Probe a write+delete with the real key at a
+  // sentinel id, so a key-store failure (quota / corruption / private mode)
+  // refuses the create HERE rather than producing a server-side e2ee workspace
+  // this device can't open: a pin would persist but no key, and re-pasting the
+  // WK would loop on the same failed write. Cleaned up immediately; the real key
+  // is persisted after the row exists.
+  try {
+    await deps.keyStore.put(deps.userId, KEY_STORE_PROBE_ID, cryptoKey)
+    await deps.keyStore.delete(deps.userId, KEY_STORE_PROBE_ID)
+  } catch {
+    throw new Error(
+      'Encrypted workspaces need browser storage that is currently unavailable ' +
+        '(private mode or storage limits). You can still create a regular workspace.',
+    )
+  }
+
   // Server row first: if the RPC throws, we've written no local key or pin for
-  // a workspace that doesn't exist.
+  // a workspace that doesn't exist (the probe above cleaned itself up).
   const created = await deps.createWorkspace(name, {
     encryptionMode: 'e2ee',
     workspaceId,

--- a/src/sync/keys/flows/createEncryptedWorkspace.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.ts
@@ -73,13 +73,22 @@ export const createEncryptedWorkspace = async <T extends object>(
     wkCanary,
   })
 
-  // Pin e2ee as soon as the server row exists — the pin is the durable record
-  // that this workspace is encrypted and MUST be set even if the key write
-  // below fails. Then best-effort persist the key. If the put fails (IndexedDB
-  // quota / private mode), the workspace is simply LOCKED on this device — the
-  // user has the WK we return and can paste it to unlock — rather than an
-  // orphaned workspace whose mode no device knows.
-  setModePin(deps.userId, workspaceId, 'e2ee')
+  // Both local writes below are BEST-EFFORT: once the server e2ee row exists,
+  // the returned `workspaceKey` is the ONLY recovery path, so nothing here may
+  // throw and abort before we return it. A failed pin/key write just leaves the
+  // workspace unpinned/locked on THIS device — the user still has the WK we
+  // return (and the §6 first-encounter gate prompts to paste it on next load),
+  // rather than an orphaned workspace whose key was lost on the stack.
+  try {
+    // Pin first — the durable record that this workspace is encrypted.
+    setModePin(deps.userId, workspaceId, 'e2ee')
+  } catch (err) {
+    console.warn(
+      `createEncryptedWorkspace: mode-pin write failed for ${workspaceId}; ` +
+        'the workspace will prompt for the saved WK on next load',
+      err,
+    )
+  }
   try {
     await deps.keyStore.put(deps.userId, workspaceId, cryptoKey)
   } catch (err) {

--- a/src/sync/keys/flows/createEncryptedWorkspace.ts
+++ b/src/sync/keys/flows/createEncryptedWorkspace.ts
@@ -20,6 +20,7 @@ import {
   formatWorkspaceKey,
   generateWorkspaceKeyBytes,
   importWorkspaceKey,
+  parseWorkspaceKey,
 } from '../../crypto/workspaceKey.js'
 import type { WorkspaceKeyStore } from '../keyStore.js'
 import { setModePin } from '../modePin.js'
@@ -54,11 +55,14 @@ export const createEncryptedWorkspace = async <T extends object>(
   keyBytes.fill(0) // drop the raw bytes once imported (the handle is enough)
 
   const wkCanary = await mintCanary(cryptoKey, workspaceId)
-  // Self-check (§8.1): the canary we're about to store must validate against
-  // the key that minted it. A failure means a crypto/env bug — fail before
+  // Self-check (§8.1): prove the EXACT string we show the user re-imports to a
+  // key that opens the canary — i.e. the §8.2 new-device unlock will succeed.
+  // Re-deriving from `workspaceKey` (not reusing `cryptoKey`) is what makes this
+  // a real proof of recoverability, not just "this key opens it". Fail before
   // creating a server row whose canary no device could ever open.
-  if (!(await validateCanary(cryptoKey, wkCanary, workspaceId))) {
-    throw new Error('createEncryptedWorkspace: freshly minted canary failed self-validation')
+  const verifyKey = await importWorkspaceKey(parseWorkspaceKey(workspaceKey))
+  if (!(await validateCanary(verifyKey, wkCanary, workspaceId))) {
+    throw new Error('createEncryptedWorkspace: minted canary failed round-trip self-validation')
   }
 
   // Server row first: if the RPC throws, we've written no local key or pin for
@@ -69,8 +73,22 @@ export const createEncryptedWorkspace = async <T extends object>(
     wkCanary,
   })
 
-  await deps.keyStore.put(deps.userId, workspaceId, cryptoKey)
+  // Pin e2ee as soon as the server row exists — the pin is the durable record
+  // that this workspace is encrypted and MUST be set even if the key write
+  // below fails. Then best-effort persist the key. If the put fails (IndexedDB
+  // quota / private mode), the workspace is simply LOCKED on this device — the
+  // user has the WK we return and can paste it to unlock — rather than an
+  // orphaned workspace whose mode no device knows.
   setModePin(deps.userId, workspaceId, 'e2ee')
+  try {
+    await deps.keyStore.put(deps.userId, workspaceId, cryptoKey)
+  } catch (err) {
+    console.warn(
+      `createEncryptedWorkspace: key store write failed for ${workspaceId}; ` +
+        'workspace is locked until the saved WK is re-pasted',
+      err,
+    )
+  }
 
   return { ...created, workspaceKey }
 }

--- a/src/sync/keys/flows/unlockWorkspaceWithKey.test.ts
+++ b/src/sync/keys/flows/unlockWorkspaceWithKey.test.ts
@@ -77,6 +77,32 @@ describe('unlockWorkspaceWithKey (§8.2)', () => {
     expect(getModePin(USER, WS)).toBeNull()
   })
 
+  it('reports a storage failure (still pins e2ee to defeat a downgrade) when the key write throws', async () => {
+    const { wkString, canary } = await mintKeyAndCanary(WS)
+    // A valid key, but the device can't persist it (IndexedDB quota / private mode).
+    const failingStore = {
+      get: async () => null,
+      put: async () => {
+        throw new Error('QuotaExceededError')
+      },
+      delete: async () => {},
+      clearAll: async () => {},
+    }
+
+    const result = await unlockWorkspaceWithKey({
+      userId: USER,
+      workspaceId: WS,
+      canary,
+      pastedKey: wkString,
+      keyStore: failingStore,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'storage' })
+    // The canary validated, so the workspace IS e2ee — pin it even though the
+    // key couldn't be stored, closing the quarantine plaintext-confirm hatch.
+    expect(getModePin(USER, WS)).toBe('e2ee')
+  })
+
   it('re-unlocks an already-e2ee-pinned workspace idempotently (post-wipe re-paste)', async () => {
     const keyStore = new InMemoryWorkspaceKeyStore()
     const { wkString, canary } = await mintKeyAndCanary(WS)

--- a/src/sync/keys/flows/unlockWorkspaceWithKey.test.ts
+++ b/src/sync/keys/flows/unlockWorkspaceWithKey.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryWorkspaceKeyStore } from '../keyStore.js'
+import { getModePin, setModePin } from '../modePin.js'
+import { mintCanary } from '../../crypto/canary.js'
+import {
+  formatWorkspaceKey,
+  generateWorkspaceKeyBytes,
+  importWorkspaceKey,
+} from '../../crypto/workspaceKey.js'
+import { unlockWorkspaceWithKey } from './unlockWorkspaceWithKey.js'
+
+const USER = 'user-1'
+const WS = 'ws-A'
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+/** Mint a fresh WK + the canary a server would store for `workspaceId`. */
+const mintKeyAndCanary = async (workspaceId: string) => {
+  const bytes = generateWorkspaceKeyBytes()
+  const key = await importWorkspaceKey(bytes)
+  const canary = await mintCanary(key, workspaceId)
+  return { wkString: formatWorkspaceKey(bytes), canary }
+}
+
+describe('unlockWorkspaceWithKey (§8.2)', () => {
+  it('stores the key and pins e2ee when the pasted WK opens the canary', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const { wkString, canary } = await mintKeyAndCanary(WS)
+
+    const result = await unlockWorkspaceWithKey({
+      userId: USER,
+      workspaceId: WS,
+      canary,
+      pastedKey: wkString,
+      keyStore,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(await keyStore.get(USER, WS)).not.toBeNull()
+    expect(getModePin(USER, WS)).toBe('e2ee')
+  })
+
+  it('rejects a well-formed WK that does not open the canary — no key, no pin', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const { canary } = await mintKeyAndCanary(WS)
+    // A different, valid-format WK that never minted this canary.
+    const { wkString: wrongKey } = await mintKeyAndCanary('ws-other')
+
+    const result = await unlockWorkspaceWithKey({
+      userId: USER,
+      workspaceId: WS,
+      canary,
+      pastedKey: wrongKey,
+      keyStore,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'invalid-key' })
+    expect(await keyStore.get(USER, WS)).toBeNull()
+    expect(getModePin(USER, WS)).toBeNull()
+  })
+
+  it('rejects a malformed paste (missing prefix) as a format error', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const { canary } = await mintKeyAndCanary(WS)
+
+    const result = await unlockWorkspaceWithKey({
+      userId: USER,
+      workspaceId: WS,
+      canary,
+      pastedKey: 'not-a-workspace-key',
+      keyStore,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'format' })
+    expect(await keyStore.get(USER, WS)).toBeNull()
+    expect(getModePin(USER, WS)).toBeNull()
+  })
+
+  it('re-unlocks an already-e2ee-pinned workspace idempotently (post-wipe re-paste)', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const { wkString, canary } = await mintKeyAndCanary(WS)
+    setModePin(USER, WS, 'e2ee') // pin survived a Lock & wipe; key store was cleared
+
+    const result = await unlockWorkspaceWithKey({
+      userId: USER,
+      workspaceId: WS,
+      canary,
+      pastedKey: wkString,
+      keyStore,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(await keyStore.get(USER, WS)).not.toBeNull()
+    expect(getModePin(USER, WS)).toBe('e2ee')
+  })
+})

--- a/src/sync/keys/flows/unlockWorkspaceWithKey.ts
+++ b/src/sync/keys/flows/unlockWorkspaceWithKey.ts
@@ -37,8 +37,10 @@ export interface UnlockWorkspaceArgs {
 export type UnlockWorkspaceResult =
   | { readonly ok: true }
   /** `format`: the paste isn't a `kmp-wk-1:` key at all (typo / wrong text).
-   *  `invalid-key`: well-formed, but doesn't decrypt THIS workspace's canary. */
-  | { readonly ok: false; readonly reason: 'format' | 'invalid-key' }
+   *  `invalid-key`: well-formed, but doesn't decrypt THIS workspace's canary.
+   *  `storage`: valid key, but this device couldn't persist it (IndexedDB
+   *  quota / private mode) — retryable; the workspace is pinned e2ee + locked. */
+  | { readonly ok: false; readonly reason: 'format' | 'invalid-key' | 'storage' }
 
 export const unlockWorkspaceWithKey = async (
   args: UnlockWorkspaceArgs,
@@ -56,9 +58,19 @@ export const unlockWorkspaceWithKey = async (
     return { ok: false, reason: 'invalid-key' }
   }
 
-  // Validated: persist the WK and pin e2ee. Re-pinning an already-e2ee
-  // workspace (post-wipe re-paste) is a no-op; the pin is never downgraded.
-  await keyStore.put(userId, workspaceId, key)
+  // Canary validated → this workspace is genuinely e2ee. Pin it FIRST (in the
+  // quarantine case the pin is what defeats a server downgrade lie, and it must
+  // stick even if the key write below fails), then persist the key. Re-pinning
+  // an already-e2ee workspace (post-wipe re-paste) is a no-op.
   setModePin(userId, workspaceId, 'e2ee')
+  try {
+    await keyStore.put(userId, workspaceId, key)
+  } catch (err) {
+    // Valid key, but this device can't store it (IndexedDB quota / private
+    // mode). Report so the caller can offer a retry — the workspace stays
+    // e2ee-pinned-but-locked, never silently stuck mid-unlock.
+    console.warn(`unlockWorkspaceWithKey: key store write failed for ${workspaceId}`, err)
+    return { ok: false, reason: 'storage' }
+  }
   return { ok: true }
 }

--- a/src/sync/keys/flows/unlockWorkspaceWithKey.ts
+++ b/src/sync/keys/flows/unlockWorkspaceWithKey.ts
@@ -59,17 +59,16 @@ export const unlockWorkspaceWithKey = async (
   }
 
   // Canary validated → this workspace is genuinely e2ee. Pin it FIRST (in the
-  // quarantine case the pin is what defeats a server downgrade lie, and it must
-  // stick even if the key write below fails), then persist the key. Re-pinning
-  // an already-e2ee workspace (post-wipe re-paste) is a no-op.
-  setModePin(userId, workspaceId, 'e2ee')
+  // quarantine case the pin is what defeats a server downgrade lie), then
+  // persist the key. Either write can fail if storage is blocked/full (private
+  // mode, IndexedDB quota, localStorage disabled); both surface as a retryable
+  // 'storage' result rather than throwing out of the flow, so the caller can
+  // reset and report. Re-pinning an already-e2ee workspace is a no-op.
   try {
+    setModePin(userId, workspaceId, 'e2ee')
     await keyStore.put(userId, workspaceId, key)
   } catch (err) {
-    // Valid key, but this device can't store it (IndexedDB quota / private
-    // mode). Report so the caller can offer a retry — the workspace stays
-    // e2ee-pinned-but-locked, never silently stuck mid-unlock.
-    console.warn(`unlockWorkspaceWithKey: key store write failed for ${workspaceId}`, err)
+    console.warn(`unlockWorkspaceWithKey: persisting unlock failed for ${workspaceId}`, err)
     return { ok: false, reason: 'storage' }
   }
   return { ok: true }

--- a/src/sync/keys/flows/unlockWorkspaceWithKey.ts
+++ b/src/sync/keys/flows/unlockWorkspaceWithKey.ts
@@ -1,0 +1,64 @@
+/**
+ * §8.2 — open an E2EE workspace with a pasted workspace key (WK).
+ *
+ * The flow that turns a pasted `kmp-wk-1:` string into a usable, pinned
+ * workspace on this device. It validates the candidate WK against the
+ * workspace's stored `wk_canary` (AEAD failure = wrong key; plaintext mismatch =
+ * right key, wrong workspace — both reject), and only on success imports the WK
+ * into the key store and pins the workspace `e2ee` (§6 rule 1).
+ *
+ * Covers two entry points with one path:
+ *   - first encounter on a new device / accepted invite (the key-required
+ *     branch (a), or the quarantine branch (b) where pasting a valid WK defeats
+ *     a server downgrade lie — §6 rule 3);
+ *   - re-unlocking a workspace already pinned `e2ee` whose WK was dropped by a
+ *     §6 Lock & wipe (the pin survives; re-pinning the same value is a no-op).
+ *
+ * Pure of UI and DB: the canary comes in as a string and the key store is
+ * injected. The caller (Phase E UI) supplies `workspaces.wk_canary` and, on
+ * success, re-materializes the workspace via the observer's `drainWorkspace`.
+ */
+
+import { validateCanary } from '../../crypto/canary.js'
+import { importWorkspaceKey, parseWorkspaceKey } from '../../crypto/workspaceKey.js'
+import type { WorkspaceKeyStore } from '../keyStore.js'
+import { setModePin } from '../modePin.js'
+
+export interface UnlockWorkspaceArgs {
+  readonly userId: string
+  readonly workspaceId: string
+  /** The workspace's stored `wk_canary` (opaque ciphertext). */
+  readonly canary: string
+  /** The user-pasted `kmp-wk-1:` string (whitespace/case tolerated). */
+  readonly pastedKey: string
+  readonly keyStore: WorkspaceKeyStore
+}
+
+export type UnlockWorkspaceResult =
+  | { readonly ok: true }
+  /** `format`: the paste isn't a `kmp-wk-1:` key at all (typo / wrong text).
+   *  `invalid-key`: well-formed, but doesn't decrypt THIS workspace's canary. */
+  | { readonly ok: false; readonly reason: 'format' | 'invalid-key' }
+
+export const unlockWorkspaceWithKey = async (
+  args: UnlockWorkspaceArgs,
+): Promise<UnlockWorkspaceResult> => {
+  const { userId, workspaceId, canary, pastedKey, keyStore } = args
+
+  let key: CryptoKey
+  try {
+    key = await importWorkspaceKey(parseWorkspaceKey(pastedKey))
+  } catch {
+    return { ok: false, reason: 'format' }
+  }
+
+  if (!(await validateCanary(key, canary, workspaceId))) {
+    return { ok: false, reason: 'invalid-key' }
+  }
+
+  // Validated: persist the WK and pin e2ee. Re-pinning an already-e2ee
+  // workspace (post-wipe re-paste) is a no-op; the pin is never downgraded.
+  await keyStore.put(userId, workspaceId, key)
+  setModePin(userId, workspaceId, 'e2ee')
+  return { ok: true }
+}

--- a/src/sync/keys/keyStore.ts
+++ b/src/sync/keys/keyStore.ts
@@ -141,3 +141,12 @@ export const createWorkspaceKeyStore = (): WorkspaceKeyStore => {
   }
   return new InMemoryWorkspaceKeyStore()
 }
+
+// Process-wide WK store. The §8 key flows and the §9 sync seam must share ONE
+// store so a WK pasted/minted in a flow is the same handle the observer and
+// upload connector resolve — an IndexedDB-backed instance is shared storage,
+// but a single instance also keeps the in-memory fallback coherent within a
+// session. Tests inject their own store and never touch this singleton.
+let sharedKeyStore: WorkspaceKeyStore | null = null
+export const getWorkspaceKeyStore = (): WorkspaceKeyStore =>
+  (sharedKeyStore ??= createWorkspaceKeyStore())

--- a/src/sync/keys/modePin.test.ts
+++ b/src/sync/keys/modePin.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   arePinsSeeded,
+  confirmPlaintextForSession,
   getModePin,
   seedModePinsOnce,
   setModePin,
@@ -82,6 +83,22 @@ describe('rollout pin seed', () => {
     const written = seedModePinsOnce('user-2', [{ workspaceId: WS_A, serverMode: 'plaintext' }])
     expect(written).toBe(1)
     expect(getModePin('user-2', WS_A)).toBe('plaintext')
+  })
+
+  it('session plaintext confirmation makes getModePin report plaintext (no persisted pin)', () => {
+    // Degraded-storage fallback: a unique id so the in-memory set doesn't leak
+    // into other tests (it isn't cleared by localStorage.clear()).
+    const ws = 'ws-session-only'
+    expect(getModePin(USER, ws)).toBeNull()
+    confirmPlaintextForSession(USER, ws)
+    expect(getModePin(USER, ws)).toBe('plaintext')
+  })
+
+  it('a persisted pin takes precedence over a session confirmation', () => {
+    const ws = 'ws-session-precedence'
+    setModePin(USER, ws, 'e2ee')
+    confirmPlaintextForSession(USER, ws)
+    expect(getModePin(USER, ws)).toBe('e2ee')
   })
 
   it('seals BEFORE pinning: a pin write that fails mid-seed still leaves the device sealed', () => {

--- a/src/sync/keys/modePin.test.ts
+++ b/src/sync/keys/modePin.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   arePinsSeeded,
   getModePin,
@@ -82,5 +82,29 @@ describe('rollout pin seed', () => {
     const written = seedModePinsOnce('user-2', [{ workspaceId: WS_A, serverMode: 'plaintext' }])
     expect(written).toBe(1)
     expect(getModePin('user-2', WS_A)).toBe('plaintext')
+  })
+
+  it('seals BEFORE pinning: a pin write that fails mid-seed still leaves the device sealed', () => {
+    // Seal-first invariant: if the marker were written LAST, a pin-write failure
+    // would leave the device unsealed and a later boot would re-seed — re-trusting
+    // the server flag for memberships synced in the meantime (a downgrade vector).
+    // Fail the pin write but allow the seal-marker write.
+    const realSetItem = Storage.prototype.setItem
+    const spy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(function (this: Storage, key: string, value: string) {
+        if (key.startsWith('kmp-e2ee-mode:')) throw new Error('quota exceeded')
+        realSetItem.call(this, key, value)
+      })
+    try {
+      expect(() =>
+        seedModePinsOnce(USER, [{ workspaceId: WS_A, serverMode: 'plaintext' }]),
+      ).toThrow()
+      // Sealed despite the pin failure → a later seed is a no-op (no re-trust).
+      expect(arePinsSeeded(USER)).toBe(true)
+    } finally {
+      spy.mockRestore()
+    }
+    expect(seedModePinsOnce(USER, [{ workspaceId: WS_A, serverMode: 'plaintext' }])).toBe(0)
   })
 })

--- a/src/sync/keys/modePin.ts
+++ b/src/sync/keys/modePin.ts
@@ -110,7 +110,11 @@ export const arePinsSeeded = (userId: string): boolean => {
 }
 
 const markPinsSeeded = (userId: string): void => {
-  if (!hasLocalStorage()) return
+  // Throw (rather than silently no-op) when the seal can't be persisted, so
+  // seal-first seeding can abort BEFORE writing any pin — see seedModePinsOnce.
+  if (!hasLocalStorage()) {
+    throw new Error('cannot seal E2EE pin seed: localStorage unavailable')
+  }
   localStorage.setItem(seededMarkerKey(userId), ROLLOUT_SEED_VERSION)
 }
 
@@ -140,12 +144,24 @@ export interface SeedEntry {
  *
  * `entries` are the signed-in user's memberships. Returns the number of
  * pins written. No-op (returns 0) if already seeded for this user.
+ *
+ * SEAL FIRST: the "ran once" marker is written BEFORE any pin. If the seal
+ * can't be persisted (localStorage blocked) this throws before trusting a
+ * single server flag — so we never leave the dangerous "some pins written but
+ * not sealed" state, which a later boot would re-seed (re-trusting the server
+ * `encryption_mode` for any membership that synced in the meantime — a
+ * downgrade vector if a hostile/stale server flagged an e2ee workspace `none`).
+ * If sealing succeeds but a later pin write fails, the workspace is already
+ * sealed, so the unpinned remainder takes the first-encounter gate on next
+ * load — never a re-seed. (The caller wraps this best-effort so a seal failure
+ * doesn't crash startup.)
  */
 export const seedModePinsOnce = (
   userId: string,
   entries: readonly SeedEntry[],
 ): number => {
   if (arePinsSeeded(userId)) return 0
+  markPinsSeeded(userId)
   let written = 0
   for (const entry of entries) {
     if (getModePin(userId, entry.workspaceId) === null) {
@@ -153,6 +169,5 @@ export const seedModePinsOnce = (
       written++
     }
   }
-  markPinsSeeded(userId)
   return written
 }

--- a/src/sync/keys/modePin.ts
+++ b/src/sync/keys/modePin.ts
@@ -53,16 +53,39 @@ const pinStorageKey = (userId: string, workspaceId: string): string =>
 const seededMarkerKey = (userId: string): string =>
   `${E2EE_PINS_SEEDED_PREFIX}${encodeURIComponent(userId)}`
 
-/** The pinned mode for this (user, workspace) on this device, or null if
- *  never pinned. */
-export const getModePin = (userId: string, workspaceId: string): ModePin | null => {
+// Session-only plaintext confirmations: workspaces the user explicitly
+// confirmed plaintext in the §6 gate when localStorage couldn't persist the pin
+// (writes blocked / quota) while the rest of the app still works. This keeps a
+// plaintext user from being trapped on the quarantine gate in a degraded
+// storage environment. It is in-memory (lost on reload → re-quarantine, where
+// storage may have recovered), and ONLY ever holds user-confirmed plaintext —
+// never anything derived from the server — so it carries no downgrade risk. A
+// real persisted pin always takes precedence.
+const sessionPlaintext = new Set<string>()
+
+const readPersistedPin = (key: string): ModePin | null => {
   if (!hasLocalStorage()) return null
   try {
-    const raw = localStorage.getItem(pinStorageKey(userId, workspaceId))
+    const raw = localStorage.getItem(key)
     return isModePin(raw) ? raw : null
   } catch {
     return null
   }
+}
+
+/** The pinned mode for this (user, workspace) on this device, or null if
+ *  never pinned. A persisted pin wins; otherwise a session-only plaintext
+ *  confirmation (see {@link confirmPlaintextForSession}) counts as plaintext. */
+export const getModePin = (userId: string, workspaceId: string): ModePin | null => {
+  const key = pinStorageKey(userId, workspaceId)
+  return readPersistedPin(key) ?? (sessionPlaintext.has(key) ? 'plaintext' : null)
+}
+
+/** Record a plaintext confirmation that couldn't be persisted (localStorage
+ *  unavailable), so {@link getModePin} reports plaintext for this session and
+ *  the user can load the workspace. Re-quarantines on next load. */
+export const confirmPlaintextForSession = (userId: string, workspaceId: string): void => {
+  sessionPlaintext.add(pinStorageKey(userId, workspaceId))
 }
 
 /**

--- a/src/sync/keys/modePin.ts
+++ b/src/sync/keys/modePin.ts
@@ -88,6 +88,23 @@ export const confirmPlaintextForSession = (userId: string, workspaceId: string):
   sessionPlaintext.add(pinStorageKey(userId, workspaceId))
 }
 
+/** True if this device can durably persist mode pins (localStorage is writable).
+ *  E2EE REQUIRES this — the pin is the wipe-surviving authority and the §6 gate
+ *  keys off it — so the create flow preflights it rather than minting an
+ *  encrypted workspace this device could never open. Plaintext doesn't need it
+ *  (it has the session fallback). Probes with a temp key and cleans up. */
+export const canPersistPins = (): boolean => {
+  if (!hasLocalStorage()) return false
+  try {
+    const probe = `${E2EE_MODE_PIN_PREFIX}__probe__`
+    localStorage.setItem(probe, '1')
+    localStorage.removeItem(probe)
+    return true
+  } catch {
+    return false
+  }
+}
+
 /**
  * Pin a workspace's mode. Set-once and locally immutable: re-pinning the
  * same value is a no-op; attempting to pin a *different* value throws,

--- a/src/sync/keys/resolver.test.ts
+++ b/src/sync/keys/resolver.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryWorkspaceKeyStore } from './keyStore.js'
+import { setModePin } from './modePin.js'
+import { createSyncResolver } from './resolver.js'
+
+const USER = 'user-1'
+const WS = 'ws-A'
+
+// The resolver only checks the key for presence (truthiness) and hands it to
+// the seam unchanged, so a sentinel stands in for a real non-extractable
+// CryptoKey — the crypto round-trip is exercised in transform/aead tests.
+const FAKE_KEY = {} as CryptoKey
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+const build = (userId: string | null = USER) => {
+  const keyStore = new InMemoryWorkspaceKeyStore()
+  const resolver = createSyncResolver(() => userId, keyStore)
+  return { keyStore, resolver }
+}
+
+describe('createSyncResolver — getMaterializability (§6 policy collapse)', () => {
+  it('plaintext pin → copy (no key needed)', async () => {
+    const { resolver } = build()
+    setModePin(USER, WS, 'plaintext')
+    expect(await resolver.getMaterializability(WS)).toBe('copy')
+  })
+
+  it('e2ee pin with WK loaded → decrypt', async () => {
+    const { resolver, keyStore } = build()
+    setModePin(USER, WS, 'e2ee')
+    await keyStore.put(USER, WS, FAKE_KEY)
+    expect(await resolver.getMaterializability(WS)).toBe('decrypt')
+  })
+
+  it('e2ee pin without WK → defer (locked, read-only — §6 rule 3)', async () => {
+    const { resolver } = build()
+    setModePin(USER, WS, 'e2ee')
+    expect(await resolver.getMaterializability(WS)).toBe('defer')
+  })
+
+  it('unpinned (first-encounter) → defer, never materialized until a flow pins it', async () => {
+    const { resolver } = build()
+    expect(await resolver.getMaterializability(WS)).toBe('defer')
+  })
+
+  it('signed-out (no user id) → defer (fail safe)', async () => {
+    const { resolver } = build(null)
+    expect(await resolver.getMaterializability(WS)).toBe('defer')
+  })
+})
+
+describe('createSyncResolver — getCek', () => {
+  it('returns the stored workspace key', async () => {
+    const { resolver, keyStore } = build()
+    await keyStore.put(USER, WS, FAKE_KEY)
+    expect(await resolver.getCek(WS)).toBe(FAKE_KEY)
+  })
+
+  it('returns null when no key is stored', async () => {
+    const { resolver } = build()
+    expect(await resolver.getCek(WS)).toBeNull()
+  })
+
+  it('returns null when signed out without touching the store', async () => {
+    const { resolver } = build(null)
+    expect(await resolver.getCek(WS)).toBeNull()
+  })
+
+  it('scopes the lookup to the current user', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    await keyStore.put('other-user', WS, FAKE_KEY)
+    const resolver = createSyncResolver(() => USER, keyStore)
+    expect(await resolver.getCek(WS)).toBeNull()
+  })
+})
+
+describe('createSyncResolver — getMode (encrypt-on-upload)', () => {
+  it('e2ee pin → e2ee', async () => {
+    const { resolver } = build()
+    setModePin(USER, WS, 'e2ee')
+    expect(await resolver.getMode(WS)).toBe('e2ee')
+  })
+
+  it('plaintext pin → none', async () => {
+    const { resolver } = build()
+    setModePin(USER, WS, 'plaintext')
+    expect(await resolver.getMode(WS)).toBe('none')
+  })
+
+  it('unpinned → none (never encrypts an unpinned workspace)', async () => {
+    const { resolver } = build()
+    expect(await resolver.getMode(WS)).toBe('none')
+  })
+
+  it('signed-out → none', async () => {
+    const { resolver } = build(null)
+    expect(await resolver.getMode(WS)).toBe('none')
+  })
+})

--- a/src/sync/keys/resolver.test.ts
+++ b/src/sync/keys/resolver.test.ts
@@ -49,6 +49,22 @@ describe('createSyncResolver — getMaterializability (§6 policy collapse)', ()
     const { resolver } = build(null)
     expect(await resolver.getMaterializability(WS)).toBe('defer')
   })
+
+  it('defers (never throws) when the key store read fails for an e2ee pin', async () => {
+    // getMaterializability runs outside the observer's per-row decode try/catch,
+    // so a throw here would wedge the whole drain. An unreadable store → defer.
+    const throwingStore = {
+      get: async () => {
+        throw new Error('IndexedDB unavailable')
+      },
+      put: async () => {},
+      delete: async () => {},
+      clearAll: async () => {},
+    }
+    const resolver = createSyncResolver(() => USER, throwingStore)
+    setModePin(USER, WS, 'e2ee')
+    await expect(resolver.getMaterializability(WS)).resolves.toBe('defer')
+  })
 })
 
 describe('createSyncResolver — getCek', () => {
@@ -73,6 +89,19 @@ describe('createSyncResolver — getCek', () => {
     await keyStore.put('other-user', WS, FAKE_KEY)
     const resolver = createSyncResolver(() => USER, keyStore)
     expect(await resolver.getCek(WS)).toBeNull()
+  })
+
+  it('returns null (does not throw) when the key store read fails', async () => {
+    const throwingStore = {
+      get: async () => {
+        throw new Error('boom')
+      },
+      put: async () => {},
+      delete: async () => {},
+      clearAll: async () => {},
+    }
+    const resolver = createSyncResolver(() => USER, throwingStore)
+    await expect(resolver.getCek(WS)).resolves.toBeNull()
   })
 })
 

--- a/src/sync/keys/resolver.ts
+++ b/src/sync/keys/resolver.ts
@@ -56,7 +56,17 @@ export const createSyncResolver = (
   const getCek: GetCek = async (workspaceId) => {
     const userId = getUserId()
     if (!userId) return null
-    return keyStore.get(userId, workspaceId)
+    try {
+      return await keyStore.get(userId, workspaceId)
+    } catch (err) {
+      // A key-store read failure (IndexedDB unavailable / corrupt / quota) must
+      // never throw out of the resolver: getMaterializability (below) runs
+      // OUTSIDE materializeStagingRows' per-row decode try/catch, so a throw
+      // there aborts the entire observer drain and strands the durable change
+      // queue. Treat an unreadable store as "no key".
+      console.warn(`[syncResolver] key read failed for ${workspaceId}; treating as no key`, err)
+      return null
+    }
   }
 
   const getMaterializability: GetMaterializability = async (workspaceId) => {
@@ -65,7 +75,10 @@ export const createSyncResolver = (
     const pin = getModePin(userId, workspaceId)
     if (pin === 'plaintext') return 'copy'
     if (pin === 'e2ee') {
-      const key = await keyStore.get(userId, workspaceId)
+      // getCek swallows read failures → null, so an unreadable key store defers
+      // (leaves the row staged; retries when the store recovers / WK is pasted)
+      // instead of wedging the drain.
+      const key = await getCek(workspaceId)
       return key ? 'decrypt' : 'defer'
     }
     // Unpinned: never materialize until a §8 flow resolves the first encounter.

--- a/src/sync/keys/resolver.ts
+++ b/src/sync/keys/resolver.ts
@@ -1,0 +1,82 @@
+/**
+ * Sync-mode resolver (design doc §6 + §9.2).
+ *
+ * The single place that turns the durable per-(user, workspace) mode pin (§6)
+ * plus the per-device workspace-key store (§5) into the three decisions the
+ * Layout B sync seam needs:
+ *
+ *   - getMaterializability(ws) — observer: how to turn a `blocks_synced` row
+ *     into the app-visible plaintext `blocks` table (decrypt / copy / defer).
+ *   - getCek(ws)               — observer + upload: the workspace CryptoKey, or
+ *     null if it isn't loaded on this device.
+ *   - getMode(ws)              — upload: whether to seal content columns on the
+ *     way out ('e2ee') or pass them through ('none').
+ *
+ * The PIN is the authority (§6 rule 1): the server's `encryption_mode` and the
+ * `enc:v1:` prefix are both untrusted, so this module reads ONLY the local pin
+ * and the local key store, never the server flag. First-encounter handling (the
+ * server-trusting branches a/b of §6 rule 3) lives in the §8 flows that own the
+ * UI to prompt/quarantine; it surfaces here only as the fail-safe default — an
+ * UNPINNED workspace is never materialized (defer) and never encrypted as e2ee
+ * on upload until a flow pins it.
+ *
+ * Materializability policy (the §6 collapse at the data layer):
+ *   pin 'plaintext'          → 'copy'    (no key; copy the row through)
+ *   pin 'e2ee'  & WK loaded   → 'decrypt'
+ *   pin 'e2ee'  & WK absent    → 'defer'  (locked read-only — §6 rule 3)
+ *   unpinned (null)          → 'defer'  (first-encounter quarantine — §6 rule 3)
+ *
+ * Upload-mode policy:
+ *   pin 'e2ee'               → 'e2ee'   (seal content columns on the wire)
+ *   otherwise                → 'none'   (plaintext / unpinned — pass through)
+ *
+ * Bound to a `getUserId` thunk rather than a fixed id so the resolver reads the
+ * current user fresh: a signed-out resolver (`null`) fails safe — defer, no key,
+ * mode 'none' — instead of resolving against a stale id.
+ */
+
+import type { GetCek, SyncMode } from '../transform.js'
+import type { GetMaterializability } from '../observer/materialize.js'
+import type { WorkspaceKeyStore } from './keyStore.js'
+import { getModePin } from './modePin.js'
+
+export interface SyncResolver {
+  /** Observer: how to materialize a workspace's staging rows. */
+  readonly getMaterializability: GetMaterializability
+  /** Observer + upload: the workspace key handle, or null if not loaded. */
+  readonly getCek: GetCek
+  /** Upload: whether to encrypt content columns on the wire. */
+  readonly getMode: (workspaceId: string) => Promise<SyncMode>
+}
+
+export const createSyncResolver = (
+  getUserId: () => string | null,
+  keyStore: WorkspaceKeyStore,
+): SyncResolver => {
+  const getCek: GetCek = async (workspaceId) => {
+    const userId = getUserId()
+    if (!userId) return null
+    return keyStore.get(userId, workspaceId)
+  }
+
+  const getMaterializability: GetMaterializability = async (workspaceId) => {
+    const userId = getUserId()
+    if (!userId) return 'defer'
+    const pin = getModePin(userId, workspaceId)
+    if (pin === 'plaintext') return 'copy'
+    if (pin === 'e2ee') {
+      const key = await keyStore.get(userId, workspaceId)
+      return key ? 'decrypt' : 'defer'
+    }
+    // Unpinned: never materialize until a §8 flow resolves the first encounter.
+    return 'defer'
+  }
+
+  const getMode = async (workspaceId: string): Promise<SyncMode> => {
+    const userId = getUserId()
+    if (!userId) return 'none'
+    return getModePin(userId, workspaceId) === 'e2ee' ? 'e2ee' : 'none'
+  }
+
+  return { getMaterializability, getCek, getMode }
+}

--- a/src/sync/keys/rolloutSeed.test.ts
+++ b/src/sync/keys/rolloutSeed.test.ts
@@ -32,6 +32,18 @@ describe('seedModePinsFromWorkspaces (§6 rollout seed)', () => {
     expect(db.getAll).toHaveBeenCalledTimes(1)
   })
 
+  it('does not throw when pin writes fail (storage disabled) so startup can continue', async () => {
+    const db = reader([{ id: 'ws-1', encryption_mode: 'none' }])
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('localStorage is blocked')
+    })
+    try {
+      await expect(seedModePinsFromWorkspaces(db, USER)).resolves.toBe(0)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
   it('seeds an empty set (fresh device) and marks seeded so later syncs take the gate', async () => {
     const db = reader([])
     const written = await seedModePinsFromWorkspaces(db, USER)

--- a/src/sync/keys/rolloutSeed.test.ts
+++ b/src/sync/keys/rolloutSeed.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getModePin } from './modePin.js'
+import { seedModePinsFromWorkspaces, type SeedReader } from './rolloutSeed.js'
+
+const USER = 'user-1'
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+const reader = (rows: Array<{ id: string; encryption_mode: string }>): SeedReader => ({
+  getAll: vi.fn(async () => rows as never),
+})
+
+describe('seedModePinsFromWorkspaces (§6 rollout seed)', () => {
+  it('pins plaintext for server-none workspaces and e2ee for server-e2ee', async () => {
+    const db = reader([
+      { id: 'ws-1', encryption_mode: 'none' },
+      { id: 'ws-2', encryption_mode: 'e2ee' },
+    ])
+    const written = await seedModePinsFromWorkspaces(db, USER)
+    expect(written).toBe(2)
+    expect(getModePin(USER, 'ws-1')).toBe('plaintext')
+    expect(getModePin(USER, 'ws-2')).toBe('e2ee')
+  })
+
+  it('is once-only: a second call writes nothing and never re-queries the DB', async () => {
+    const db = reader([{ id: 'ws-1', encryption_mode: 'none' }])
+    await seedModePinsFromWorkspaces(db, USER)
+    const written = await seedModePinsFromWorkspaces(db, USER)
+    expect(written).toBe(0)
+    // arePinsSeeded short-circuits before the second query.
+    expect(db.getAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('seeds an empty set (fresh device) and marks seeded so later syncs take the gate', async () => {
+    const db = reader([])
+    const written = await seedModePinsFromWorkspaces(db, USER)
+    expect(written).toBe(0)
+    // A workspace that syncs in AFTER the seal is NOT seeded — stays unpinned.
+    const db2 = reader([{ id: 'ws-late', encryption_mode: 'none' }])
+    expect(await seedModePinsFromWorkspaces(db2, USER)).toBe(0)
+    expect(getModePin(USER, 'ws-late')).toBeNull()
+  })
+})

--- a/src/sync/keys/rolloutSeed.ts
+++ b/src/sync/keys/rolloutSeed.ts
@@ -2,6 +2,14 @@
  * §6 rollout pin-seed — the one-time bootstrap that pins pre-existing
  * memberships from the server's `encryption_mode`.
  *
+ * ⚠️ PLANNED REMOVAL (issue #116). This server-trusting seed exists ONLY for the
+ * coordinated rollout window (no E2EE workspace exists yet, so trusting the flag
+ * is safe). It carries a narrow, irreducible downgrade residual on a fresh
+ * device whose first-boot seal write fails and later recovers with post-rollout
+ * data present. Once the rollout cohort has seeded (~1 week after release),
+ * DELETE this module + its caller so future fresh devices gate every unpinned
+ * workspace — which permanently closes the residual.
+ *
  * The first pin-aware boot finds every workspace unpinned. We initialize those
  * pins directly from the server flag — the ONE place the design trusts it —
  * because at rollout no E2EE workspace exists yet, so there's nothing to

--- a/src/sync/keys/rolloutSeed.ts
+++ b/src/sync/keys/rolloutSeed.ts
@@ -48,5 +48,15 @@ export const seedModePinsFromWorkspaces = async (
     workspaceId: row.id,
     serverMode: row.encryption_mode === 'e2ee' ? 'e2ee' : 'plaintext',
   }))
-  return seedModePinsOnce(userId, entries)
+  try {
+    return seedModePinsOnce(userId, entries)
+  } catch (err) {
+    // BEST-EFFORT: setModePin throws if localStorage is unavailable / blocked
+    // (private mode, storage disabled). The seed is only an optimization — it
+    // spares pre-existing workspaces a first-encounter gate — so a write
+    // failure must NOT abort startup. Boot proceeds; without pins those
+    // workspaces hit the gate, but the app still loads.
+    console.warn('[rolloutSeed] pin-seed failed (storage unavailable?); continuing without it', err)
+    return 0
+  }
 }

--- a/src/sync/keys/rolloutSeed.ts
+++ b/src/sync/keys/rolloutSeed.ts
@@ -11,11 +11,15 @@
  * seed (seedModePinsOnce + arePinsSeeded enforce the once-only marker in
  * wipe-surviving localStorage).
  *
- * Reads the LOCAL `workspaces` table, so on an established device every synced
- * membership is already present and gets pinned before the observer/gate read
- * pins. A genuinely-fresh device seeds whatever has synced so far (often
- * nothing) and the rest take the gate — the accepted "one resolution step per
- * workspace per new device" cost.
+ * SAFETY rests on WHEN this runs: the caller invokes it AFTER `db.init()` but
+ * BEFORE `db.connect()`, so the `workspaces` table holds ONLY rows persisted on
+ * disk by a prior, pre-this-release session. Those predate e2ee existing at all,
+ * so a row's `encryption_mode` can't be a downgraded e2ee workspace — trusting
+ * it is safe by construction. A fresh device / profile has no on-disk rows here,
+ * so it seeds nothing and marks-seeded; every workspace that syncs in afterward
+ * (including any e2ee one a hostile server flags `none`) takes the
+ * first-encounter gate, never this server-trusting path. This is what limits the
+ * seed to the genuine rollout cohort without a separate cohort signal.
  */
 
 import { arePinsSeeded, seedModePinsOnce, type SeedEntry } from './modePin.js'

--- a/src/sync/keys/rolloutSeed.ts
+++ b/src/sync/keys/rolloutSeed.ts
@@ -1,0 +1,48 @@
+/**
+ * §6 rollout pin-seed — the one-time bootstrap that pins pre-existing
+ * memberships from the server's `encryption_mode`.
+ *
+ * The first pin-aware boot finds every workspace unpinned. We initialize those
+ * pins directly from the server flag — the ONE place the design trusts it —
+ * because at rollout no E2EE workspace exists yet, so there's nothing to
+ * misrepresent (every workspace is 'none' → 'plaintext'). Fires at most once
+ * per (user, device); thereafter an unpinned workspace always takes the
+ * steady-state gate (branch a key-required / branch b quarantine), never the
+ * seed (seedModePinsOnce + arePinsSeeded enforce the once-only marker in
+ * wipe-surviving localStorage).
+ *
+ * Reads the LOCAL `workspaces` table, so on an established device every synced
+ * membership is already present and gets pinned before the observer/gate read
+ * pins. A genuinely-fresh device seeds whatever has synced so far (often
+ * nothing) and the rest take the gate — the accepted "one resolution step per
+ * workspace per new device" cost.
+ */
+
+import { arePinsSeeded, seedModePinsOnce, type SeedEntry } from './modePin.js'
+
+interface WorkspaceModeRow {
+  readonly id: string
+  readonly encryption_mode: string
+}
+
+/** Minimal read surface — the PowerSync DB satisfies it. */
+export interface SeedReader {
+  getAll<T>(sql: string): Promise<T[]>
+}
+
+export const seedModePinsFromWorkspaces = async (
+  db: SeedReader,
+  userId: string,
+): Promise<number> => {
+  // Short-circuit before touching the DB if this user already seeded — keeps
+  // the once-only guarantee cheap on every boot.
+  if (arePinsSeeded(userId)) return 0
+  const rows = await db.getAll<WorkspaceModeRow>(
+    'SELECT id, encryption_mode FROM workspaces',
+  )
+  const entries: SeedEntry[] = rows.map((row) => ({
+    workspaceId: row.id,
+    serverMode: row.encryption_mode === 'e2ee' ? 'e2ee' : 'plaintext',
+  }))
+  return seedModePinsOnce(userId, entries)
+}

--- a/src/sync/keys/workspaceAccess.test.ts
+++ b/src/sync/keys/workspaceAccess.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveWorkspaceAccess } from './workspaceAccess.js'
+import { decideWorkspaceEntry, resolveWorkspaceAccess } from './workspaceAccess.js'
 
 describe('resolveWorkspaceAccess (§6 rule 3 — UI gate policy)', () => {
   it('plaintext pin → ready (server flag and key irrelevant)', () => {
@@ -31,5 +31,31 @@ describe('resolveWorkspaceAccess (§6 rule 3 — UI gate policy)', () => {
       kind: 'locked',
       reason: 'quarantine',
     })
+  })
+})
+
+describe('decideWorkspaceEntry (row-aware — guards the unsynced-row case)', () => {
+  const noneRow = { encryptionMode: 'none' }
+  const e2eeRow = { encryptionMode: 'e2ee' }
+
+  it('decides WITHOUT the row when the pin settles it', () => {
+    // plaintext pin → ready even before the row syncs (bootstrap is plaintext).
+    expect(decideWorkspaceEntry('plaintext', false, null)).toEqual({ kind: 'ready' })
+    // e2ee pin + WK loaded → ready (materialization uses the pin/key, not the row).
+    expect(decideWorkspaceEntry('e2ee', true, null)).toEqual({ kind: 'ready' })
+  })
+
+  it('WAITS when the decision needs the row but it has not synced', () => {
+    // unpinned: can't tell branch a from b without the server flag.
+    expect(decideWorkspaceEntry(null, false, null)).toEqual({ kind: 'waiting' })
+    // e2ee pin, no WK: needs the canary (in the row) to validate a paste.
+    expect(decideWorkspaceEntry('e2ee', false, null)).toEqual({ kind: 'waiting' })
+  })
+
+  it('decides via the row once it is present', () => {
+    expect(decideWorkspaceEntry(null, false, noneRow)).toEqual({ kind: 'locked', reason: 'quarantine' })
+    expect(decideWorkspaceEntry(null, false, e2eeRow)).toEqual({ kind: 'locked', reason: 'key-required' })
+    expect(decideWorkspaceEntry('e2ee', false, e2eeRow)).toEqual({ kind: 'locked', reason: 'key-required' })
+    expect(decideWorkspaceEntry('plaintext', false, noneRow)).toEqual({ kind: 'ready' })
   })
 })

--- a/src/sync/keys/workspaceAccess.test.ts
+++ b/src/sync/keys/workspaceAccess.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorkspaceAccess } from './workspaceAccess.js'
+
+describe('resolveWorkspaceAccess (§6 rule 3 — UI gate policy)', () => {
+  it('plaintext pin → ready (server flag and key irrelevant)', () => {
+    expect(resolveWorkspaceAccess('plaintext', 'none', false)).toEqual({ kind: 'ready' })
+    // A hostile server flipping the flag to e2ee can't relock a plaintext pin.
+    expect(resolveWorkspaceAccess('plaintext', 'e2ee', false)).toEqual({ kind: 'ready' })
+  })
+
+  it('e2ee pin with the WK loaded → ready', () => {
+    expect(resolveWorkspaceAccess('e2ee', 'e2ee', true)).toEqual({ kind: 'ready' })
+  })
+
+  it('e2ee pin without the WK → locked, key-required (rule 3 locked)', () => {
+    expect(resolveWorkspaceAccess('e2ee', 'e2ee', false)).toEqual({
+      kind: 'locked',
+      reason: 'key-required',
+    })
+  })
+
+  it('unpinned + server says e2ee → locked, key-required (branch a, fail closed)', () => {
+    expect(resolveWorkspaceAccess(null, 'e2ee', false)).toEqual({
+      kind: 'locked',
+      reason: 'key-required',
+    })
+  })
+
+  it('unpinned + server says none → locked, quarantine (branch b — uncertain)', () => {
+    expect(resolveWorkspaceAccess(null, 'none', false)).toEqual({
+      kind: 'locked',
+      reason: 'quarantine',
+    })
+  })
+})

--- a/src/sync/keys/workspaceAccess.ts
+++ b/src/sync/keys/workspaceAccess.ts
@@ -42,3 +42,41 @@ export const resolveWorkspaceAccess = (
     ? { kind: 'locked', reason: 'key-required' }
     : { kind: 'locked', reason: 'quarantine' }
 }
+
+/** Minimal shape of the local `workspaces` row the entry decision needs. */
+export interface WorkspaceModeRow {
+  readonly encryptionMode: string
+}
+
+export type WorkspaceEntry =
+  | WorkspaceAccess
+  /** The synced `workspaces` row isn't local yet and we can't decide safely
+   *  without it — wait for it to replicate, then re-decide. */
+  | { readonly kind: 'waiting' }
+
+/**
+ * Decide how to enter a workspace, accounting for whether its server row has
+ * replicated locally yet. {@link resolveWorkspaceAccess} assumes the row's
+ * `encryption_mode`/`wk_canary` are known; this wrapper guards the case where
+ * they are NOT (a workspace opened by URL right after an RLS-allowed access
+ * check, before sync delivered the row).
+ *
+ * We can decide WITHOUT the row only when the local pin settles it and no
+ * server-supplied field is needed:
+ *   - plaintext pin            → ready (bootstrap-writing plaintext is correct);
+ *   - e2ee pin + WK loaded      → ready (materialization uses the pin/key, the
+ *     row isn't needed; uploads seal via the pin).
+ * Otherwise the row's `encryption_mode` (branch a/b) and `wk_canary` (to
+ * validate a pasted key) are required, so a missing row means WAIT — never
+ * proceed (which would bootstrap plaintext into a possibly-encrypted workspace)
+ * and never gate with a null canary (which can't validate any key).
+ */
+export const decideWorkspaceEntry = (
+  pin: ModePin | null,
+  hasKey: boolean,
+  row: WorkspaceModeRow | null,
+): WorkspaceEntry => {
+  const canDecideWithoutRow = pin === 'plaintext' || (pin === 'e2ee' && hasKey)
+  if (!canDecideWithoutRow && row === null) return { kind: 'waiting' }
+  return resolveWorkspaceAccess(pin, row?.encryptionMode ?? 'none', hasKey)
+}

--- a/src/sync/keys/workspaceAccess.ts
+++ b/src/sync/keys/workspaceAccess.ts
@@ -1,0 +1,44 @@
+/**
+ * §6 rule 3 — the UI access gate for the ACTIVE workspace.
+ *
+ * Complement to the resolver's `getMaterializability` (which collapses every
+ * "can't render" case to `defer` for the observer). The UI needs one more
+ * distinction the observer doesn't: WHY a workspace can't render, so it can show
+ * the right prompt. Same authority — the local pin — read here against the
+ * (untrusted, but safe-in-one-direction) server `encryption_mode` to split the
+ * never-pinned case into its two branches:
+ *
+ *   pin 'plaintext'            → ready
+ *   pin 'e2ee' + WK loaded      → ready
+ *   pin 'e2ee' + WK absent       → locked: key-required (rule 3 "locked")
+ *   unpinned + server 'e2ee'    → locked: key-required (branch a — trust e2ee,
+ *                                  fail closed; prompt for the WK, no downgrade)
+ *   unpinned + server 'none'    → locked: quarantine   (branch b — uncertain;
+ *                                  offer paste-WK OR confirm-plaintext)
+ *
+ * Trusting server 'e2ee' can only make the client stricter (a key prompt);
+ * distrusting server 'none' is what defeats a downgrade lie. NOTE: this is safe
+ * only once the rollout pin-seed has run (so pre-existing plaintext workspaces
+ * are pinned, not treated as unpinned-server-none and quarantined).
+ */
+
+import type { ModePin } from './modePin.js'
+
+export type WorkspaceAccess =
+  | { readonly kind: 'ready' }
+  | { readonly kind: 'locked'; readonly reason: 'key-required' | 'quarantine' }
+
+export const resolveWorkspaceAccess = (
+  pin: ModePin | null,
+  serverEncryptionMode: string,
+  hasKey: boolean,
+): WorkspaceAccess => {
+  if (pin === 'plaintext') return { kind: 'ready' }
+  if (pin === 'e2ee') {
+    return hasKey ? { kind: 'ready' } : { kind: 'locked', reason: 'key-required' }
+  }
+  // Unpinned — first encounter. Trust 'e2ee' (fail closed), quarantine 'none'.
+  return serverEncryptionMode === 'e2ee'
+    ? { kind: 'locked', reason: 'key-required' }
+    : { kind: 'locked', reason: 'quarantine' }
+}


### PR DESCRIPTION
## E2EE: Phase D + E (minimal path to live per-workspace encryption)

Builds on PR #56 (Layout B staging + observer, crypto primitives, key store, mode-pin storage). This wires those dormant pieces into the running app so a user can **create and open an end-to-end encrypted workspace**, while plaintext workspaces behave exactly as before.

### What this does

- **Resolver (`src/sync/keys/resolver.ts`)** — the single place that turns the durable per-(user, workspace) mode pin (§6) + the per-device workspace-key store (§5) into the three decisions the Layout B seam needs: `getMaterializability` (observer: decrypt/copy/defer), `getCek` (key handle), `getMode` (encrypt-on-upload).
- **§8.1 `createEncryptedWorkspace`** — mints the WK + canary, creates the server row (RPC already deployed), stores the non-extractable key, pins `e2ee`. No WK bytes reach the server (only the opaque canary). UI: an "End-to-end encrypted" option in the create dialog that reveals the `kmp-wk-1:` key once with a "no recovery" warning + retype-confirm.
- **§8.2 `unlockWorkspaceWithKey`** — validates a pasted WK against the workspace canary, then stores key + pins `e2ee`. Covers first-encounter key-required, quarantine, and post-wipe re-paste.
- **Access gate (`resolveWorkspaceAccess` + `WorkspaceKeyGate`)** — §6 rule 3: splits never-pinned into branch (a) key-required (trust server `e2ee`, fail closed) vs branch (b) quarantine (server `none`, uncertain — paste WK *or* confirm plaintext). Rendered in place of the workspace **before any bootstrap write**, so plaintext is never written into a locked encrypted workspace.
- **Rollout seed + activation** — `seedModePinsFromWorkspaces` pins pre-existing memberships from the local server flag once at startup (§6 bootstrap), *before* the observer/gate read pins, so established devices keep materializing plaintext workspaces. The resolver is then wired into the observer (`repo.ts`) and the upload connector (`powersync.ts`); App's `resolveInitialLayout` diverts to the gate when locked.

### Safety properties

- The **pin is the authority** — the server's `encryption_mode` and the `enc:v1:` prefix are never trusted to *downgrade*; trusting server `e2ee` only fails closed (a key prompt).
- **No silent strand:** the gate only diverts when a pin or a synced local row gives real info; an unsynced row is left to poll, never mis-quarantined (which would otherwise risk offering plaintext-confirm for an as-yet-unsynced e2ee workspace).
- **Zero behavior change for existing plaintext users:** after the seed pins them `plaintext`, every decision is `copy`/`none`/`ready` — identical to today.
- Tests keep the observer's plaintext stub (production passes the resolver via `RepoOpts.syncObserverDeps`), so no test churn.

### Deferred (follow-ups, not in this PR)

- §6 **Lock & wipe** (drop WKs + whole-DB wipe, pins survive)
- §8.3 share polish (owner WK-reveal surface; the collaborator path already works via §8.2)
- Phase F: drift guard + docs refresh (`docs/e2ee-deploy.md`)

### Known edge (flagged, not blocking)

`createEncryptedWorkspace` creates the server row before persisting the local key. If the IndexedDB `put` fails *after* the row is created, the flow throws before revealing the WK — leaving a server-side e2ee workspace with no local key. IndexedDB write failure is rare; can reorder to reveal-before-persist if we want it hardened.

### Verification

- `yarn run lint` ✓ (0 errors)
- Full `yarn run test`: **2892 passed**; the 28 failures are all in `packages/agent-cli/` (`bridgeServer`/`config`/`cliProfiles`/`evalDataFlag`) — pre-existing **environmental** failures (socket-bind / subprocess under the sandbox, per AGENTS.md). This branch's diff vs base restricted to `packages/` is empty, so they are not regressions. **Zero `src/` failures.**
- Type-clean (only the pre-existing `baseUrl` deprecation notice).
- **Live end-to-end verification still pending** — creating an encrypted workspace writes to prod Supabase + PowerSync, so it's left for an explicit go-ahead / manual run on the tmp profile.

### Deploy note

Enabling e2ee creation is safe only once encrypt-on-upload (this PR) ships on top of the already-deployed Layout B cutover. This PR ships them together. (The local-only sync-config cutover commit on `master` is unrelated and not part of this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
