### PR TITLE
test(perf): deterministic timers + shared bridge server

### DIFF
--- a/packages/agent-cli/src/server.ts
+++ b/packages/agent-cli/src/server.ts
@@ -37,6 +37,11 @@ const maxBodyBytes = Number.isFinite(configuredMaxBodyBytes) && configuredMaxBod
   : 10 * 1024 * 1024
 const bridgeSecret = await resolveBridgeSecret()
 const bridgeSecretHeader = 'x-agent-runtime-secret'
+// Opt-in, off in production. When set, exposes POST /runtime/test/reset
+// (still gated behind the bridge secret) so a test suite can share one
+// server process and wipe state between cases instead of respawning per
+// test. Inert unless this env var is exactly 'true'.
+const testResetEnabled = process.env.AGENT_RUNTIME_TEST_RESET === 'true'
 const defaultAllowedOrigins = new Set(['https://stvad.github.io'])
 const configuredAllowedOrigins = (process.env.AGENT_RUNTIME_ALLOWED_ORIGINS ?? '')
   .split(',')
@@ -508,6 +513,27 @@ const getStatus = () => ({
   })),
 })
 
+// Wipe all in-memory state. Only reachable via the test-only reset route
+// (see `testResetEnabled`). Pending long-poll waiters carry a timeout and
+// an open response, so cancel + close those before dropping the maps.
+const resetState = (): void => {
+  for (const set of waitersByClient.values()) {
+    for (const waiter of set) {
+      clearTimeout(waiter.timeout)
+      try {
+        waiter.response.end()
+      } catch {
+        /* response already closed */
+      }
+    }
+  }
+  clients.clear()
+  commands.clear()
+  pendingByClient.clear()
+  waitersByClient.clear()
+  tokens.clear()
+}
+
 const handleRequest = async (
   request: http.IncomingMessage,
   response: http.ServerResponse,
@@ -528,6 +554,13 @@ const handleRequest = async (
   cleanup()
 
   try {
+    if (testResetEnabled && request.method === 'POST' && requestUrl.pathname === '/runtime/test/reset') {
+      if (!requireBridgeSecret(request, response)) return
+      resetState()
+      sendJson(response, 200, {ok: true})
+      return
+    }
+
     if (request.method === 'GET' && requestUrl.pathname === '/health') {
       if (requestUrl.searchParams.get('detail') === '1') {
         if (!requireBridgeSecret(request, response)) return

--- a/packages/agent-cli/test/bridgeServer.test.ts
+++ b/packages/agent-cli/test/bridgeServer.test.ts
@@ -1,7 +1,7 @@
 /** End-to-end test of the bridge HTTP server. We spawn the built script
  *  as a child process on a random port and exercise it over the wire:
  *  token auth, per-client queues, and client-gone failure modes. */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { spawn, ChildProcess } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -45,7 +45,11 @@ const unknownTokenMessage =
   'Open or focus the app tab for the same workspace, then retry; if needed, run `yarn agent connect` to pair a fresh token. ' +
   'Common causes: the bridge restarted, the app tab disconnected or idled out, the token was revoked, or the CLI is using a token/profile from another workspace or browser profile.'
 
-beforeEach(async () => {
+// One server for the whole file. Each test wipes state via the
+// secret-gated reset route (enabled by AGENT_RUNTIME_TEST_RESET) instead
+// of paying a fresh spawn + port-bind per case — which also removes the
+// pick-port/spawn TOCTOU race from every-test down to a single occurrence.
+beforeAll(async () => {
   const port = await pickPort()
   baseUrl = `http://127.0.0.1:${port}`
   server = spawn('node', [serverScript], {
@@ -54,17 +58,26 @@ beforeEach(async () => {
       AGENT_RUNTIME_PORT: String(port),
       AGENT_RUNTIME_HOST: '127.0.0.1',
       AGENT_RUNTIME_BRIDGE_SECRET: bridgeSecret,
+      AGENT_RUNTIME_TEST_RESET: 'true',
     },
     stdio: ['ignore', 'ignore', 'pipe'],
   })
   await waitForReady(port)
 })
 
-afterEach(async () => {
+afterAll(async () => {
   if (server && !server.killed) {
     server.kill('SIGKILL')
     await new Promise(resolve => server.once('exit', resolve))
   }
+})
+
+beforeEach(async () => {
+  const response = await fetch(`${baseUrl}/runtime/test/reset`, {
+    method: 'POST',
+    headers: bridgeHeaders,
+  })
+  expect(response.ok).toBe(true)
 })
 
 const registerClient = async (clientId: string, body: object) => {

--- a/src/extensions/test/useOverrides.test.tsx
+++ b/src/extensions/test/useOverrides.test.tsx
@@ -8,7 +8,7 @@
  * refresh events a no-op for the runtime resolver.
  */
 import {act, renderHook} from '@testing-library/react'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {useOverrides} from '@/extensions/useOverrides.js'
 import {writeOverridesCache} from '@/extensions/overridesCache.js'
 import {refreshAppRuntime} from '@/extensions/runtimeEvents.js'
@@ -106,20 +106,27 @@ describe('useOverrides', () => {
     expect(result.current.generation).toBe(generationBeforeUnmount)
   })
 
-  it('produces distinct generations on consecutive refreshes', async () => {
-    const {result} = renderHook(() => useOverrides(WS))
-    const g0 = result.current.generation
+  it('produces distinct generations on consecutive refreshes', () => {
+    // The default refresh detail is a `new Date().toISOString()` token;
+    // two dispatches in the same millisecond would collide. Fake timers
+    // (which mock Date) let us advance the clock 1ms deterministically
+    // instead of sleeping and hoping the wall clock ticked.
+    vi.useFakeTimers()
+    try {
+      const {result} = renderHook(() => useOverrides(WS))
+      const g0 = result.current.generation
 
-    dispatchRefresh()
-    const g1 = result.current.generation
-    // The default refresh detail is a Date.now()-based ISO string;
-    // sleep a millisecond to ensure the next dispatch gets a distinct
-    // value (which the runtime context relies on to invalidate memos).
-    await act(() => new Promise(r => setTimeout(r, 2)))
-    dispatchRefresh()
-    const g2 = result.current.generation
+      dispatchRefresh()
+      const g1 = result.current.generation
 
-    expect(g1).not.toBe(g0)
-    expect(g2).not.toBe(g1)
+      vi.advanceTimersByTime(1)
+      dispatchRefresh()
+      const g2 = result.current.generation
+
+      expect(g1).not.toBe(g0)
+      expect(g2).not.toBe(g1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/plugins/spatial-navigation/test/PanelFocusRecovery.test.tsx
+++ b/src/plugins/spatial-navigation/test/PanelFocusRecovery.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { BlockCache } from '@/data/blockCache'
 import { ChangeScope, type User } from '@/data/api'
 import { Repo } from '@/data/repo'
@@ -16,6 +16,11 @@ import { __resetSpatialNavigationForTesting } from '../walker.ts'
 const WS = 'ws-1'
 const USER: User = {id: 'user-1'}
 const PANEL_ID = 'panel'
+
+// Comfortably past the component's RECOVERY_DEBOUNCE_MS (250) so that a
+// pending recovery would have fired if one were armed. Used with fake
+// timers in the no-fire tests below.
+const DEBOUNCE_SETTLE_MS = 350
 
 interface Harness {
   h: TestDb
@@ -204,11 +209,18 @@ describe('PanelFocusRecovery', () => {
     ])
 
     const panelBlock = env.repo.block(PANEL_ID)
-    render(<PanelFocusRecovery block={panelBlock}/>)
 
-    // Give the layout effect + microtask + observer + debounce a tick
-    // to settle.
-    await new Promise(resolve => setTimeout(resolve, 350))
+    // The recovery path early-exits (no stored hint for an id that was
+    // never mounted) without scheduling a timer or writing to the DB, so
+    // we can drive the full debounce window on fake timers instead of
+    // sleeping for real.
+    vi.useFakeTimers()
+    try {
+      render(<PanelFocusRecovery block={panelBlock}/>)
+      await act(async () => { await vi.advanceTimersByTimeAsync(DEBOUNCE_SETTLE_MS) })
+    } finally {
+      vi.useRealTimers()
+    }
 
     expect(peekFocusedBlockLocation(panelBlock)?.blockId).toBe('never-mounted')
   })
@@ -318,22 +330,36 @@ describe('PanelFocusRecovery', () => {
     ])
 
     const panelBlock = env.repo.block(PANEL_ID)
-    render(<PanelFocusRecovery block={panelBlock}/>)
-    expect(peekFocusedBlockLocation(panelBlock)?.blockId).toBe('middle')
 
-    // Simulate a tab move: the block briefly unmounts and remounts
-    // under the same render scope well inside the debounce window.
-    panel.querySelector('[data-block-id="middle"]')!.remove()
-    await new Promise(resolve => setTimeout(resolve, 20))
+    // Fake timers drive the debounce deterministically. The block leaves
+    // and returns inside the window, so the recovery cancels itself and
+    // never writes — no DB I/O on this path, so faking time is safe.
+    vi.useFakeTimers()
+    try {
+      render(<PanelFocusRecovery block={panelBlock}/>)
+      expect(peekFocusedBlockLocation(panelBlock)?.blockId).toBe('middle')
 
-    const replacement = document.createElement('div')
-    setNavAttrs(replacement, 'middle')
-    panel.appendChild(replacement)
+      // Simulate a tab move: the block briefly unmounts and remounts
+      // under the same render scope well inside the debounce window. The
+      // remove fire arms the debounce; advancing 20ms stays inside it.
+      await act(async () => {
+        panel.querySelector('[data-block-id="middle"]')!.remove()
+        await vi.advanceTimersByTimeAsync(20)
+      })
 
-    // Wait past the debounce window and verify no recovery write fired.
-    await new Promise(resolve => setTimeout(resolve, 350))
+      // The remount's observer fire cancels the pending recovery; then
+      // run past the full window to prove nothing fires.
+      const replacement = document.createElement('div')
+      setNavAttrs(replacement, 'middle')
+      await act(async () => {
+        panel.appendChild(replacement)
+        await vi.advanceTimersByTimeAsync(DEBOUNCE_SETTLE_MS)
+      })
 
-    expect(peekFocusedBlockLocation(panelBlock)?.blockId).toBe('middle')
+      expect(peekFocusedBlockLocation(panelBlock)?.blockId).toBe('middle')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('refreshes the positional hint as the user navigates between blocks', async () => {


### PR DESCRIPTION
Follow-up to #110 — the non-DB perf/determinism items from the test-suite audit. The DB-open lever already landed in #107/#108/#109; this PR clears the `setTimeout`-sleep and per-test-spawn items.

## Changes

**`bridgeServer.test.ts` — one shared server instead of 13 spawns** (`6df7325`)
The suite spawned the built `dist/server.js` fresh for each of its 13 tests (~300ms each) purely for state isolation. Now it spawns once in `beforeAll`, kills in `afterAll`, and wipes state between cases via a new **double-guarded** `POST /runtime/test/reset`:
- the route only mounts when `AGENT_RUNTIME_TEST_RESET=true` (off in production) **and** still requires the bridge secret;
- it clears the client/command/token maps and cancels any pending long-poll waiters (timeout handle + open response) before dropping them.

Result: file **~11.6s → ~1.7s** (test bodies 3.96s → 0.8s), and the `pickPort`/spawn TOCTOU race goes from once-per-test to a single occurrence.

**`PanelFocusRecovery.test.tsx` — fake timers for the no-fire debounce** (`ec800e9`)
The two "nothing recovered" cases really slept `350ms + 350ms + 20ms` of wall time. That path does zero DB I/O, so faking the clock is safe and deterministic. ~840ms/run reclaimed.

**`useOverrides.test.tsx` — faked clock instead of a 2ms sleep** (`ec800e9`)
Replaced the real 2ms `Date.now()`-token sleep with a faked-clock 1ms advance, removing a latent timing flake.

## Honest scope notes
Two audit items turned out **not** to be timer work and were reclassified to #112 (the kernelQueries / grouped-backlinks "no-fire" sleeps wait on a real `db.onChange` round-trip — they need a tracer-bullet restructure, not fake timers). The `HotkeyReconciler` real-timer test is **intentional** (mirrors browser commit/effect-flush ordering) and stays. The `roam-import` `minimalExport` "duplication" was a **false positive** — the two fixtures diverge by design (see #110) — so it's a won't-do, not a skip.

## Verification
Full `yarn run check` green: **268 files / 2894 tests passed**.

Closes #110.

https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB)_