### PR TITLE
test(perf): share one PowerSync DB across the heaviest test suites

### DIFF
--- a/src/components/BlockProperties.component.test.tsx
+++ b/src/components/BlockProperties.component.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import {
   ChangeScope,
@@ -10,7 +10,7 @@ import {
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { typesFacet } from '@/data/facets'
 import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet'
@@ -109,12 +109,16 @@ const TestBlockRenderer = ({block}: BlockRendererProps) => {
 }
 
 describe('BlockProperties component', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
   let runtime: FacetRuntime
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
 
   beforeEach(async () => {
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     let now = 1700_000_000_000
     let idSeq = 0
     let txSeq = 0
@@ -163,11 +167,11 @@ describe('BlockProperties component', () => {
     uiStateBlockRef.current = repo.block('ui-state')
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     cleanup()
     repoRef.current = undefined
     uiStateBlockRef.current = undefined
-    await h.cleanup()
+    repo.stopSyncObserver()
   })
 
   it('keeps primitive value edits local until blur commits them', async () => {

--- a/src/components/renderer/DefaultBlockRenderer.test.tsx
+++ b/src/components/renderer/DefaultBlockRenderer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import {
   ChangeScope,
@@ -8,7 +8,7 @@ import {
   defineProperty,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { propertySchemasFacet } from '@/data/facets'
@@ -102,14 +102,18 @@ const dispatchPaste = (target: Element, text: string): Event => {
 }
 
 describe('DefaultBlockRenderer paste handling', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
   let runtime: FacetRuntime
 
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
   beforeEach(async () => {
     vi.mocked(pasteMultilineText).mockClear()
 
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     let now = 1700_000_000_000
     let txSeq = 0
     repo = new Repo({
@@ -176,7 +180,7 @@ describe('DefaultBlockRenderer paste handling', () => {
     cleanup()
     repoRef.current = undefined
     uiStateBlockRef.current = undefined
-    await h.cleanup()
+    repo.stopSyncObserver()
   })
 
   const renderBlock = () =>

--- a/src/components/renderer/LayoutRenderer.test.tsx
+++ b/src/components/renderer/LayoutRenderer.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
 import type { User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks'
 import { BlockContextProvider, useBlockContext } from '@/context/block'
@@ -42,7 +42,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   let txSeq = 0
   const repo = new Repo({
     db: h.db,
@@ -57,6 +58,10 @@ const setup = async (): Promise<Harness> => {
   return {h, repo, layoutSessionBlockId: layoutSessionBlock.id}
 }
 
+let sharedDb: TestDb
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+
 describe('LayoutRenderer', () => {
   let env: Harness
 
@@ -67,7 +72,7 @@ describe('LayoutRenderer', () => {
 
   afterEach(async () => {
     cleanup()
-    await env.h.cleanup()
+    env.repo.stopSyncObserver()
   })
 
   const layoutSessionBlock = () => env.repo.block(env.layoutSessionBlockId)

--- a/src/components/renderer/PanelRenderer.test.tsx
+++ b/src/components/renderer/PanelRenderer.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, render, screen } from '@testing-library/react'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import type { Block } from '@/data/block'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import {
   activePanelIdProp,
@@ -88,7 +88,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   let txSeq = 0
   const repo = new Repo({
     db: h.db,
@@ -134,6 +135,10 @@ const setup = async (): Promise<Harness> => {
   return {h, repo, runtime, panel: repo.block('panel-a')}
 }
 
+let sharedDb: TestDb
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+
 describe('PanelRenderer', () => {
   let env: Harness
 
@@ -147,7 +152,7 @@ describe('PanelRenderer', () => {
   afterEach(async () => {
     cleanup()
     repoRef.current = undefined
-    await env.h.cleanup()
+    env.repo.stopSyncObserver()
   })
 
   const renderPanel = (wideScrollSurface: boolean) =>

--- a/src/data/block.test.ts
+++ b/src/data/block.test.ts
@@ -10,7 +10,7 @@
  *     repo.children
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   BlockNotFoundError,
   BlockNotLoadedError,
@@ -20,7 +20,7 @@ import {
   type BlockData,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Block } from './block'
 import { Repo } from './repo'
 
@@ -31,7 +31,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -45,9 +47,12 @@ const setup = async (): Promise<Harness> => {
   return {h, cache, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const titleProp = defineProperty<string>('title', {
   codec: codecs.string,

--- a/src/data/internals/blockHandle.test.ts
+++ b/src/data/internals/blockHandle.test.ts
@@ -15,24 +15,30 @@
  *     block.test.ts; verified here against the Handle contract too)
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 interface Harness { h: TestDb; cache: BlockCache; repo: Repo }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   const repo = new Repo({db: h.db, cache, user: {id: 'u1'}})
   return {h, cache, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const seed = async (id: string, content = 'x') => {
   await env.repo.tx(

--- a/src/data/internals/cycleDetection.test.ts
+++ b/src/data/internals/cycleDetection.test.ts
@@ -27,18 +27,22 @@
  * subscriber surface.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CycleDetectedEvent } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 interface Harness { h: TestDb; cache: BlockCache; repo: Repo }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   const repo = new Repo({
     db: h.db,
@@ -48,11 +52,8 @@ beforeEach(async () => {
   })
   env = { h, cache, repo }
 })
-afterEach(async () => {
-  if (env) {
-    env.repo.stopSyncObserver()
-    await env.h.cleanup()
-  }
+afterEach(() => {
+  if (env) env.repo.stopSyncObserver()
 })
 
 // "Newer than the seeded rows" (which carry updated_at = 0), so a sync-applied

--- a/src/data/internals/facets.test.ts
+++ b/src/data/internals/facets.test.ts
@@ -13,7 +13,7 @@
  *     propertySchemasFacet (Phase 3 — chunk A)
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { createElement, type JSX } from 'react'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
@@ -29,7 +29,7 @@ import {
   MutatorNotRegisteredError,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '../kernelDataExtension'
 import {
   mutatorsFacet,
@@ -56,11 +56,16 @@ import {
 } from '@/data/blockTypes'
 import { Repo } from '../repo'
 
+let sharedDb: TestDb
 let h: TestDb
 let cache: BlockCache
 let repo: Repo
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -75,7 +80,7 @@ beforeEach(async () => {
     registerKernelProcessors: false,
   })
 })
-afterEach(async () => { await h.cleanup() })
+afterEach(() => { repo.stopSyncObserver() })
 
 describe('setFacetRuntime + mutatorsFacet', () => {
   it('mutatorsFacet.combine builds a name-keyed map', () => {

--- a/src/data/internals/invalidation.test.ts
+++ b/src/data/internals/invalidation.test.ts
@@ -22,10 +22,10 @@
  * so a local write can't double-fire through the sync path by construction.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
 import { Repo } from '../repo'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
@@ -42,7 +42,9 @@ interface Harness { h: TestDb; cache: BlockCache; repo: Repo }
 const setup = async (
   opts: {startTail?: boolean} = {},
 ): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset per test in setup().
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   const repo = new Repo({
     db: h.db,
@@ -56,12 +58,13 @@ const setup = async (
   return {h, cache, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
-afterEach(async () => {
-  if (env) {
-    env.repo.stopSyncObserver()
-    await env.h.cleanup()
-  }
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+afterEach(() => {
+  // Dispose the per-test observer; the shared DB closes once in afterAll.
+  if (env) env.repo.stopSyncObserver()
 })
 
 const create = async (

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -13,7 +13,7 @@
  * (stage 1.6) will migrate to.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   CORE_BLOCK_MERGED_EVENT,
   ChangeScope,
@@ -24,7 +24,7 @@ import {
   type CoreBlockMergedEvent,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 import { isCollapsedProp } from '@/data/properties'
 import { aliasesProp } from './coreProperties'
@@ -41,7 +41,11 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // One real PowerSync DB is opened per file (beforeAll) and reset between
+  // tests — ~100x cheaper than reopening it for each case. A fresh Repo per
+  // test keeps the cache / handle-store / registry isolated.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -71,9 +75,15 @@ const setup = async (): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer (started by default in the Repo
+// constructor) so its db.onChange subscription doesn't leak onto the shared
+// DB; the DB itself is closed once in afterAll.
+afterEach(() => { env.repo.stopSyncObserver() })
 
 /** Seed a small tree: root, three children A/B/C at depth 1. */
 const seedABC = async () => {

--- a/src/data/internals/kernelQueries.test.ts
+++ b/src/data/internals/kernelQueries.test.ts
@@ -10,7 +10,7 @@
  * loop works for non-kernel contributions.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
@@ -21,7 +21,7 @@ import {
 } from '@/data/api'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '../kernelDataExtension'
 import { queriesFacet } from '../facets'
 import { Repo } from '../repo'
@@ -37,7 +37,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -54,9 +56,14 @@ const setup = async (): Promise<Harness> => {
   return {h, cache, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's default sync observer so its db.onChange
+// subscription doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/data/internals/normalizeReferencesProcessor.test.ts
+++ b/src/data/internals/normalizeReferencesProcessor.test.ts
@@ -7,13 +7,13 @@
  * processor wiring: writes through tx primitives commit normalized.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   ChangeScope,
   type BlockReference,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 const WS = 'ws-1'
@@ -24,7 +24,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -38,9 +39,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const readReferences = async (db: TestDb['db'], id: string): Promise<BlockReference[]> => {
   const row = await db.get<{references_json: string}>(

--- a/src/data/internals/phase3PluginExample.test.ts
+++ b/src/data/internals/phase3PluginExample.test.ts
@@ -27,7 +27,7 @@
  * regression without adding a meaningless feature.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { createElement, type JSX } from 'react'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
@@ -40,7 +40,7 @@ import {
   type PropertyEditor,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '../kernelDataExtension'
 import {
   mutatorsFacet,
@@ -99,12 +99,16 @@ const tasksPluginExtension = [
 
 // ──── Test setup ────
 
+let sharedDb: TestDb
 let h: TestDb
 let cache: BlockCache
 let repo: Repo
 
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -127,7 +131,7 @@ beforeEach(async () => {
   )
 })
 
-afterEach(async () => { await h.cleanup() })
+afterEach(async () => { repo.stopSyncObserver() })
 
 // ──── End-to-end §12.1 wiring ────
 

--- a/src/data/internals/processorRunner.test.ts
+++ b/src/data/internals/processorRunner.test.ts
@@ -23,7 +23,7 @@
  *     does not fire for that tx
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ChangeScope,
   codecs,
@@ -32,7 +32,7 @@ import {
 } from '@/data/api'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 import { postCommitProcessorsFacet, propertySchemasFacet } from '../facets'
 
@@ -44,7 +44,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -59,9 +60,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 interface Calls<S = unknown> {
   events: Array<{txId: string; changedRowIds: string[]; scheduledArgs?: S}>

--- a/src/data/internals/sameTxRunner.test.ts
+++ b/src/data/internals/sameTxRunner.test.ts
@@ -24,14 +24,14 @@
  *     NOT re-fire itself (single pass)
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   ChangeScope,
   ProcessorRejection,
   type AnySameTxProcessor,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 const WS = 'ws-1'
@@ -42,7 +42,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -57,9 +58,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 interface FireLog {
   events: Array<{name: string; ids: string[]; afterContents: Array<string | null>}>

--- a/src/data/internals/txEngine.test.ts
+++ b/src/data/internals/txEngine.test.ts
@@ -17,7 +17,7 @@
  * snapshots → cache.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   ChangeScope,
   CycleError,
@@ -41,7 +41,7 @@ import {
 } from '@/data/api'
 import { aliasesProp } from '@/data/internals/coreProperties'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 // ──── Test fixtures ────
@@ -86,7 +86,9 @@ interface Harness {
 }
 
 const setup = async (overrides?: {isReadOnly?: boolean}): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   const tick = () => ++timeCursor
@@ -120,9 +122,14 @@ const setup = async (overrides?: {isReadOnly?: boolean}): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's default sync observer so its db.onChange
+// subscription doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 // ──── tx.create ────
 
@@ -762,7 +769,9 @@ describe('read-only mode', () => {
       const crud = await ro.psCrud()
       expect(crud.map(c => JSON.parse(c.data).id).sort()).toEqual(['prefs-1', 'ui-1'])
     } finally {
-      await ro.h.cleanup()
+      // ro shares the file-level DB now — just drop its observer; the DB is
+      // closed once in afterAll. (The next test's beforeEach resets the data.)
+      ro.repo.stopSyncObserver()
     }
   })
 })

--- a/src/data/internals/typeSystem.test.ts
+++ b/src/data/internals/typeSystem.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
   BlockNotFoundForTypeError,
@@ -11,13 +11,16 @@ import {
   defineSameTxProcessor,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { sameTxProcessorsFacet, typesFacet } from '@/data/facets'
 import { addedTypes, getBlockTypes, typesProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
 
+let sharedDb: TestDb
 let h: TestDb
 let repo: Repo
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 const createBlock = async (id: string, properties: Record<string, unknown> = {}) => {
   await repo.tx(async tx => {
@@ -32,7 +35,8 @@ const createBlock = async (id: string, properties: Record<string, unknown> = {})
 }
 
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   repo = new Repo({
@@ -47,9 +51,7 @@ beforeEach(async () => {
   })
 })
 
-afterEach(async () => {
-  await h.cleanup()
-})
+afterEach(() => { repo.stopSyncObserver() })
 
 describe('Repo type membership orchestration', () => {
   it('adds a type, encodes initial values, and runs a type-add same-tx processor only on the first transition', async () => {

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
   ChangeScope,
@@ -8,7 +8,7 @@ import {
   type BlockReference,
 } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
 import { typesProp } from '@/data/properties'
 import { propertySchemasFacet } from '../facets'
@@ -66,7 +66,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -92,9 +94,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer (some tests start it explicitly)
+// so its db.onChange subscription doesn't leak onto the shared DB.
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/data/targets.test.ts
+++ b/src/data/targets.test.ts
@@ -22,7 +22,7 @@
  * since the daily-notes plugin owns those helpers now.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   ChangeScope,
   DeterministicIdCrossWorkspaceError,
@@ -31,7 +31,7 @@ import { aliasesProp } from '@/data/internals/coreProperties'
 import { typesProp } from '@/data/properties'
 import { PAGE_TYPE } from '@/data/blockTypes'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from './repo'
 import {
   aliasSeatSeed,
@@ -48,7 +48,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -63,9 +65,12 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('computeAliasSeatId', () => {
   it('is stable for a given (workspaceId, alias)', () => {

--- a/src/data/test/blocksSynced.test.ts
+++ b/src/data/test/blocksSynced.test.ts
@@ -19,9 +19,9 @@
  *      trigger is the change-capture queue the observer drains.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import type { BlockData } from '@/data/api'
 
 interface ColumnInfo {
@@ -47,9 +47,12 @@ const fixture: BlockData = {
   deleted: false,
 }
 
+let sharedDb: TestDb
 let env: TestDb
-beforeEach(async () => { env = await createTestDb() })
-afterEach(async () => { await env.cleanup() })
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+// Reuse one DB across the file; reset (not reopen) per test.
+beforeEach(async () => { await resetTestDb(sharedDb.db); env = sharedDb })
 
 describe('blocks_synced staging table', () => {
   it('mirrors the blocks column shape exactly (name + type + nullability)', async () => {

--- a/src/data/test/blocksSyncedChanges.test.ts
+++ b/src/data/test/blocksSyncedChanges.test.ts
@@ -19,9 +19,9 @@
  *      DELETE+INSERT) appends 'delete' then a higher-seq 'upsert' that wins.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import type { BlockData } from '@/data/api'
 
 const data = (o: Partial<BlockData> = {}): BlockData => ({
@@ -30,9 +30,12 @@ const data = (o: Partial<BlockData> = {}): BlockData => ({
   updatedBy: 'u', deleted: false, ...o,
 })
 
+let sharedDb: TestDb
 let env: TestDb
-beforeEach(async () => { env = await createTestDb() })
-afterEach(async () => { await env.cleanup() })
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+// Reuse one DB across the file; reset (not reopen) per test.
+beforeEach(async () => { await resetTestDb(sharedDb.db); env = sharedDb })
 
 const put = (d: BlockData) => env.db.execute(BLOCKS_SYNCED_RAW_TABLE.put.sql, blockToRowParams(d))
 const del = (id: string) => env.db.execute(BLOCKS_SYNCED_RAW_TABLE.delete.sql, [id])

--- a/src/data/test/createTestDb.ts
+++ b/src/data/test/createTestDb.ts
@@ -44,6 +44,7 @@ import {
 } from '@/data/blockSchema'
 import {
   CLIENT_SCHEMA_STATEMENTS,
+  REPROJECT_REF_MARKER_PREFIX,
   backfillBlockAliasesIfEmpty,
   backfillBlocksFtsIfEmpty,
   backfillBlockTypesIfEmpty,
@@ -295,6 +296,14 @@ export const resetTestDb = async (db: PowerSyncDatabase): Promise<void> => {
     )
     for (const table of existing(RESET_CONTENT_TABLES)) await tx.execute(`DELETE FROM ${table}`)
     for (const table of existing(RESET_AUDIT_TABLES)) await tx.execute(`DELETE FROM ${table}`)
+    // Clear per-property reprojection markers so a schema-swap reprojection
+    // is re-detected per test — a freshly-opened harness has none of these
+    // (only the backfill/ANALYZE markers from template init, which we keep).
+    if (present.has('client_schema_state')) {
+      await tx.execute(
+        `DELETE FROM client_schema_state WHERE key LIKE '${REPROJECT_REF_MARKER_PREFIX}%'`,
+      )
+    }
     // Restart AUTOINCREMENT counters (e.g. ps_crud.id) so per-test row-id
     // expectations stay stable.
     if (present.has('sqlite_sequence')) await tx.execute('DELETE FROM sqlite_sequence')

--- a/src/data/test/createTestDb.ts
+++ b/src/data/test/createTestDb.ts
@@ -243,3 +243,60 @@ export const createTestDb = async (): Promise<TestDb> => {
     },
   }
 }
+
+// Data tables cleared by `resetTestDb`, ordered so content/side tables go
+// first (their AFTER-DELETE triggers re-touch the side indexes + audit
+// tables) and the audit/queue tables go last so trigger-written rows are
+// swept too. NOT cleared: `client_schema_state` (backfill markers / schema
+// state), `tx_context` (a singleton row — reset via UPDATE), the FTS shadow
+// tables (`blocks_fts_*` content/idx/etc. — managed by the `blocks_fts`
+// virtual table; touching them directly corrupts the index), and PowerSync's
+// own internals (`ps_buckets`, `ps_oplog`, …) except the upload queue.
+const RESET_CONTENT_TABLES = [
+  'blocks',
+  'blocks_synced',
+  'blocks_synced_changes',
+  'workspaces',
+  'workspace_members',
+  'block_aliases',
+  'block_references',
+  'block_types',
+  'blocks_fts', // virtual FTS table — DELETE clears its shadow tables safely
+  'blocks_fts_rowids',
+] as const
+const RESET_AUDIT_TABLES = ['row_events', 'command_events', 'ps_crud', 'ps_crud_rejected'] as const
+
+/**
+ * Truncate all test data from a `createTestDb` database and reset
+ * `tx_context`, returning it to the same empty state a freshly-opened
+ * harness has — ~100x cheaper than opening a new PowerSyncDatabase
+ * (~2.5ms vs ~260ms). Use with one `beforeAll` open + `afterAll` close and
+ * a `beforeEach(() => resetTestDb(h.db))`, building a fresh `Repo` per test
+ * for registry/cache/handle-store isolation.
+ *
+ * Only clears tables that actually exist, so it tolerates schema variants
+ * (e.g. a plugin's local table that isn't present in a given harness). If a
+ * test installs its OWN extra data table, clear it explicitly in the test.
+ */
+export const resetTestDb = async (db: PowerSyncDatabase): Promise<void> => {
+  const present = new Set(
+    (await db.getAll<{name: string}>(
+      "SELECT name FROM sqlite_master WHERE type='table'",
+    )).map(row => row.name),
+  )
+  const existing = (names: readonly string[]) => names.filter(name => present.has(name))
+
+  await db.writeTransaction(async tx => {
+    // Reset routing context first so the content deletes below are treated
+    // as non-local (no upload-routing into ps_crud) regardless of what the
+    // previous test left behind.
+    await tx.execute(
+      'UPDATE tx_context SET tx_id = NULL, tx_seq = NULL, user_id = NULL, scope = NULL, source = NULL',
+    )
+    for (const table of existing(RESET_CONTENT_TABLES)) await tx.execute(`DELETE FROM ${table}`)
+    for (const table of existing(RESET_AUDIT_TABLES)) await tx.execute(`DELETE FROM ${table}`)
+    // Restart AUTOINCREMENT counters (e.g. ps_crud.id) so per-test row-id
+    // expectations stay stable.
+    if (present.has('sqlite_sequence')) await tx.execute('DELETE FROM sqlite_sequence')
+  })
+}

--- a/src/data/test/focusBlock.test.ts
+++ b/src/data/test/focusBlock.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { focusBlock, focusedBlockLocationProp, isEditingProp, topLevelBlockIdProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 
 const WS = 'ws-1'
 const USER = {id: 'user-1'}
@@ -17,7 +17,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   let now = 1700_000_000_000
   let txSeq = 0
   const repo = new Repo({
@@ -48,14 +49,17 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   env = await setup()
 })
 
 afterEach(async () => {
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 describe('focusBlock', () => {

--- a/src/data/test/globalState.test.ts
+++ b/src/data/test/globalState.test.ts
@@ -22,7 +22,7 @@
  *   - resetBlockSelection: no-op when already empty, clears when set
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   ChangeScope,
   codecs,
@@ -35,7 +35,7 @@ import { BlockCache } from '@/data/blockCache'
 import { sameTxProcessorsFacet, typesFacet } from '@/data/facets'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { addedTypes } from '@/data/properties'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { Repo } from '../repo'
 import { PAGE_TYPE, USER_TYPE } from '@/data/blockTypes'
@@ -66,11 +66,15 @@ interface Harness {
   repo: Repo
 }
 
+// Builds a harness on the shared, already-reset DB. Called from beforeEach
+// AND mid-test (some tests build a second Repo on the SAME data to bypass the
+// per-Repo memoize cache), so it must NOT reset — reset lives in beforeEach.
+// `h.cleanup` disposes this harness's sync observer without closing the shared
+// DB, so every `*.h.cleanup()` call (main or secondary) stays correct.
 const setup = async (types: readonly TypeContribution[] = []): Promise<Harness> => {
-  const h = await createTestDb()
   const cache = new BlockCache()
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: USER,
     registerKernelProcessors: false,
@@ -82,7 +86,7 @@ const setup = async (types: readonly TypeContribution[] = []): Promise<Harness> 
       types.map(type => typesFacet.of(type, {source: 'test'})),
     ]))
   }
-  return {h, repo}
+  return {h: {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}, repo}
 }
 
 const registerTypes = (repo: Repo, types: readonly TypeContribution[]): void => {
@@ -92,8 +96,11 @@ const registerTypes = (repo: Repo, types: readonly TypeContribution[]): void => 
   ]))
 }
 
+let sharedDb: TestDb
 let env: Harness
-beforeEach(async () => { env = await setup() })
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+beforeEach(async () => { await resetTestDb(sharedDb.db); env = await setup() })
 afterEach(async () => { await env.h.cleanup() })
 
 describe('getUserBlock', () => {

--- a/src/data/test/kernelPage.test.ts
+++ b/src/data/test/kernelPage.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope, defineBlockType } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
@@ -13,7 +13,7 @@ import {
   kernelPageBlockId,
 } from '@/data/kernelPage'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 
 const WS = 'ws-kernel-page'
 const FOO_PAGE_TYPE = 'panel:foo'
@@ -25,7 +25,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -42,9 +43,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('getOrCreateKernelPage', () => {
   it('creates a deterministic page tagged with PAGE_TYPE plus the marker type', async () => {

--- a/src/data/test/propertiesPage.test.ts
+++ b/src/data/test/propertiesPage.test.ts
@@ -1,13 +1,13 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { PAGE_TYPE, PROPERTIES_PAGE_TYPE } from '@/data/blockTypes'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { getOrCreatePropertiesPage } from '@/data/propertiesPage'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 
 const WS = 'ws-properties-page'
 
@@ -17,7 +17,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -28,9 +29,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('getOrCreatePropertiesPage', () => {
   it('creates the singleton as both a page and properties page', async () => {

--- a/src/data/test/repoHandles.test.ts
+++ b/src/data/test/repoHandles.test.ts
@@ -21,25 +21,31 @@
  *     hand to verify the dep-matching contract.)
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 import type { Dependency } from '../internals/handleStore'
 
 interface Harness { h: TestDb; cache: BlockCache; repo: Repo }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   const repo = new Repo({db: h.db, cache, user: {id: 'u1'}})
   return {h, cache, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (
   id: string,

--- a/src/data/test/repoLifecycle.test.ts
+++ b/src/data/test/repoLifecycle.test.ts
@@ -19,10 +19,10 @@
  * contract).
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BlockCache } from '@/data/blockCache'
 import { ChangeScope } from '@/data/api'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 interface Harness {
@@ -30,19 +30,25 @@ interface Harness {
   repo: Repo
 }
 
+// Builds a harness on the shared, already-reset DB. Called from beforeEach
+// AND mid-test (some tests build a second Repo to prove per-Repo identity), so
+// it must NOT reset — reset lives in beforeEach. `h.cleanup` disposes this
+// harness's observer without closing the shared DB.
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
   const cache = new BlockCache()
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
   })
-  return {h, repo}
+  return {h: {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
-beforeEach(async () => { env = await setup() })
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+beforeEach(async () => { await resetTestDb(sharedDb.db); env = await setup() })
 afterEach(async () => { await env.h.cleanup() })
 
 describe('repo.block(id) identity stability', () => {

--- a/src/data/test/repoUndo.test.ts
+++ b/src/data/test/repoUndo.test.ts
@@ -20,10 +20,10 @@
  *     by checking ps_crud row count grew after the undo replay
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope, ReadOnlyError } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../repo'
 
 const WS = 'ws-1'
@@ -34,7 +34,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -89,9 +91,12 @@ const rowCount = async (repo: Repo, table: string): Promise<number> => {
   return row.n
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('repo.undo / redo on tx.update (setContent)', () => {
   it('reverts content on undo and re-applies on redo', async () => {

--- a/src/data/test/resetTestDb.test.ts
+++ b/src/data/test/resetTestDb.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { ChangeScope } from '@/data/api'
+import { BlockCache } from '@/data/blockCache'
+import { Repo } from '@/data/repo'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
+
+const WS = 'ws-1'
+const count = async (h: TestDb, table: string): Promise<number> =>
+  (await h.db.get<{n: number}>(`SELECT COUNT(*) AS n FROM ${table}`)).n
+
+describe('resetTestDb', () => {
+  let h: TestDb
+  beforeAll(async () => { h = await createTestDb() })
+  afterAll(async () => { await h.cleanup() })
+  beforeEach(async () => { await resetTestDb(h.db) })
+
+  const seed = async (): Promise<Repo> => {
+    const repo = new Repo({
+      db: h.db,
+      cache: new BlockCache(),
+      user: {id: 'u1'},
+      registerKernelProcessors: false,
+      startSyncObserver: false,
+    })
+    repo.setActiveWorkspaceId(WS)
+    await repo.tx(async tx => {
+      await tx.create({id: 'a', workspaceId: WS, parentId: null, orderKey: 'a0', content: 'Target page'})
+      await tx.create({id: 'b', workspaceId: WS, parentId: 'a', orderKey: 'a0', content: 'a child block'})
+    }, {scope: ChangeScope.BlockDefault})
+    return repo
+  }
+
+  it('leaves all data tables and tx_context empty after a reset', async () => {
+    await seed()
+    expect(await count(h, 'blocks')).toBeGreaterThan(0)
+    expect(await count(h, 'ps_crud')).toBeGreaterThan(0) // writes routed to the upload queue
+
+    await resetTestDb(h.db)
+
+    for (const table of ['blocks', 'blocks_synced', 'block_aliases', 'block_types',
+      'block_references', 'blocks_fts_rowids', 'row_events', 'command_events',
+      'ps_crud', 'ps_crud_rejected', 'workspaces', 'workspace_members']) {
+      expect(await count(h, table), `${table} should be empty`).toBe(0)
+    }
+    const ctx = await h.db.get<Record<string, unknown>>('SELECT * FROM tx_context')
+    expect(ctx).toMatchObject({tx_id: null, user_id: null, scope: null, source: null})
+    // FTS stays queryable (not corrupted by the reset) and is empty.
+    expect((await h.db.getAll('SELECT rowid FROM blocks_fts')).length).toBe(0)
+  })
+
+  it('isolates tests: a fresh Repo sees a clean slate, then creates + queries', async () => {
+    // Runs after the test above; the beforeEach reset must have wiped its rows.
+    expect(await count(h, 'blocks')).toBe(0)
+    const repo = await seed()
+    const tree = await repo.query.subtree({id: 'a'}).load()
+    expect(tree.map(b => b.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('restarts ps_crud autoincrement ids after reset', async () => {
+    await seed()
+    const firstId = (await h.db.get<{id: number}>('SELECT MIN(id) AS id FROM ps_crud')).id
+    await resetTestDb(h.db)
+    await seed()
+    const afterId = (await h.db.get<{id: number}>('SELECT MIN(id) AS id FROM ps_crud')).id
+    expect(afterId).toBe(firstId)
+  })
+})

--- a/src/data/test/typesPage.test.ts
+++ b/src/data/test/typesPage.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BlockCache } from '@/data/blockCache'
 import { PAGE_TYPE, TYPES_PAGE_TYPE } from '@/data/blockTypes'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { getOrCreateTypesPage, typesPageBlockId } from '@/data/typesPage'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 
 const WS = 'ws-types-page'
 
@@ -16,7 +16,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -27,9 +28,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('getOrCreateTypesPage', () => {
   it('creates the singleton as both a page and a Types page', async () => {

--- a/src/data/typeExtraction.test.ts
+++ b/src/data/typeExtraction.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { kernelPropertyUiExtension } from '@/components/propertyEditors/typesPropertyUi'
 import { kernelValuePresetsExtension } from '@/components/propertyEditors/kernelValuePresets'
@@ -34,7 +34,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -106,10 +108,14 @@ const createBlockWithRefs = async (
   return id
 }
 
+let sharedDb: TestDb
 let env: Harness
-afterEach(async () => {
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+afterEach(() => {
+  // Dispose the per-test services; the shared DB is closed once in afterAll.
+  // (Each test calls `env = await setup()`, which resets the DB first.)
   env.dispose()
-  await env.h.cleanup()
 })
 
 // ──── createTypeBlock ───────────────────────────────────────────────

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { createElement, type JSX } from 'react'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope, codecs, definePreset, defineProperty, type AnyValuePreset } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { kernelPropertyUiExtension } from '@/components/propertyEditors/typesPropertyUi'
 import { kernelValuePresetsExtension } from '@/components/propertyEditors/kernelValuePresets'
@@ -25,12 +25,14 @@ interface Harness {
 }
 
 const setup = async (extraPresets: readonly AnyValuePreset[] = []): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll); each test calls setup()
+  // inline, so reset here gives the per-test clean slate.
+  await resetTestDb(sharedDb.db)
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
     now: () => ++timeCursor,
@@ -48,10 +50,14 @@ const setup = async (extraPresets: readonly AnyValuePreset[] = []): Promise<Harn
   await getOrCreatePropertiesPage(repo, WS)
   const service = repo.userSchemas
   const dispose = service.start()
+  const h: TestDb = {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}
   return {h, repo, service, dispose}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 afterEach(async () => {
   env.dispose()
   await env.h.cleanup()

--- a/src/data/userTypesService.test.ts
+++ b/src/data/userTypesService.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { kernelPropertyUiExtension } from '@/components/propertyEditors/typesPropertyUi'
 import { kernelValuePresetsExtension } from '@/components/propertyEditors/kernelValuePresets'
@@ -29,7 +29,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -61,10 +62,13 @@ const setup = async (): Promise<Harness> => {
   return {h, repo, service, dispose}
 }
 
+let sharedDb: TestDb
 let env: Harness
-afterEach(async () => {
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+afterEach(() => {
+  // Dispose the per-test service; the shared DB closes once in afterAll.
   env.dispose()
-  await env.h.cleanup()
 })
 
 const waitForTypeRegistration = async (

--- a/src/extensions/test/useShortcutSurfaceActivations.test.tsx
+++ b/src/extensions/test/useShortcutSurfaceActivations.test.tsx
@@ -2,10 +2,10 @@
 
 import { Suspense } from 'react'
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { actionContextsFacet } from '@/extensions/core'
 import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet'
@@ -120,12 +120,16 @@ function ActiveNormalModeProbe() {
 }
 
 describe('useShortcutSurfaceActivations', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
   let runtime: FacetRuntime
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
 
   beforeEach(async () => {
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     let txSeq = 0
     repo = new Repo({
       db: h.db,
@@ -202,10 +206,10 @@ describe('useShortcutSurfaceActivations', () => {
     }, {scope: ChangeScope.BlockDefault, description: 'create shortcut surface fixture'})
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     cleanup()
+    repo.stopSyncObserver()
     testGlobals.repo = undefined
-    await h.cleanup()
   })
 
   it('moves block shortcut ownership when the active panel changes without changing focused location', async () => {

--- a/src/plugins/agent-runtime/test/commands.test.ts
+++ b/src/plugins/agent-runtime/test/commands.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BlockCache } from '@/data/blockCache'
 import { EXTENSION_TYPE, PAGE_TYPE } from '@/data/blockTypes'
 import { aliasesProp, extensionDescriptionProp, extensionNameProp, typesProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { staticDataExtensions } from '@/extensions/staticDataExtensions'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { __setCompileImplForTest } from '@/extensions/compileExtensionModule'
@@ -25,7 +25,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -43,9 +44,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo, context}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('agent runtime commands', () => {
   it('installs labelled extensions under a per-label container page', async () => {

--- a/src/plugins/alias/test/collisionMerge.test.ts
+++ b/src/plugins/alias/test/collisionMerge.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope, type BlockData } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { aliasesProp } from '@/data/internals/coreProperties'
 import { kernelDataExtension } from '@/data/kernelDataExtension.js'
@@ -20,7 +20,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -43,9 +44,14 @@ const setup = async (): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const aliasProperty = (aliases: readonly string[]) => ({
   [aliasesProp.name]: aliasesProp.codec.encode([...aliases]),

--- a/src/plugins/alias/test/collisionRejection.test.ts
+++ b/src/plugins/alias/test/collisionRejection.test.ts
@@ -18,10 +18,10 @@
  *     layer can surface it
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, ProcessorRejection } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { aliasesProp } from '@/data/internals/coreProperties'
 import { dailyNotesDataExtension } from '@/plugins/daily-notes'
@@ -40,7 +40,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -68,14 +69,17 @@ const setup = async (): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
   env = await setup()
   vi.useFakeTimers({shouldAdvanceTime: true})
 })
 afterEach(async () => {
   vi.useRealTimers()
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 const readAliases = async (id: string): Promise<string[]> => {

--- a/src/plugins/alias/test/syncProcessor.test.ts
+++ b/src/plugins/alias/test/syncProcessor.test.ts
@@ -13,10 +13,10 @@
  * and rolls back the whole user tx atomically.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { aliasesProp } from '@/data/internals/coreProperties'
 import { dailyNotesDataExtension } from '@/plugins/daily-notes'
@@ -33,7 +33,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -62,14 +63,17 @@ const setup = async (): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
   env = await setup()
   vi.useFakeTimers({shouldAdvanceTime: true})
 })
 afterEach(async () => {
   vi.useRealTimers()
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 const WS = 'ws-1'

--- a/src/plugins/app-intents/test/appIntents.test.ts
+++ b/src/plugins/app-intents/test/appIntents.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks'
 import { editorSelection } from '@/data/properties'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
@@ -35,7 +35,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   let id = 0
   const repo = new Repo({
     db: h.db,
@@ -60,7 +61,10 @@ const setLocationSearch = (search: string): void => {
   window.history.replaceState(null, '', `/${search}`)
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   __resetLayoutSessionIdForTesting()
@@ -74,7 +78,7 @@ beforeEach(async () => {
 afterEach(async () => {
   vi.useRealTimers()
   setLocationSearch('')
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 const seedLandingLayout = async () => {

--- a/src/plugins/backlinks/test/query.test.ts
+++ b/src/plugins/backlinks/test/query.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, type BlockReference } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
 import { Repo } from '@/data/repo'
 import type { Dependency } from '@/data/internals/handleStore'
@@ -53,7 +53,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -72,9 +74,12 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/plugins/block-tagging/test/appendTag.test.ts
+++ b/src/plugins/block-tagging/test/appendTag.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import { ChangeScope } from '@/data/api'
 import { appendTagToBlocks, appendTagToContent } from '../appendTag.ts'
@@ -55,11 +55,15 @@ describe('appendTagToContent', () => {
 })
 
 describe('appendTagToBlocks', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
 
   beforeEach(async () => {
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     repo = new Repo({
       db: h.db,
       cache: new BlockCache(),
@@ -69,9 +73,7 @@ describe('appendTagToBlocks', () => {
     repo.setFacetRuntime(resolveFacetRuntimeSync([kernelDataExtension]))
   })
 
-  afterEach(async () => {
-    await h.cleanup()
-  })
+  afterEach(() => { repo.stopSyncObserver() })
 
   const seed = async (id: string, content: string): Promise<void> => {
     await repo.tx(tx => tx.create({

--- a/src/plugins/daily-notes/test/actions.test.ts
+++ b/src/plugins/daily-notes/test/actions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
@@ -12,7 +12,7 @@ import {
   peekFocusedBlockLocation,
   topLevelBlockIdProp,
 } from '@/data/properties'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
@@ -42,7 +42,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   let id = 0
   const repo = new Repo({
     db: h.db,
@@ -59,7 +60,10 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   __resetLayoutSessionIdForTesting()
@@ -70,7 +74,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.useRealTimers()
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 describe('dailyNotesActions', () => {

--- a/src/plugins/daily-notes/test/dailyNotes.test.ts
+++ b/src/plugins/daily-notes/test/dailyNotes.test.ts
@@ -13,7 +13,7 @@
  * tx.restore / tx.move) and `createTestDb` harness.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { aliasesProp } from '@/data/properties'
 import { PAGE_TYPE } from '@/data/blockTypes'
@@ -23,7 +23,7 @@ import {
 } from '@/plugins/daily-notes/localSchema.js'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
@@ -47,7 +47,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -65,9 +67,12 @@ const setup = async (): Promise<Harness> => {
   return {h, cache, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('deterministic ids', () => {
   it('journalBlockId is stable for a given workspace', () => {

--- a/src/plugins/daily-notes/test/spreadBlockDates.test.ts
+++ b/src/plugins/daily-notes/test/spreadBlockDates.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet.js'
 import {
   SRS_SM25_TYPE,
@@ -26,12 +26,16 @@ import {
 
 const WS = 'ws-1'
 
+let sharedDb: TestDb
 let h: TestDb
 let repo: Repo
 let runtime: FacetRuntime
 
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -57,7 +61,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await h.cleanup()
+  repo.stopSyncObserver()
 })
 
 const seedSrsBlock = async (id: string): Promise<void> => {

--- a/src/plugins/daily-notes/test/targetIntegration.test.ts
+++ b/src/plugins/daily-notes/test/targetIntegration.test.ts
@@ -14,14 +14,14 @@
  *     typesProp; shares its namespace with `dailyNoteBlockId`.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { aliasesProp } from '@/data/internals/coreProperties'
 import { typesProp } from '@/data/properties'
 import { PAGE_TYPE } from '@/data/blockTypes'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
@@ -42,7 +42,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -61,9 +62,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('dailyNoteBlockId', () => {
   it('is stable for a given (workspaceId, iso)', () => {

--- a/src/plugins/find-replace/test/dataExtension.test.ts
+++ b/src/plugins/find-replace/test/dataExtension.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope, type BlockData } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension.js'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import {
   FIND_REPLACE_APPLY_CONTENT_REPLACE_MUTATOR,
@@ -25,7 +25,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -44,9 +45,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/plugins/geo/test/createOrFindPlace.test.ts
+++ b/src/plugins/geo/test/createOrFindPlace.test.ts
@@ -1,13 +1,13 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { BlockCache } from '@/data/blockCache'
 import { PAGE_TYPE } from '@/data/blockTypes'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { PLACE_TYPE } from '../blockTypes'
 import { geoDataExtension } from '../dataExtension'
 import { createOrFindPlace, placeMachineAlias } from '../createOrFindPlace'
@@ -31,7 +31,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -43,9 +44,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const DANDELION = {
   name: 'Dandelion Chocolate',

--- a/src/plugins/geo/test/locationsPage.test.ts
+++ b/src/plugins/geo/test/locationsPage.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
@@ -8,7 +8,7 @@ import { PAGE_TYPE } from '@/data/blockTypes'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { MAP_TYPE } from '../blockTypes'
 import { geoDataExtension } from '../dataExtension'
 import { getOrCreateLocationsPage, locationsPageBlockId } from '../locationsPage'
@@ -21,7 +21,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -36,9 +37,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('getOrCreateLocationsPage', () => {
   it('creates the Locations page with PAGE_TYPE + MAP_TYPE on first call', async () => {

--- a/src/plugins/geo/test/query.test.ts
+++ b/src/plugins/geo/test/query.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { geoDataExtension } from '../dataExtension'
 import { createOrFindPlace } from '../createOrFindPlace'
 import { locationProp, placeLatProp } from '../properties'
@@ -20,7 +20,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -32,9 +33,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const createBlock = async (
   id: string,

--- a/src/plugins/grouped-backlinks/test/query.test.ts
+++ b/src/plugins/grouped-backlinks/test/query.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, type BlockReference } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { resolveFacetRuntimeSync, type AppExtension } from '@/extensions/facet.js'
 import { kernelDataExtension } from '@/data/kernelDataExtension.js'
@@ -44,7 +44,9 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file, reset between tests; fresh Repo per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -64,9 +66,12 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/plugins/left-sidebar/test/actions.test.ts
+++ b/src/plugins/left-sidebar/test/actions.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import {
   __resetLayoutSessionIdForTesting,
@@ -22,7 +22,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   let id = 0
   const repo = new Repo({
     db: h.db,
@@ -35,7 +36,10 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   __resetLayoutSessionIdForTesting()
@@ -43,7 +47,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 describe('left sidebar actions', () => {

--- a/src/plugins/left-sidebar/test/shortcuts.test.ts
+++ b/src/plugins/left-sidebar/test/shortcuts.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { getUserBlock } from '@/data/stateBlocks.js'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { journalBlockId } from '@/plugins/daily-notes'
 import {
@@ -33,7 +33,8 @@ const createRepo = (h: TestDb): Repo => {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   return {h, repo: createRepo(h)}
 }
 
@@ -50,9 +51,14 @@ const countLiveByContent = async (h: TestDb, parentId: string, content: string):
   return rows[0]?.count ?? 0
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 describe('deterministic ids', () => {
   it('shortcutsBlockId is stable for a given user-page id', () => {

--- a/src/plugins/quick-find/test/recents.test.ts
+++ b/src/plugins/quick-find/test/recents.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import {
   RECENT_BLOCKS_LIMIT,
@@ -20,7 +20,8 @@ interface Harness {
 }
 
 const setup = async (initialIds: string[]): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -44,8 +45,11 @@ const setup = async (initialIds: string[]): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
-afterEach(async () => { await env?.h.cleanup() })
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+afterEach(() => { env?.repo.stopSyncObserver() })
 
 const flush = async (repo: Repo) => {
   await repo.tx(async () => {}, {scope: ChangeScope.UiState})

--- a/src/plugins/references/test/mergeRetargetProcessor.test.ts
+++ b/src/plugins/references/test/mergeRetargetProcessor.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope, normalizeReferences, type BlockData } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension.js'
 import { Repo } from '@/data/repo'
 import { aliasesProp } from '@/data/internals/coreProperties'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import { aliasDataExtension } from '@/plugins/alias/dataExtension.js'
 import { ALIAS_COLLISION_MERGE_MUTATOR } from '@/plugins/alias/collisionMerge.ts'
@@ -21,7 +21,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -45,9 +46,14 @@ const setup = async (): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const aliasProperty = (aliases: readonly string[]) => ({
   [aliasesProp.name]: aliasesProp.codec.encode([...aliases]),

--- a/src/plugins/references/test/referencesProcessor.test.ts
+++ b/src/plugins/references/test/referencesProcessor.test.ts
@@ -21,10 +21,10 @@
  *   - command_events.scope='block-default:references' on processor txs
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, codecs, defineProperty, type BlockReference } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { computeAliasSeatId } from '@/data/targets'
 import { dailyNoteBlockId, dailyNotesDataExtension } from '@/plugins/daily-notes'
@@ -49,12 +49,15 @@ interface Harness {
 const setup = async (
   extraExtensions: readonly AppExtension[] = [],
 ): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test. Called
+  // again from a nested beforeEach (with a different schema extension); the
+  // reset is idempotent and h.cleanup disposes the prior Repo's observer.
+  await resetTestDb(sharedDb.db)
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
     now: () => ++timeCursor,
@@ -67,6 +70,7 @@ const setup = async (
     referencesDataExtension,
     ...extraExtensions,
   ]))
+  const h: TestDb = {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}
   return {
     h,
     cache,
@@ -79,7 +83,10 @@ const setup = async (
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
   env = await setup()
   vi.useFakeTimers({shouldAdvanceTime: true})

--- a/src/plugins/references/test/renameProcessor.test.ts
+++ b/src/plugins/references/test/renameProcessor.test.ts
@@ -12,10 +12,10 @@
  *   - R4/R7 (anything else):       `[[α]] → [α](((target-id)))`
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { aliasesProp } from '@/data/internals/coreProperties'
 import { dailyNotesDataExtension } from '@/plugins/daily-notes'
@@ -32,12 +32,13 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test.
+  await resetTestDb(sharedDb.db)
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
     now: () => ++timeCursor,
@@ -50,6 +51,8 @@ const setup = async (): Promise<Harness> => {
     referencesDataExtension,
     aliasDataExtension,
   ]))
+  // h.cleanup disposes this Repo's observer (not the shared DB).
+  const h: TestDb = {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}
   return {
     h,
     cache,
@@ -61,7 +64,10 @@ const setup = async (): Promise<Harness> => {
   }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
   env = await setup()
   vi.useFakeTimers({shouldAdvanceTime: true})

--- a/src/plugins/roam-import/test/import.test.ts
+++ b/src/plugins/roam-import/test/import.test.ts
@@ -20,12 +20,12 @@
  * production.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { getOrCreatePropertiesPage } from '@/data/propertiesPage'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../../../data/repo'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import {
@@ -64,12 +64,15 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test; the
+  // returned h.cleanup disposes this Repo's observer rather than closing the
+  // shared DB, so the existing afterEach stays correct.
+  await resetTestDb(sharedDb.db)
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: USER_ID},
     now: () => ++timeCursor,
@@ -88,10 +91,14 @@ const setup = async (): Promise<Harness> => {
     srsReschedulingDataExtension,
   ]))
   await getOrCreatePropertiesPage(repo, WORKSPACE)
+  const h: TestDb = {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
 afterEach(async () => { await env.h.cleanup() })
 

--- a/src/plugins/roam-import/test/schemaReconciliation.test.ts
+++ b/src/plugins/roam-import/test/schemaReconciliation.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope, type BlockData } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { kernelPropertyUiExtension } from '@/components/propertyEditors/typesPropertyUi'
 import { kernelValuePresetsExtension } from '@/components/propertyEditors/kernelValuePresets'
@@ -26,12 +26,13 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test.
+  await resetTestDb(sharedDb.db)
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
     now: () => ++timeCursor,
@@ -47,10 +48,14 @@ const setup = async (): Promise<Harness> => {
   ]))
   await getOrCreatePropertiesPage(repo, WS)
   const dispose = repo.userSchemas.start()
+  const h: TestDb = {db: sharedDb.db, cleanup: async () => { repo.stopSyncObserver() }}
   return {h, repo, dispose}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
 afterEach(async () => {
   env.dispose()

--- a/src/plugins/spatial-navigation/test/PanelFocusRecovery.test.tsx
+++ b/src/plugins/spatial-navigation/test/PanelFocusRecovery.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { BlockCache } from '@/data/blockCache'
 import { ChangeScope, type User } from '@/data/api'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import {
   focusedBlockLocationProp,
   peekFocusedBlockLocation,
@@ -23,7 +23,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -79,7 +80,10 @@ const setFocused = async (blockId: string, renderScopeId = `i-${blockId}`): Prom
   await env.repo.block(PANEL_ID).set(focusedBlockLocationProp, focusedLocation(blockId, renderScopeId))
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   __resetSpatialNavigationForTesting()
@@ -105,7 +109,7 @@ afterEach(async () => {
   cleanup()
   __resetSpatialNavigationForTesting()
   document.body.innerHTML = ''
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 describe('PanelFocusRecovery', () => {

--- a/src/plugins/spatial-navigation/test/actions.test.ts
+++ b/src/plugins/spatial-navigation/test/actions.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { BlockCache } from '@/data/blockCache.js'
 import { ChangeScope, type User } from '@/data/api'
 import { Repo } from '@/data/repo.js'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb.js'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb.js'
 import {
   focusBlock,
   focusedBlockLocationProp,
@@ -30,7 +30,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -104,7 +105,10 @@ const decorateAction = <T extends typeof ActionContextTypes.NORMAL_MODE | typeof
   return decorator.decorate(action as ActionConfig) as ActionConfig<T>
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   env = await setup()
@@ -113,7 +117,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   document.body.innerHTML = ''
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 describe('spatial navigation selection actions', () => {

--- a/src/plugins/srs-rescheduling/test/actions.test.ts
+++ b/src/plugins/srs-rescheduling/test/actions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { dailyNoteBlockId } from '@/plugins/daily-notes'
@@ -8,7 +8,7 @@ import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { dailyNotesDataExtension } from '@/plugins/daily-notes'
 import { typesProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import {
   formatRescheduleToastMessage,
@@ -29,11 +29,15 @@ import {
 const WORKSPACE = 'ws-1'
 const USER = 'user-1'
 
+let sharedDb: TestDb
 let h: TestDb
 let repo: Repo
 
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   let now = 1700_000_000_000
   let id = 0
   repo = new Repo({
@@ -54,7 +58,7 @@ beforeEach(async () => {
 afterEach(async () => {
   vi.useRealTimers()
   vi.restoreAllMocks()
-  await h.cleanup()
+  repo.stopSyncObserver()
 })
 
 describe('rescheduleBlock', () => {

--- a/src/plugins/srs-rescheduling/test/moveSrsState.test.ts
+++ b/src/plugins/srs-rescheduling/test/moveSrsState.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope, codecs, defineProperty } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { propertySchemasFacet } from '@/data/facets.js'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import { dailyNotesDataExtension } from '@/plugins/daily-notes'
 import { moveSrsState } from '../moveSrsState.ts'
@@ -91,11 +91,15 @@ const seedPlainBlock = async (
 }
 
 describe('moveSrsState', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
 
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
   beforeEach(async () => {
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     let txSeq = 0
     repo = new Repo({
       db: h.db,
@@ -115,7 +119,7 @@ describe('moveSrsState', () => {
   })
 
   afterEach(async () => {
-    await h.cleanup()
+    repo.stopSyncObserver()
   })
 
   const loadProps = async (id: string) => {

--- a/src/plugins/srs-rescheduling/test/rescheduleDecorator.test.ts
+++ b/src/plugins/srs-rescheduling/test/rescheduleDecorator.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { actionsFacet } from '@/extensions/core.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import { typesProp } from '@/data/properties.js'
@@ -24,6 +24,7 @@ import {
 } from '../index.ts'
 
 const WS = 'ws-1'
+let sharedDb: TestDb
 let h: TestDb
 let repo: Repo
 
@@ -44,8 +45,11 @@ const findRescheduleAction = (runtime: ReturnType<typeof setupRuntime>) =>
     action.context === ActionContextTypes.NORMAL_MODE,
   ) as ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
 
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   repo = new Repo({
     db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
     registerKernelProcessors: false,
@@ -53,7 +57,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await h.cleanup()
+  repo.stopSyncObserver()
 })
 
 describe('reschedule action with SRS decorator', () => {

--- a/src/plugins/srs-rescheduling/test/srsBlockDateAdapter.test.ts
+++ b/src/plugins/srs-rescheduling/test/srsBlockDateAdapter.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import { typesProp } from '@/data/properties.js'
 import {
@@ -25,6 +25,7 @@ import {
 
 const WS = 'ws-1'
 
+let sharedDb: TestDb
 let h: TestDb
 let repo: Repo
 
@@ -39,8 +40,11 @@ const setupRuntime = () => {
   return runtime
 }
 
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   repo = new Repo({
     db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
     registerKernelProcessors: false,
@@ -49,7 +53,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await h.cleanup()
+  repo.stopSyncObserver()
 })
 
 describe('srsBlockDateAdapter', () => {

--- a/src/plugins/srs-review/test/dueCards.integration.test.ts
+++ b/src/plugins/srs-review/test/dueCards.integration.test.ts
@@ -6,11 +6,11 @@
 // excluded — the bug lived in the query engine's three-valued handling
 // of `exclude`, not in the query we build. These tests run the actual
 // query so that regression stays caught.
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope, type BlockReference } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { typesProp } from '@/data/properties'
 import { propertySchemasFacet, typesFacet } from '@/data/facets'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
@@ -30,7 +30,8 @@ const NOW = new Date('2026-06-02T12:00:00')
 interface Harness { h: TestDb; repo: Repo }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -54,9 +55,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
+++ b/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import type { Block } from '@/data/block'
 import { actionDecoratorsFacet, actionsFacet } from '@/extensions/core'
@@ -72,14 +72,18 @@ const runEvent = (
   })
 
 describe('SwipeActionMenu', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
   let runtime: FacetRuntime
 
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
   beforeEach(async () => {
     vi.stubGlobal('ResizeObserver', TestResizeObserver)
 
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     let txSeq = 0
     repo = new Repo({
       db: h.db,
@@ -133,7 +137,7 @@ describe('SwipeActionMenu', () => {
     cleanup()
     vi.unstubAllGlobals()
     uiStateBlockRef.current = undefined
-    await h.cleanup()
+    repo.stopSyncObserver()
   })
 
   const renderMenu = () =>

--- a/src/plugins/todo/test/actions.test.ts
+++ b/src/plugins/todo/test/actions.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { typesProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { SWIPE_RIGHT_BLOCK_ACTION_ID } from '@/plugins/swipe-quick-actions'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types'
@@ -14,11 +14,15 @@ import { cycleTodoState, todoActions } from '../actions'
 import { todoDataExtension } from '../dataExtension'
 import { statusProp, TODO_TYPE } from '../schema'
 
+let sharedDb: TestDb
 let h: TestDb
 let repo: Repo
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
-  h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  h = sharedDb
   let now = 1700_000_000_000
   let id = 0
   repo = new Repo({
@@ -42,9 +46,7 @@ beforeEach(async () => {
   }), {scope: ChangeScope.BlockDefault, description: 'create block'})
 })
 
-afterEach(async () => {
-  await h.cleanup()
-})
+afterEach(() => { repo.stopSyncObserver() })
 
 describe('cycleTodoState', () => {
   it('rotates not todo -> open -> done -> not todo', async () => {

--- a/src/shortcuts/defaultShortcuts.test.ts
+++ b/src/shortcuts/defaultShortcuts.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { waitFor } from '@testing-library/react'
 import type { EditorView } from '@codemirror/view'
 import { BlockCache } from '@/data/blockCache'
 import { ChangeScope, type User } from '@/data/api'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import {
   editorSelection,
   focusBlock,
@@ -51,7 +51,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   const repo = new Repo({
     db: h.db,
@@ -183,12 +184,15 @@ const isDeleted = async (id: string): Promise<boolean> => {
   return row.deleted === 1
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => {
   __resetLayoutSessionIdForTesting()
   env = await setup()
 })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(async () => { env.repo.stopSyncObserver() })
 
 describe('default CodeMirror shortcuts', () => {
   it('prevents native CodeMirror handling for structural move shortcuts', () => {

--- a/src/sync/observer/cutoverParity.test.ts
+++ b/src/sync/observer/cutoverParity.test.ts
@@ -19,13 +19,13 @@
  * trigger interactions are the real ones on both sides.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   BLOCKS_SYNCED_RAW_TABLE,
   BLOCK_STORAGE_COLUMNS,
   blockToRowParams,
 } from '@/data/blockSchema'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { materializeStagingRows, type Materializability } from './materialize.js'
 import type { GetCek } from '../transform.js'
 import type { BlockData } from '@/data/api'
@@ -100,10 +100,20 @@ const stageAndMaterialize = async (db: TestDb['db'], b: BlockData) => {
   )
 }
 
+// Two DBs: the "reference" (direct blocks write) and the "observer" (staged +
+// materialized) path, compared for parity. Open each once; reset per test.
+let sharedRef: TestDb
+let sharedObs: TestDb
 let ref: TestDb
 let obs: TestDb
-beforeEach(async () => { ref = await createTestDb(); obs = await createTestDb() })
-afterEach(async () => { await ref.cleanup(); await obs.cleanup() })
+beforeAll(async () => { sharedRef = await createTestDb(); sharedObs = await createTestDb() })
+afterAll(async () => { await sharedRef.cleanup(); await sharedObs.cleanup() })
+beforeEach(async () => {
+  await resetTestDb(sharedRef.db)
+  await resetTestDb(sharedObs.db)
+  ref = sharedRef
+  obs = sharedObs
+})
 
 describe('cutover parity — plaintext block: observer path vs a direct blocks write', () => {
   it('produces an identical blocks row and identical derived indexes', async () => {

--- a/src/sync/observer/materialize.test.ts
+++ b/src/sync/observer/materialize.test.ts
@@ -14,13 +14,13 @@
  * the source-gating and trigger interactions are the real ones.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   BLOCKS_SYNCED_RAW_TABLE,
   BLOCK_STORAGE_COLUMNS,
   blockToRowParams,
 } from '@/data/blockSchema'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { materializeStagingRows, type Materializability } from './materialize.js'
 import { encodeForWire, type GetCek } from '../transform.js'
 import { generateWorkspaceKeyBytes, importWorkspaceKey } from '../crypto/workspaceKey.js'
@@ -58,9 +58,12 @@ const stagingCiphertextParams = (
   return params
 }
 
+let sharedDb: TestDb
 let env: TestDb
-beforeEach(async () => { env = await createTestDb() })
-afterEach(async () => { await env.cleanup() })
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+// Reuse one DB across the file; reset (not reopen) per test.
+beforeEach(async () => { await resetTestDb(sharedDb.db); env = sharedDb })
 
 const stageRow = (data: BlockData, params?: unknown[]) =>
   env.db.execute(BLOCKS_SYNCED_RAW_TABLE.put.sql, params ?? blockToRowParams(data))

--- a/src/sync/observer/observer.test.ts
+++ b/src/sync/observer/observer.test.ts
@@ -5,10 +5,10 @@
  * materialize → invalidate, plus the drain's race/failure/restart robustness.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { startBlocksSyncedObserver, type BlocksSyncedObserver } from './observer.js'
 import type { GetMaterializability } from './materialize.js'
 import { encodeForWire, type GetCek } from '../transform.js'
@@ -33,12 +33,15 @@ const stagingCiphertextParams = (
   return params
 }
 
+let sharedDb: TestDb
 let env: TestDb
 let observers: BlocksSyncedObserver[]
-beforeEach(async () => { env = await createTestDb(); observers = [] })
-afterEach(async () => {
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+beforeEach(async () => { await resetTestDb(sharedDb.db); env = sharedDb; observers = [] })
+afterEach(() => {
+  // Dispose any observers the test started; the shared DB closes in afterAll.
   for (const o of observers) o.dispose()
-  await env.cleanup()
 })
 
 const put = (d: BlockData, params?: unknown[]) =>

--- a/src/test/initData.test.ts
+++ b/src/test/initData.test.ts
@@ -12,11 +12,11 @@
  * `repo.tx` so both pages land atomically.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { aliasesProp } from '@/data/properties'
 import { EXTENSION_TYPE, PAGE_TYPE } from '@/data/blockTypes'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../data/repo'
 import { seedTutorial } from '@/initData'
 import { exampleExtensions } from '@/extensions/exampleExtensions'
@@ -34,7 +34,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -53,9 +54,14 @@ const setup = async (): Promise<Harness> => {
   return { h, repo }
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const listAllBlockIds = async (h: TestDb): Promise<string[]> => {
   const rows = await h.db.getAll<{ id: string }>('SELECT id FROM blocks WHERE deleted = 0')

--- a/src/utils/test/copy.test.ts
+++ b/src/utils/test/copy.test.ts
@@ -23,10 +23,10 @@
  * `navigator.clipboard.write` and would require a DOM environment.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '../../data/repo'
 import { serializeBlock, serializeSelectedBlocks } from '@/utils/copy'
 
@@ -38,12 +38,14 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
     now: () => ++timeCursor,
@@ -52,9 +54,12 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 interface SeedNode {
   id: string

--- a/src/utils/test/linkTargetAutocomplete.test.ts
+++ b/src/utils/test/linkTargetAutocomplete.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import type { BlockData } from '@/data/api'
 import { aliasesProp } from '@/data/properties.js'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import {
   labelForBlockData,
@@ -23,7 +23,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
@@ -38,9 +39,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string

--- a/src/utils/test/navigation.test.ts
+++ b/src/utils/test/navigation.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MouseEvent } from 'react'
 import {
   blockOpenerAction,
@@ -11,7 +11,7 @@ import {
 } from '@/utils/navigation'
 import { panelHistory } from '@/utils/panelHistory'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks'
 import {
@@ -36,9 +36,11 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache: new BlockCache(),
     user: USER,
     registerKernelProcessors: false,
@@ -47,16 +49,19 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   __resetLayoutSessionIdForTesting()
   env = await setup()
 })
 
-afterEach(async () => {
+afterEach(() => {
   vi.unstubAllGlobals()
-  await env.h.cleanup()
+  env.repo.stopSyncObserver()
 })
 
 const layoutSessionBlock = async () => {

--- a/src/utils/test/panelLayoutProjection.test.ts
+++ b/src/utils/test/panelLayoutProjection.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope, type User } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { keysBetween } from '@/data/orderKey'
 import {
@@ -34,7 +34,8 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
     db: h.db,
     cache: new BlockCache(),
@@ -47,9 +48,14 @@ const setup = async (): Promise<Harness> => {
   return {h, repo, layoutSessionBlockId: layoutSessionBlock.id}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+// Dispose the per-test Repo's sync observer so its db.onChange subscription
+// doesn't leak onto the shared DB (closed once in afterAll).
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const layoutSessionBlock = () => env.repo.block(env.layoutSessionBlockId)
 

--- a/src/utils/test/paste.test.ts
+++ b/src/utils/test/paste.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { isCollapsedProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
 import {
@@ -21,12 +21,14 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
   let idCursor = 0
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache,
     user: {id: 'user-1'},
     now: () => ++timeCursor,
@@ -35,9 +37,12 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const createBlock = async (
   id: string,

--- a/src/utils/test/propertyCreation.test.ts
+++ b/src/utils/test/propertyCreation.test.ts
@@ -1,18 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import { showPropertiesProp } from '@/data/properties'
 import { consumePendingPropertyCreateRequest } from '@/utils/propertyNavigation'
 import { convertEmptyChildBlockToProperty } from '@/utils/propertyCreation'
 
 describe('convertEmptyChildBlockToProperty', () => {
+  let sharedDb: TestDb
   let h: TestDb
   let repo: Repo
 
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
   beforeEach(async () => {
-    h = await createTestDb()
+    await resetTestDb(sharedDb.db)
+    h = sharedDb
     let now = 1700_000_000_000
     let txSeq = 0
     repo = new Repo({
@@ -44,7 +48,7 @@ describe('convertEmptyChildBlockToProperty', () => {
 
   afterEach(async () => {
     consumePendingPropertyCreateRequest('parent')
-    await h.cleanup()
+    repo.stopSyncObserver()
   })
 
   it('turns an empty child block into a pending property creation on its parent', async () => {

--- a/src/utils/test/selection.test.ts
+++ b/src/utils/test/selection.test.ts
@@ -1,9 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { BlockCache } from '@/data/blockCache'
 import { ChangeScope, type User } from '@/data/api'
 import { isCollapsedProp } from '@/data/properties'
 import { Repo } from '@/data/repo'
-import { createTestDb, type TestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import {
   blockAfterSubtreeRemoval,
   blockIdsInOrderedSelectionRange,
@@ -20,9 +20,11 @@ interface Harness {
 }
 
 const setup = async (): Promise<Harness> => {
-  const h = await createTestDb()
+  // Shared DB opened once per file (beforeAll), reset here per test.
+  await resetTestDb(sharedDb.db)
+  const h = sharedDb
   const repo = new Repo({
-    db: h.db,
+    db: sharedDb.db,
     cache: new BlockCache(),
     user: USER,
     registerKernelProcessors: false,
@@ -31,11 +33,18 @@ const setup = async (): Promise<Harness> => {
   return {h, repo}
 }
 
+let sharedDb: TestDb
 let env: Harness
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   env = await setup()
 })
+
+// The original had no afterEach (and so never closed its per-test DB);
+// dispose the per-test Repo's observer now that the DB is shared.
+afterEach(() => { env.repo.stopSyncObserver() })
 
 const seedOutline = async (
   repo: Repo,


### PR DESCRIPTION
Follow-up to the test-suite audit, attacking the biggest iteration-speed lever: per-test database setup.

## Problem
`createTestDb()` opens a real `@powersync/node` database (worker threads + a template-dir copy). Profiled here at **~262ms per open**, paid in `beforeEach` by ~85 files. A truncate-reset of an already-open DB costs **~2.5ms (~100×)**.

## Approach
Add a reusable `resetTestDb(db)` to the harness and switch the DB-backed suites to **open one DB per file (`beforeAll`) + reset between tests**, building a fresh `Repo` per test for registry / cache / handle-store isolation and disposing its (default-on) sync observer so `db.onChange` subscriptions don't leak onto the shared DB.

`resetTestDb` clears every data + audit/queue table, the per-property `reproject_ref:*` markers, and the `tx_context` singleton in one `writeTransaction`. Correctness details: it leaves the FTS shadow tables alone (cleared via the `blocks_fts` virtual table — touching them directly corrupts the index), keeps the backfill/ANALYZE markers (a fresh harness has them), restarts AUTOINCREMENT counters, and tolerates absent tables. `resetTestDb.test.ts` pins the empties / cross-test-isolation / autoincrement contract.

## Result
Full-suite total per-file time **852s → 222s (−74%)**. **79 test files** converted. All converted suites pass unchanged — including the timing-sensitive invalidation no-fire guards (`kernelQueries`, `grouped-backlinks`) and the schema-swap reprojection tests (`referencesProcessor`), confirming the reset gives real per-test isolation. (The remaining 222s is dominated by ~164s of sandbox-only `bridgeServer` overhead that doesn't exist on real CI; excluding it, the converted DB tests went from ~688s to ~58s of CPU.)

## Harness shapes
Three shapes, by necessity:
- **Single-harness** files reset inside `setup()` (`const h = sharedDb`; afterEach disposes the observer).
- **Multi-Repo / mid-test re-setup** files (globalState, repoLifecycle, referencesProcessor) reset in `beforeEach` and return an `h` whose `cleanup` disposes the observer rather than closing the shared DB — so every existing `*.h.cleanup()` / `env.dispose()` body stays correct.
- **Inline / raw-db** files (sync observer, staging) point the test db at the shared one and reset per test.

Two correctness fixes fell out: the `reproject_ref:*` clear (schema-swap reprojection state was leaking across tests), and `selection.test.ts` had no `afterEach` at all (a pre-existing per-test DB leak).

## Not converted (deliberate)
- `createTestDb.test.ts` (harness self-test — must open real DBs), `repoQueryDispatch` + `treeQueries` (already `beforeAll`).
- Four per-`it` files that open the DB *inside* each test's try/finally with observer-on Repos (`blockDateAdapter`, `srs-rescheduling/plugin`, `BlockTypeBlockRenderer`, `update-indicator/loadTimes`): the Repo isn't in scope at the cleanup site, so safe sharing needs restructuring for ~5s total — left as a follow-up.

## Verification
Verified locally under Node 22 (`vitest run`) before/after each batch; the 9 failing files are pre-existing and environmental (agent-cli / agent-runtime / safeMode need `yarn compile` on Node 24, unrelated to this change).