### PR TITLE
test(perf): share DB across the deferred per-test suites (follow-up to #108)

### DIFF
--- a/src/data/test/repoLifecycle.test.ts
+++ b/src/data/test/repoLifecycle.test.ts
@@ -90,19 +90,17 @@ describe('repo.setReadOnly', () => {
     expect(env.repo.isReadOnly).toBe(false)
   })
 
-  it('respects opts.isReadOnly at construction', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db,
-        cache: new BlockCache(),
-        user: {id: 'u'},
-        isReadOnly: true,
-      })
-      expect(repo.isReadOnly).toBe(true)
-    } finally {
-      await h.cleanup()
-    }
+  it('respects opts.isReadOnly at construction', () => {
+    // Construction-only assertion — no DB I/O — so it rides the shared DB
+    // with the observer off rather than opening its own harness.
+    const repo = new Repo({
+      db: sharedDb.db,
+      cache: new BlockCache(),
+      user: {id: 'u'},
+      isReadOnly: true,
+      startSyncObserver: false,
+    })
+    expect(repo.isReadOnly).toBe(true)
   })
 })
 

--- a/src/plugins/daily-notes/test/blockDateAdapter.test.ts
+++ b/src/plugins/daily-notes/test/blockDateAdapter.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { Repo } from '@/data/repo'
-import { createTestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
 import {
@@ -46,203 +46,170 @@ const stubAdapter = (id: string, predicate: (content: string) => boolean): Block
   setIso: async () => true,
 })
 
+let sharedDb: TestDb
+
+beforeAll(async () => {
+  sharedDb = await createTestDb()
+})
+
+afterAll(async () => {
+  await sharedDb.cleanup()
+})
+
+beforeEach(async () => {
+  await resetTestDb(sharedDb.db)
+})
+
+const makeRepo = () =>
+  new Repo({
+    db: sharedDb.db,
+    cache: new BlockCache(),
+    user: {id: 'user-1'},
+    registerKernelProcessors: false,
+    startSyncObserver: false,
+  })
+
 describe('blockDateAdapter dispatch', () => {
   it('returns null when no adapter applies', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        blockDateAdapterFacet.of(referenceDateAdapter, {source: 'test'}),
-      ])
-      repo.setFacetRuntime(runtime)
+    const repo = makeRepo()
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      blockDateAdapterFacet.of(referenceDateAdapter, {source: 'test'}),
+    ])
+    repo.setFacetRuntime(runtime)
 
-      await repo.tx(tx => tx.create({
-        id: 'plain', workspaceId: 'ws', parentId: null, orderKey: 'a',
-        content: 'just text, no date here',
-      }), {scope: ChangeScope.BlockDefault})
+    await repo.tx(tx => tx.create({
+      id: 'plain', workspaceId: 'ws', parentId: null, orderKey: 'a',
+      content: 'just text, no date here',
+    }), {scope: ChangeScope.BlockDefault})
 
-      const block = repo.block('plain')
-      await block.load()
+    const block = repo.block('plain')
+    await block.load()
 
-      expect(pickBlockDateAdapter(runtime, block)).toBeNull()
-      expect(hasAnyBlockDateAdapter(runtime, block)).toBe(false)
-    } finally {
-      await h.cleanup()
-    }
+    expect(pickBlockDateAdapter(runtime, block)).toBeNull()
+    expect(hasAnyBlockDateAdapter(runtime, block)).toBe(false)
   })
 
   it('picks the reference adapter when content has one date wikilink', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        blockDateAdapterFacet.of(referenceDateAdapter, {source: 'test'}),
-      ])
-      repo.setFacetRuntime(runtime)
+    const repo = makeRepo()
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      blockDateAdapterFacet.of(referenceDateAdapter, {source: 'test'}),
+    ])
+    repo.setFacetRuntime(runtime)
 
-      await repo.tx(tx => tx.create({
-        id: 'dated', workspaceId: 'ws', parentId: null, orderKey: 'a',
-        content: 'due [[2026-05-15]]',
-      }), {scope: ChangeScope.BlockDefault})
+    await repo.tx(tx => tx.create({
+      id: 'dated', workspaceId: 'ws', parentId: null, orderKey: 'a',
+      content: 'due [[2026-05-15]]',
+    }), {scope: ChangeScope.BlockDefault})
 
-      const block = repo.block('dated')
-      await block.load()
+    const block = repo.block('dated')
+    await block.load()
 
-      const adapter = pickBlockDateAdapter(runtime, block)
-      expect(adapter?.id).toBe(referenceDateAdapter.id)
-      expect(await adapter?.getCurrentIso(block)).toBe('2026-05-15')
-    } finally {
-      await h.cleanup()
-    }
+    const adapter = pickBlockDateAdapter(runtime, block)
+    expect(adapter?.id).toBe(referenceDateAdapter.id)
+    expect(await adapter?.getCurrentIso(block)).toBe('2026-05-15')
   })
 
   it('respects negative precedence — higher-priority adapter wins when both apply', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      const winner = stubAdapter('test.high-priority', () => true)
-      const loser = stubAdapter('test.low-priority', () => true)
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        blockDateAdapterFacet.of(loser, {source: 'test-low'}),
-        blockDateAdapterFacet.of(winner, {source: 'test-high', precedence: -1}),
-      ])
-      repo.setFacetRuntime(runtime)
+    const repo = makeRepo()
+    const winner = stubAdapter('test.high-priority', () => true)
+    const loser = stubAdapter('test.low-priority', () => true)
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      blockDateAdapterFacet.of(loser, {source: 'test-low'}),
+      blockDateAdapterFacet.of(winner, {source: 'test-high', precedence: -1}),
+    ])
+    repo.setFacetRuntime(runtime)
 
-      await repo.tx(tx => tx.create({
-        id: 'b', workspaceId: 'ws', parentId: null, orderKey: 'a',
-        content: 'whatever',
-      }), {scope: ChangeScope.BlockDefault})
+    await repo.tx(tx => tx.create({
+      id: 'b', workspaceId: 'ws', parentId: null, orderKey: 'a',
+      content: 'whatever',
+    }), {scope: ChangeScope.BlockDefault})
 
-      const block = repo.block('b')
-      await block.load()
-      expect(pickBlockDateAdapter(runtime, block)?.id).toBe(winner.id)
-    } finally {
-      await h.cleanup()
-    }
+    const block = repo.block('b')
+    await block.load()
+    expect(pickBlockDateAdapter(runtime, block)?.id).toBe(winner.id)
   })
 
   it('falls through past adapters whose canHandle returns false', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      const skip = stubAdapter('test.skip', content => content.includes('SKIP'))
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        blockDateAdapterFacet.of(skip, {source: 'test-skip', precedence: -1}),
-        blockDateAdapterFacet.of(referenceDateAdapter, {source: 'test'}),
-      ])
-      repo.setFacetRuntime(runtime)
+    const repo = makeRepo()
+    const skip = stubAdapter('test.skip', content => content.includes('SKIP'))
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      blockDateAdapterFacet.of(skip, {source: 'test-skip', precedence: -1}),
+      blockDateAdapterFacet.of(referenceDateAdapter, {source: 'test'}),
+    ])
+    repo.setFacetRuntime(runtime)
 
-      await repo.tx(tx => tx.create({
-        id: 'dated', workspaceId: 'ws', parentId: null, orderKey: 'a',
-        content: 'due [[2026-05-15]]',
-      }), {scope: ChangeScope.BlockDefault})
+    await repo.tx(tx => tx.create({
+      id: 'dated', workspaceId: 'ws', parentId: null, orderKey: 'a',
+      content: 'due [[2026-05-15]]',
+    }), {scope: ChangeScope.BlockDefault})
 
-      const block = repo.block('dated')
-      await block.load()
-      expect(pickBlockDateAdapter(runtime, block)?.id).toBe(referenceDateAdapter.id)
-    } finally {
-      await h.cleanup()
-    }
+    const block = repo.block('dated')
+    await block.load()
+    expect(pickBlockDateAdapter(runtime, block)?.id).toBe(referenceDateAdapter.id)
   })
 })
 
 describe('referenceDateAdapter', () => {
   it('canHandle accepts blocks with exactly one date reference', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      await repo.tx(async tx => {
-        await tx.create({id: 'one', workspaceId: 'ws', parentId: null, orderKey: 'a',
-          content: 'meet [[2026-05-15]]'})
-        await tx.create({id: 'two', workspaceId: 'ws', parentId: null, orderKey: 'b',
-          content: '[[2026-05-15]] vs [[2026-05-16]]'})
-        await tx.create({id: 'none', workspaceId: 'ws', parentId: null, orderKey: 'c',
-          content: 'no reference here'})
-      }, {scope: ChangeScope.BlockDefault})
+    const repo = makeRepo()
+    await repo.tx(async tx => {
+      await tx.create({id: 'one', workspaceId: 'ws', parentId: null, orderKey: 'a',
+        content: 'meet [[2026-05-15]]'})
+      await tx.create({id: 'two', workspaceId: 'ws', parentId: null, orderKey: 'b',
+        content: '[[2026-05-15]] vs [[2026-05-16]]'})
+      await tx.create({id: 'none', workspaceId: 'ws', parentId: null, orderKey: 'c',
+        content: 'no reference here'})
+    }, {scope: ChangeScope.BlockDefault})
 
-      const one = repo.block('one'); await one.load()
-      const two = repo.block('two'); await two.load()
-      const none = repo.block('none'); await none.load()
+    const one = repo.block('one'); await one.load()
+    const two = repo.block('two'); await two.load()
+    const none = repo.block('none'); await none.load()
 
-      expect(referenceDateAdapter.canHandle(one)).toBe(true)
-      expect(referenceDateAdapter.canHandle(two)).toBe(false)
-      expect(referenceDateAdapter.canHandle(none)).toBe(false)
-    } finally {
-      await h.cleanup()
-    }
+    expect(referenceDateAdapter.canHandle(one)).toBe(true)
+    expect(referenceDateAdapter.canHandle(two)).toBe(false)
+    expect(referenceDateAdapter.canHandle(none)).toBe(false)
   })
 
   it('setIso preserves the reference style (ISO vs long form)', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      await repo.tx(async tx => {
-        await tx.create({id: 'iso', workspaceId: 'ws', parentId: null, orderKey: 'a',
-          content: 'due [[2026-05-15]]'})
-        await tx.create({id: 'long', workspaceId: 'ws', parentId: null, orderKey: 'b',
-          content: 'meet [[May 15th, 2026]]'})
-      }, {scope: ChangeScope.BlockDefault})
+    const repo = makeRepo()
+    await repo.tx(async tx => {
+      await tx.create({id: 'iso', workspaceId: 'ws', parentId: null, orderKey: 'a',
+        content: 'due [[2026-05-15]]'})
+      await tx.create({id: 'long', workspaceId: 'ws', parentId: null, orderKey: 'b',
+        content: 'meet [[May 15th, 2026]]'})
+    }, {scope: ChangeScope.BlockDefault})
 
-      const iso = repo.block('iso'); await iso.load()
-      const long = repo.block('long'); await long.load()
+    const iso = repo.block('iso'); await iso.load()
+    const long = repo.block('long'); await long.load()
 
-      expect(await referenceDateAdapter.setIso(iso, '2026-06-01')).toBe(true)
-      expect(iso.peek()?.content).toBe('due [[2026-06-01]]')
+    expect(await referenceDateAdapter.setIso(iso, '2026-06-01')).toBe(true)
+    expect(iso.peek()?.content).toBe('due [[2026-06-01]]')
 
-      expect(await referenceDateAdapter.setIso(long, '2026-06-01')).toBe(true)
-      expect(long.peek()?.content).toBe('meet [[June 1st, 2026]]')
-    } finally {
-      await h.cleanup()
-    }
+    expect(await referenceDateAdapter.setIso(long, '2026-06-01')).toBe(true)
+    expect(long.peek()?.content).toBe('meet [[June 1st, 2026]]')
   })
 
   it('can target the live CodeMirror document before persisted content catches up', async () => {
-    const h = await createTestDb()
-    try {
-      const repo = new Repo({
-        db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-        registerKernelProcessors: false,
-      })
-      await repo.tx(tx => tx.create({
-        id: 'edited', workspaceId: 'ws', parentId: null, orderKey: 'a',
-        content: 'stale [[2026-05-01]]',
-      }), {scope: ChangeScope.BlockDefault})
+    const repo = makeRepo()
+    await repo.tx(tx => tx.create({
+      id: 'edited', workspaceId: 'ws', parentId: null, orderKey: 'a',
+      content: 'stale [[2026-05-01]]',
+    }), {scope: ChangeScope.BlockDefault})
 
-      const block = repo.block('edited')
-      await block.load()
-      const editorView = fakeEditorView('live [[2026-05-01]]')
-      const adapter = createEditorReferenceDateAdapter(editorView as never)
+    const block = repo.block('edited')
+    await block.load()
+    const editorView = fakeEditorView('live [[2026-05-01]]')
+    const adapter = createEditorReferenceDateAdapter(editorView as never)
 
-      expect(adapter.canHandle(block)).toBe(true)
-      expect(await adapter.getCurrentIso(block)).toBe('2026-05-01')
-      expect(await adapter.setIso(block, '2026-05-08')).toBe(true)
+    expect(adapter.canHandle(block)).toBe(true)
+    expect(await adapter.getCurrentIso(block)).toBe('2026-05-01')
+    expect(await adapter.setIso(block, '2026-05-08')).toBe(true)
 
-      expect(editorView.state.doc.toString()).toBe('live [[2026-05-08]]')
-      expect(block.peek()?.content).toBe('live [[2026-05-08]]')
-    } finally {
-      await h.cleanup()
-    }
+    expect(editorView.state.doc.toString()).toBe('live [[2026-05-08]]')
+    expect(block.peek()?.content).toBe('live [[2026-05-08]]')
   })
 })

--- a/src/plugins/srs-rescheduling/test/plugin.test.ts
+++ b/src/plugins/srs-rescheduling/test/plugin.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { kernelDataExtension } from '@/data/kernelDataExtension'
 import { Repo } from '@/data/repo'
-import { createTestDb } from '@/data/test/createTestDb'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { actionsFacet } from '@/extensions/core.js'
 import { blockContentSurfacePropsFacet } from '@/extensions/blockInteraction.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
@@ -50,6 +50,20 @@ import {
 } from '../srsClipboard.ts'
 
 describe('srsReschedulingPlugin', () => {
+  let sharedDb: TestDb
+
+  beforeAll(async () => {
+    sharedDb = await createTestDb()
+  })
+
+  afterAll(async () => {
+    await sharedDb.cleanup()
+  })
+
+  beforeEach(async () => {
+    await resetTestDb(sharedDb.db)
+  })
+
   const withSrsScrubRepo = async (
     run: (
       repo: Repo,
@@ -63,65 +77,61 @@ describe('srsReschedulingPlugin', () => {
     vi.setSystemTime(new Date(2026, 4, 5))
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
-    const h = await createTestDb()
+    const repo = new Repo({
+      db: sharedDb.db,
+      cache: new BlockCache(),
+      user: {id: 'user-1'},
+      registerKernelProcessors: false,
+      startSyncObserver: false,
+    })
+    repo.setFacetRuntime(resolveFacetRuntimeSync([
+      kernelDataExtension,
+      dailyNotesDataExtension,
+      srsReschedulingPlugin,
+    ]))
+
+    const nextReview = await getOrCreateDailyNote(repo, 'ws-1', '2026-05-01')
+    await repo.tx(tx => tx.create({
+      id: 'srs-block',
+      workspaceId: 'ws-1',
+      parentId: null,
+      orderKey: 'a',
+      content: 'Card',
+      properties: {
+        types: [SRS_SM25_TYPE],
+        [srsIntervalProp.name]: srsIntervalProp.codec.encode(10),
+        [srsFactorProp.name]: srsFactorProp.codec.encode(2),
+        [srsNextReviewDateProp.name]: srsNextReviewDateProp.codec.encode(nextReview.id),
+        [srsReviewCountProp.name]: srsReviewCountProp.codec.encode(3),
+      },
+    }), {scope: ChangeScope.BlockDefault, description: 'seed srs block'})
+
+    const block = repo.block('srs-block')
+    await block.load()
+
+    let draft: DateScrubDraft | null = null
+    const unregister = registerScrubHandler({
+      start: vi.fn(() => true),
+      update: vi.fn(),
+      end: vi.fn(),
+      stage: vi.fn((_blockId, next) => {
+        draft = next
+        return true
+      }),
+      getDraft: vi.fn(() => draft),
+    })
+
     try {
-      const repo = new Repo({
-        db: h.db,
-        cache: new BlockCache(),
-        user: {id: 'user-1'},
-        registerKernelProcessors: false,
+      expect(startKeyboardScrubForTarget({block})).toBe(true)
+
+      const runtime = repo.facetRuntime
+      if (!runtime) throw new Error('facet runtime missing')
+      await run(repo, block, runtime.read(actionsFacet), () => draft, next => {
+        draft = next
       })
-      repo.setFacetRuntime(resolveFacetRuntimeSync([
-        kernelDataExtension,
-        dailyNotesDataExtension,
-        srsReschedulingPlugin,
-      ]))
-
-      const nextReview = await getOrCreateDailyNote(repo, 'ws-1', '2026-05-01')
-      await repo.tx(tx => tx.create({
-        id: 'srs-block',
-        workspaceId: 'ws-1',
-        parentId: null,
-        orderKey: 'a',
-        content: 'Card',
-        properties: {
-          types: [SRS_SM25_TYPE],
-          [srsIntervalProp.name]: srsIntervalProp.codec.encode(10),
-          [srsFactorProp.name]: srsFactorProp.codec.encode(2),
-          [srsNextReviewDateProp.name]: srsNextReviewDateProp.codec.encode(nextReview.id),
-          [srsReviewCountProp.name]: srsReviewCountProp.codec.encode(3),
-        },
-      }), {scope: ChangeScope.BlockDefault, description: 'seed srs block'})
-
-      const block = repo.block('srs-block')
-      await block.load()
-
-      let draft: DateScrubDraft | null = null
-      const unregister = registerScrubHandler({
-        start: vi.fn(() => true),
-        update: vi.fn(),
-        end: vi.fn(),
-        stage: vi.fn((_blockId, next) => {
-          draft = next
-          return true
-        }),
-        getDraft: vi.fn(() => draft),
-      })
-
-      try {
-        expect(startKeyboardScrubForTarget({block})).toBe(true)
-
-        const runtime = repo.facetRuntime
-        if (!runtime) throw new Error('facet runtime missing')
-        await run(repo, block, runtime.read(actionsFacet), () => draft, next => {
-          draft = next
-        })
-      } finally {
-        endKeyboardScrub(false)
-        unregister()
-      }
     } finally {
-      await h.cleanup()
+      endKeyboardScrub(false)
+      unregister()
     }
   }
 
@@ -259,177 +269,166 @@ describe('srsReschedulingPlugin', () => {
   })
 
   it('decorates the swipe-right block action to archive SRS blocks', async () => {
-    const h = await createTestDb()
-    try {
-      let txSeq = 0
-      const repo = new Repo({
-        db: h.db,
-        cache: new BlockCache(),
-        user: {id: 'user-1'},
-        newTxSeq: () => ++txSeq,
-        startSyncObserver: false,
+    let txSeq = 0
+    const repo = new Repo({
+      db: sharedDb.db,
+      cache: new BlockCache(),
+      user: {id: 'user-1'},
+      newTxSeq: () => ++txSeq,
+      startSyncObserver: false,
+    })
+    const baseSwipeRight = vi.fn(async () => undefined)
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      dailyNotesDataExtension,
+      srsReschedulingPlugin,
+      actionsFacet.of({
+        id: SWIPE_RIGHT_BLOCK_ACTION_ID,
+        description: 'Swipe right',
+        context: ActionContextTypes.NORMAL_MODE,
+        handler: baseSwipeRight,
+      }, {source: 'test'}),
+    ])
+    repo.setFacetRuntime(runtime)
+
+    const snapshot = repo.snapshotTypeRegistries()
+    await repo.tx(async tx => {
+      await tx.create({
+        id: 'srs-block',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a0',
+        content: 'SRS',
       })
-      const baseSwipeRight = vi.fn(async () => undefined)
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        dailyNotesDataExtension,
-        srsReschedulingPlugin,
-        actionsFacet.of({
-          id: SWIPE_RIGHT_BLOCK_ACTION_ID,
-          description: 'Swipe right',
-          context: ActionContextTypes.NORMAL_MODE,
-          handler: baseSwipeRight,
-        }, {source: 'test'}),
-      ])
-      repo.setFacetRuntime(runtime)
+      await repo.addTypeInTx(tx, 'srs-block', SRS_SM25_TYPE, {}, snapshot)
+      await tx.create({
+        id: 'plain-block',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a1',
+        content: 'Plain',
+      })
+    }, {scope: ChangeScope.BlockDefault, description: 'seed swipe-right blocks'})
 
-      const snapshot = repo.snapshotTypeRegistries()
-      await repo.tx(async tx => {
-        await tx.create({
-          id: 'srs-block',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a0',
-          content: 'SRS',
-        })
-        await repo.addTypeInTx(tx, 'srs-block', SRS_SM25_TYPE, {}, snapshot)
-        await tx.create({
-          id: 'plain-block',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a1',
-          content: 'Plain',
-        })
-      }, {scope: ChangeScope.BlockDefault, description: 'seed swipe-right blocks'})
+    const action = getEffectiveActions(runtime).find(it => it.id === SWIPE_RIGHT_BLOCK_ACTION_ID) as
+      ActionConfig<typeof ActionContextTypes.NORMAL_MODE> | undefined
+    expect(action).toBeDefined()
 
-      const action = getEffectiveActions(runtime).find(it => it.id === SWIPE_RIGHT_BLOCK_ACTION_ID) as
-        ActionConfig<typeof ActionContextTypes.NORMAL_MODE> | undefined
-      expect(action).toBeDefined()
+    const srsBlock = repo.block('srs-block')
+    await srsBlock.load()
+    await action!.handler({block: srsBlock, uiStateBlock: srsBlock}, {} as CustomEvent)
+    expect(srsBlock.get(srsArchivedProp)).toBe(true)
+    expect(baseSwipeRight).not.toHaveBeenCalled()
 
-      const srsBlock = repo.block('srs-block')
-      await srsBlock.load()
-      await action!.handler({block: srsBlock, uiStateBlock: srsBlock}, {} as CustomEvent)
-      expect(srsBlock.get(srsArchivedProp)).toBe(true)
-      expect(baseSwipeRight).not.toHaveBeenCalled()
-
-      const plainBlock = repo.block('plain-block')
-      await plainBlock.load()
-      await action!.handler({block: plainBlock, uiStateBlock: plainBlock}, {} as CustomEvent)
-      expect(baseSwipeRight).toHaveBeenCalledOnce()
-    } finally {
-      await h.cleanup()
-    }
+    const plainBlock = repo.block('plain-block')
+    await plainBlock.load()
+    await action!.handler({block: plainBlock, uiStateBlock: plainBlock}, {} as CustomEvent)
+    expect(baseSwipeRight).toHaveBeenCalledOnce()
   })
 
   it('decorates cmd-enter todo cycle actions to archive SRS blocks', async () => {
-    const h = await createTestDb()
-    try {
-      let txSeq = 0
-      const repo = new Repo({
-        db: h.db,
-        cache: new BlockCache(),
-        user: {id: 'user-1'},
-        newTxSeq: () => ++txSeq,
-        registerKernelProcessors: false,
-        startSyncObserver: false,
+    let txSeq = 0
+    const repo = new Repo({
+      db: sharedDb.db,
+      cache: new BlockCache(),
+      user: {id: 'user-1'},
+      newTxSeq: () => ++txSeq,
+      registerKernelProcessors: false,
+      startSyncObserver: false,
+    })
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      dailyNotesDataExtension,
+      todoDataExtension,
+      todoActionsExtension,
+      srsReschedulingPlugin,
+    ])
+    repo.setFacetRuntime(runtime)
+
+    const snapshot = repo.snapshotTypeRegistries()
+    await repo.tx(async tx => {
+      await tx.create({
+        id: 'srs-normal',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a0',
+        content: 'SRS normal',
       })
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        dailyNotesDataExtension,
-        todoDataExtension,
-        todoActionsExtension,
-        srsReschedulingPlugin,
-      ])
-      repo.setFacetRuntime(runtime)
+      await repo.addTypeInTx(tx, 'srs-normal', SRS_SM25_TYPE, {}, snapshot)
+      await tx.create({
+        id: 'srs-edit',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a1',
+        content: 'SRS edit',
+      })
+      await repo.addTypeInTx(tx, 'srs-edit', SRS_SM25_TYPE, {}, snapshot)
+      await tx.create({
+        id: 'plain-normal',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a2',
+        content: 'Plain normal',
+      })
+      await tx.create({
+        id: 'plain-edit',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a3',
+        content: 'Plain edit',
+      })
+    }, {scope: ChangeScope.BlockDefault, description: 'seed cmd-enter blocks'})
 
-      const snapshot = repo.snapshotTypeRegistries()
-      await repo.tx(async tx => {
-        await tx.create({
-          id: 'srs-normal',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a0',
-          content: 'SRS normal',
-        })
-        await repo.addTypeInTx(tx, 'srs-normal', SRS_SM25_TYPE, {}, snapshot)
-        await tx.create({
-          id: 'srs-edit',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a1',
-          content: 'SRS edit',
-        })
-        await repo.addTypeInTx(tx, 'srs-edit', SRS_SM25_TYPE, {}, snapshot)
-        await tx.create({
-          id: 'plain-normal',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a2',
-          content: 'Plain normal',
-        })
-        await tx.create({
-          id: 'plain-edit',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a3',
-          content: 'Plain edit',
-        })
-      }, {scope: ChangeScope.BlockDefault, description: 'seed cmd-enter blocks'})
+    const actions = getEffectiveActions(runtime)
+    const normalAction = actions.find(action =>
+      action.id === TODO_CYCLE_ACTION_ID && action.context === ActionContextTypes.NORMAL_MODE
+    ) as ActionConfig<typeof ActionContextTypes.NORMAL_MODE> | undefined
+    const editAction = actions.find(action =>
+      action.id === EDIT_MODE_TODO_CYCLE_ACTION_ID && action.context === ActionContextTypes.EDIT_MODE_CM
+    ) as ActionConfig<typeof ActionContextTypes.EDIT_MODE_CM> | undefined
+    expect(normalAction).toBeDefined()
+    expect(editAction).toBeDefined()
 
-      const actions = getEffectiveActions(runtime)
-      const normalAction = actions.find(action =>
-        action.id === TODO_CYCLE_ACTION_ID && action.context === ActionContextTypes.NORMAL_MODE
-      ) as ActionConfig<typeof ActionContextTypes.NORMAL_MODE> | undefined
-      const editAction = actions.find(action =>
-        action.id === EDIT_MODE_TODO_CYCLE_ACTION_ID && action.context === ActionContextTypes.EDIT_MODE_CM
-      ) as ActionConfig<typeof ActionContextTypes.EDIT_MODE_CM> | undefined
-      expect(normalAction).toBeDefined()
-      expect(editAction).toBeDefined()
+    const srsNormal = repo.block('srs-normal')
+    await srsNormal.load()
+    await normalAction!.handler({block: srsNormal, uiStateBlock: srsNormal}, {} as KeyboardEvent)
+    expect(srsNormal.get(srsArchivedProp)).toBe(true)
+    expect(srsNormal.types).toContain(SRS_SM25_TYPE)
+    expect(srsNormal.types).not.toContain(TODO_TYPE)
 
-      const srsNormal = repo.block('srs-normal')
-      await srsNormal.load()
-      await normalAction!.handler({block: srsNormal, uiStateBlock: srsNormal}, {} as KeyboardEvent)
-      expect(srsNormal.get(srsArchivedProp)).toBe(true)
-      expect(srsNormal.types).toContain(SRS_SM25_TYPE)
-      expect(srsNormal.types).not.toContain(TODO_TYPE)
+    const srsEdit = repo.block('srs-edit')
+    await srsEdit.load()
+    await editAction!.handler({
+      block: srsEdit,
+      uiStateBlock: srsEdit,
+      editorView: {dispatch: vi.fn()},
+    } as never, {} as KeyboardEvent)
+    expect(srsEdit.get(srsArchivedProp)).toBe(true)
+    expect(srsEdit.types).toContain(SRS_SM25_TYPE)
+    expect(srsEdit.types).not.toContain(TODO_TYPE)
 
-      const srsEdit = repo.block('srs-edit')
-      await srsEdit.load()
-      await editAction!.handler({
-        block: srsEdit,
-        uiStateBlock: srsEdit,
-        editorView: {dispatch: vi.fn()},
-      } as never, {} as KeyboardEvent)
-      expect(srsEdit.get(srsArchivedProp)).toBe(true)
-      expect(srsEdit.types).toContain(SRS_SM25_TYPE)
-      expect(srsEdit.types).not.toContain(TODO_TYPE)
+    const plainNormal = repo.block('plain-normal')
+    await plainNormal.load()
+    await normalAction!.handler({block: plainNormal, uiStateBlock: plainNormal}, {} as KeyboardEvent)
+    expect(plainNormal.types).toContain(TODO_TYPE)
+    expect(plainNormal.get(statusProp)).toBe('open')
 
-      const plainNormal = repo.block('plain-normal')
-      await plainNormal.load()
-      await normalAction!.handler({block: plainNormal, uiStateBlock: plainNormal}, {} as KeyboardEvent)
-      expect(plainNormal.types).toContain(TODO_TYPE)
-      expect(plainNormal.get(statusProp)).toBe('open')
-
-      const plainEdit = repo.block('plain-edit')
-      await plainEdit.load()
-      await editAction!.handler({
-        block: plainEdit,
-        uiStateBlock: plainEdit,
-        editorView: {dispatch: vi.fn()},
-      } as never, {} as KeyboardEvent)
-      expect(plainEdit.types).toContain(TODO_TYPE)
-      expect(plainEdit.get(statusProp)).toBe('open')
-    } finally {
-      await h.cleanup()
-    }
+    const plainEdit = repo.block('plain-edit')
+    await plainEdit.load()
+    await editAction!.handler({
+      block: plainEdit,
+      uiStateBlock: plainEdit,
+      editorView: {dispatch: vi.fn()},
+    } as never, {} as KeyboardEvent)
+    expect(plainEdit.types).toContain(TODO_TYPE)
+    expect(plainEdit.get(statusProp)).toBe('open')
   })
 
   describe('srs.cut / srs.paste flow', () => {
-    const setupRepo = async () => {
-      const h = await createTestDb()
+    const setupRepo = () => {
       let txSeq = 0
       const repo = new Repo({
-        db: h.db,
+        db: sharedDb.db,
         cache: new BlockCache(),
         user: {id: 'user-1'},
         newTxSeq: () => ++txSeq,
@@ -442,7 +441,7 @@ describe('srsReschedulingPlugin', () => {
         srsReschedulingPlugin,
       ])
       repo.setFacetRuntime(runtime)
-      return {h, repo, runtime}
+      return {repo, runtime}
     }
 
     const seedSrsBlock = async (
@@ -488,34 +487,30 @@ describe('srsReschedulingPlugin', () => {
     })
 
     it('cut stashes the source block and paste moves SRS to the target', async () => {
-      const {h, repo, runtime} = await setupRepo()
-      try {
-        await seedSrsBlock(repo, 'src', 13)
-        await seedPlainBlock(repo, 'dst')
+      const {repo, runtime} = setupRepo()
+      await seedSrsBlock(repo, 'src', 13)
+      await seedPlainBlock(repo, 'dst')
 
-        const cut = runtime.read(actionsFacet).find(it => it.id === 'srs.cut') as
-          ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
-        const paste = runtime.read(actionsFacet).find(it => it.id === 'srs.paste') as
-          ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
+      const cut = runtime.read(actionsFacet).find(it => it.id === 'srs.cut') as
+        ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
+      const paste = runtime.read(actionsFacet).find(it => it.id === 'srs.paste') as
+        ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
 
-        const srcBlock = repo.block('src')
-        await srcBlock.load()
-        await cut.handler({block: srcBlock, uiStateBlock: srcBlock} as never, {} as KeyboardEvent)
-        expect(getSrsClipboard()).toEqual({sourceBlockId: 'src', sourceWorkspaceId: 'ws-1'})
+      const srcBlock = repo.block('src')
+      await srcBlock.load()
+      await cut.handler({block: srcBlock, uiStateBlock: srcBlock} as never, {} as KeyboardEvent)
+      expect(getSrsClipboard()).toEqual({sourceBlockId: 'src', sourceWorkspaceId: 'ws-1'})
 
-        const dstBlock = repo.block('dst')
-        await dstBlock.load()
-        await paste.handler({block: dstBlock, uiStateBlock: dstBlock} as never, {} as KeyboardEvent)
-        expect(getSrsClipboard()).toBeNull()
+      const dstBlock = repo.block('dst')
+      await dstBlock.load()
+      await paste.handler({block: dstBlock, uiStateBlock: dstBlock} as never, {} as KeyboardEvent)
+      expect(getSrsClipboard()).toBeNull()
 
-        const dstData = await dstBlock.load()
-        const srcData = await srcBlock.load()
-        expect(dstData?.properties.types).toEqual([SRS_SM25_TYPE])
-        expect(srsIntervalProp.codec.decode(dstData!.properties[srsIntervalProp.name])).toBe(13)
-        expect(srcData?.properties.types ?? []).not.toContain(SRS_SM25_TYPE)
-      } finally {
-        await h.cleanup()
-      }
+      const dstData = await dstBlock.load()
+      const srcData = await srcBlock.load()
+      expect(dstData?.properties.types).toEqual([SRS_SM25_TYPE])
+      expect(srsIntervalProp.codec.decode(dstData!.properties[srsIntervalProp.name])).toBe(13)
+      expect(srcData?.properties.types ?? []).not.toContain(SRS_SM25_TYPE)
     })
 
     // "cut on a non-SRS block is a no-op" is enforced by surfaces via
@@ -524,104 +519,92 @@ describe('srsReschedulingPlugin', () => {
     // out of contract.
 
     it('paste is a no-op when nothing is stashed', async () => {
-      const {h, repo, runtime} = await setupRepo()
-      try {
-        await seedPlainBlock(repo, 'dst')
+      const {repo, runtime} = setupRepo()
+      await seedPlainBlock(repo, 'dst')
 
-        const paste = runtime.read(actionsFacet).find(it => it.id === 'srs.paste') as
-          ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
-        const block = repo.block('dst')
-        await block.load()
-        await paste.handler({block, uiStateBlock: block} as never, {} as KeyboardEvent)
+      const paste = runtime.read(actionsFacet).find(it => it.id === 'srs.paste') as
+        ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
+      const block = repo.block('dst')
+      await block.load()
+      await paste.handler({block, uiStateBlock: block} as never, {} as KeyboardEvent)
 
-        const data = await block.load()
-        expect(data?.properties.types ?? []).not.toContain(SRS_SM25_TYPE)
-      } finally {
-        await h.cleanup()
-      }
+      const data = await block.load()
+      expect(data?.properties.types ?? []).not.toContain(SRS_SM25_TYPE)
     })
 
     it('canRun gates cut to SRS blocks and paste to non-source blocks with a stash', async () => {
-      const {h, repo, runtime} = await setupRepo()
-      try {
-        await seedSrsBlock(repo, 'src', 5)
-        await seedPlainBlock(repo, 'plain')
+      const {repo, runtime} = setupRepo()
+      await seedSrsBlock(repo, 'src', 5)
+      await seedPlainBlock(repo, 'plain')
 
-        const actions = runtime.read(actionsFacet)
-        const cutAction = actions.find(it => it.id === 'srs.cut') as
-          ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
-        const pasteAction = actions.find(it => it.id === 'srs.paste') as
-          ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
+      const actions = runtime.read(actionsFacet)
+      const cutAction = actions.find(it => it.id === 'srs.cut') as
+        ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
+      const pasteAction = actions.find(it => it.id === 'srs.paste') as
+        ActionConfig<typeof ActionContextTypes.NORMAL_MODE>
 
-        const srcBlock = repo.block('src')
-        const plainBlock = repo.block('plain')
-        await srcBlock.load()
-        await plainBlock.load()
+      const srcBlock = repo.block('src')
+      const plainBlock = repo.block('plain')
+      await srcBlock.load()
+      await plainBlock.load()
 
-        // Cut visible on SRS blocks only.
-        expect(cutAction.canRun!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(true)
-        expect(cutAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
+      // Cut visible on SRS blocks only.
+      expect(cutAction.canRun!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(true)
+      expect(cutAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
 
-        // Paste hidden until something is cut.
-        expect(pasteAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
+      // Paste hidden until something is cut.
+      expect(pasteAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(false)
 
-        setSrsClipboard({sourceBlockId: 'src', sourceWorkspaceId: 'ws-1'})
-        expect(pasteAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(true)
-        // Paste hidden on the source block itself.
-        expect(pasteAction.canRun!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(false)
-      } finally {
-        await h.cleanup()
-      }
+      setSrsClipboard({sourceBlockId: 'src', sourceWorkspaceId: 'ws-1'})
+      expect(pasteAction.canRun!({block: plainBlock, uiStateBlock: plainBlock} as never)).toBe(true)
+      // Paste hidden on the source block itself.
+      expect(pasteAction.canRun!({block: srcBlock, uiStateBlock: srcBlock} as never)).toBe(false)
     })
   })
 
   it('does not rewrite legacy inline SRS content from edit mode', async () => {
-    const h = await createTestDb()
-    try {
-      let now = 1700_000_000_000
-      let id = 0
-      const repo = new Repo({
-        db: h.db,
-        cache: new BlockCache(),
-        user: {id: 'user-1'},
-        now: () => ++now,
-        newId: () => `generated-${++id}`,
-        registerKernelProcessors: false,
+    let now = 1700_000_000_000
+    let id = 0
+    const repo = new Repo({
+      db: sharedDb.db,
+      cache: new BlockCache(),
+      user: {id: 'user-1'},
+      now: () => ++now,
+      newId: () => `generated-${++id}`,
+      registerKernelProcessors: false,
+      startSyncObserver: false,
+    })
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      dailyNotesDataExtension,
+      srsReschedulingPlugin,
+    ])
+    repo.setFacetRuntime(runtime)
+    await repo.tx(async tx => {
+      await tx.create({
+        id: 'legacy-inline-srs',
+        workspaceId: 'ws-1',
+        parentId: null,
+        orderKey: 'a0',
+        content: 'Review [[May 1st, 2026]]',
       })
-      const runtime = resolveFacetRuntimeSync([
-        kernelDataExtension,
-        dailyNotesDataExtension,
-        srsReschedulingPlugin,
-      ])
-      repo.setFacetRuntime(runtime)
-      await repo.tx(async tx => {
-        await tx.create({
-          id: 'legacy-inline-srs',
-          workspaceId: 'ws-1',
-          parentId: null,
-          orderKey: 'a0',
-          content: 'Review [[May 1st, 2026]]',
-        })
-      }, {scope: ChangeScope.BlockDefault, description: 'seed legacy inline srs'})
+    }, {scope: ChangeScope.BlockDefault, description: 'seed legacy inline srs'})
 
-      const action = runtime.read(actionsFacet).find(it =>
-        it.id === 'edit.cm.srs.reschedule.good',
-      ) as ActionConfig<typeof ActionContextTypes.EDIT_MODE_CM>
-      const block = repo.block('legacy-inline-srs')
-      await block.load()
-      const editorView = {dispatch: vi.fn()}
+    const action = runtime.read(actionsFacet).find(it =>
+      it.id === 'edit.cm.srs.reschedule.good',
+    ) as ActionConfig<typeof ActionContextTypes.EDIT_MODE_CM>
+    const block = repo.block('legacy-inline-srs')
+    await block.load()
+    const editorView = {dispatch: vi.fn()}
 
-      await action.handler({
-        block,
-        uiStateBlock: block,
-        editorView,
-      } as never, {} as KeyboardEvent)
+    await action.handler({
+      block,
+      uiStateBlock: block,
+      editorView,
+    } as never, {} as KeyboardEvent)
 
-      expect(editorView.dispatch).not.toHaveBeenCalled()
-      expect(block.data.content).toBe('Review [[May 1st, 2026]]')
-      expect(block.types).toContain(SRS_SM25_TYPE)
-    } finally {
-      await h.cleanup()
-    }
+    expect(editorView.dispatch).not.toHaveBeenCalled()
+    expect(block.data.content).toBe('Review [[May 1st, 2026]]')
+    expect(block.types).toContain(SRS_SM25_TYPE)
   })
 })


### PR DESCRIPTION
## What

Finishes the test-perf DB-sharing work from #108 by converting the per-`it`
`createTestDb()` suites that were deferred there, plus one stray
construction-only test that was opening a throwaway DB.

Same pattern as #108: one `beforeAll` open + `afterAll` close + a
`beforeEach(() => resetTestDb(sharedDb.db))`, building a fresh `Repo` per test
(with `startSyncObserver: false` where the observer isn't exercised) so
registry/cache/handle-store isolation is preserved while the ~262ms DB open
happens once instead of once per test.

## Files converted

| File | DB opens | tests-exec time |
| --- | --- | --- |
| `daily-notes/test/blockDateAdapter.test.ts` | 7 → 1 | 2.22s → 0.61s |
| `srs-rescheduling/test/plugin.test.ts` | 10 → 1 | 2.95s → 0.57s |
| `data/test/repoLifecycle.test.ts` (`respects opts.isReadOnly`) | 1 → 0 | 0.66s → 0.41s |

~4.2s shaved across the three (measured before/after, single run; the bulk is
the `tests` phase, transform/import overhead is fixed).

The `repoLifecycle` case is a pure construction-only assertion (`expect(repo.isReadOnly).toBe(true)` — no DB I/O), so it now rides the shared DB with the observer off instead of opening its own harness.

## Deliberately NOT converted

- **`BlockTypeBlockRenderer.test.ts`, `update-indicator/test/loadTimes.test.ts`** —
  single-`it` suites. Sharing opens the DB exactly once either way, so the
  conversion would add `beforeAll`/`afterAll`/`beforeEach(reset)` ceremony for
  **zero** speedup (in fact a hair slower: one open + one reset vs one open).
- **`globalState.test.ts` "still bootstraps the prefs block in read-only repos"** —
  asserts on a pristine `ps_crud` / `command_events` from a read-only repo's
  write routing. Keeping it on its own DB isolates that assertion from the
  shared `env` repo's running sync observer.

## Verification

- `tsc -b` clean
- `eslint` clean on all changed files
- Affected files green (58 tests); surrounding dirs green
  (`daily-notes` + `srs-rescheduling` + `data/test` = 303 tests / 34 files)
- All timing-sensitive scrub/draft and read-only-routing behavior unchanged

https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB)_