### PR TITLE
Layout B observer: drain the queue in bounded windows

### DIFF
--- a/src/plugins/sync-status/SyncStatusHeaderItem.tsx
+++ b/src/plugins/sync-status/SyncStatusHeaderItem.tsx
@@ -23,6 +23,7 @@ import {
 } from './model.ts'
 import {
   formatPendingChanges,
+  materializeQueueCountSql,
   uploadQueueCountCap,
   uploadQueueExactCountSql,
   uploadQueuePreviewCountSql,
@@ -142,6 +143,7 @@ export function SyncStatusHeaderItem() {
         pendingChanges={0}
         pendingChangesApproximate={false}
         rejectedCount={rejectedCount}
+        materializingChanges={0}
         localErrorMessage={localErrorMessage}
       />
     )
@@ -179,6 +181,19 @@ function RemoteSyncStatusHeaderContent({
   const pendingChangesApproximate = previewCount > uploadQueueCountCap
   const pendingChanges = pendingChangesApproximate ? uploadQueueCountCap : previewCount
 
+  // Staged rows the Layout B observer hasn't applied to `blocks` yet. The change
+  // queue mutates every drain window, so watch it throttled like the upload
+  // preview; it counts down to 0 as the backlog materializes.
+  const materializeQueue = useQuery<UploadQueueCountRow>(
+    materializeQueueCountSql,
+    [],
+    {
+      reportFetching: false,
+      throttleMs: uploadQueuePreviewThrottleMs,
+    },
+  )
+  const materializingChanges = Number(materializeQueue.data[0]?.count ?? 0)
+
   return (
     <SyncStatusHeaderContent
       localOnly={false}
@@ -186,6 +201,7 @@ function RemoteSyncStatusHeaderContent({
       pendingChanges={pendingChanges}
       pendingChangesApproximate={pendingChangesApproximate}
       rejectedCount={rejectedCount}
+      materializingChanges={materializingChanges}
       localErrorMessage={queue.error?.message ?? baseLocalErrorMessage}
     />
   )
@@ -197,6 +213,7 @@ interface SyncStatusHeaderContentProps {
   pendingChanges: number
   pendingChangesApproximate: boolean
   rejectedCount: number
+  materializingChanges: number
   localErrorMessage: string | null
 }
 
@@ -206,6 +223,7 @@ function SyncStatusHeaderContent({
   pendingChanges,
   pendingChangesApproximate,
   rejectedCount,
+  materializingChanges,
   localErrorMessage,
 }: SyncStatusHeaderContentProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -236,6 +254,7 @@ function SyncStatusHeaderContent({
     pendingChanges,
     pendingChangesApproximate,
     rejectedChanges: rejectedCount,
+    materializingChanges,
     downloadFraction: status.downloadProgress?.downloadedFraction ?? null,
     errorMessage,
     lastSyncedAt: status.lastSyncedAt,
@@ -284,6 +303,14 @@ function SyncStatusHeaderContent({
                 <>
                   <div className="text-muted-foreground">Progress</div>
                   <div className="text-right">{view.progressPercent}%</div>
+                </>
+              )}
+              {materializingChanges > 0 && (
+                <>
+                  <div className="text-muted-foreground">Processing</div>
+                  <div className="text-right">
+                    {materializingChanges.toLocaleString()} {materializingChanges === 1 ? 'block' : 'blocks'}
+                  </div>
                 </>
               )}
               <div className="text-muted-foreground">Last sync</div>

--- a/src/plugins/sync-status/model.ts
+++ b/src/plugins/sync-status/model.ts
@@ -3,6 +3,7 @@ export type SyncIndicatorState =
   | 'local'
   | 'uploading'
   | 'downloading'
+  | 'materializing'
   | 'pending'
   | 'connecting'
   | 'offline'
@@ -28,6 +29,13 @@ export interface SyncIndicatorInput {
    *  Defaults to 0 so callers that don't pipe it in stay backwards-
    *  compatible. */
   rejectedChanges?: number
+  /** Rows synced into the `blocks_synced` staging table but not yet applied to
+   *  the app-visible `blocks` table — the Layout B observer's
+   *  `blocks_synced_changes` backlog. Non-zero means downloaded data hasn't
+   *  fully surfaced in the UI yet (e.g. a large initial sync still draining).
+   *  Defaults to 0 so callers that don't pipe it in stay unaffected. */
+  materializingChanges?: number
+  materializingChangesApproximate?: boolean
   downloadFraction?: number | null
   errorMessage?: string | null
   lastSyncedAt?: Date
@@ -102,6 +110,8 @@ export const getSyncIndicatorView = ({
   pendingChanges,
   pendingChangesApproximate = false,
   rejectedChanges = 0,
+  materializingChanges = 0,
+  materializingChangesApproximate = false,
   downloadFraction,
   errorMessage,
   lastSyncedAt,
@@ -156,6 +166,29 @@ export const getSyncIndicatorView = ({
       ),
       pendingLabel,
       progressPercent,
+      spinning: true,
+    }
+  }
+
+  // Downloaded data that hasn't been applied to `blocks` yet is invisible in the
+  // UI, so surface the catch-up explicitly — above uploading/pending/offline/
+  // synced (all of which would otherwise misreport "done" while content is still
+  // missing), but below an active download (its % is the upstream progress) and
+  // below a hard error.
+  if (materializingChanges > 0) {
+    return {
+      state: 'materializing',
+      tone: 'active',
+      icon: 'sync',
+      label: 'Processing',
+      title: appendPendingTitle(
+        `Applying ${formatChangeCount(materializingChanges, materializingChangesApproximate)} of synced data to this device.`,
+        pendingChanges,
+        false,
+        pendingChangesApproximate,
+      ),
+      pendingLabel,
+      progressPercent: null,
       spinning: true,
     }
   }

--- a/src/plugins/sync-status/queueCounts.ts
+++ b/src/plugins/sync-status/queueCounts.ts
@@ -18,6 +18,15 @@ export const uploadQueuePreviewCountSql =
 export const uploadQueueExactCountSql =
   `SELECT COUNT(DISTINCT json_extract(data, '$.id')) AS count FROM ps_crud`
 
+// Rows downloaded into the `blocks_synced` staging table but not yet applied to
+// the app-visible `blocks` table — the Layout B observer's materialization
+// backlog (its `blocks_synced_changes` change queue; see observer.ts). It drains
+// to 0 as the observer catches up, so the indicator counts down. A plain
+// single-table COUNT(*) — cheap even at a large initial-sync backlog, and the
+// real magnitude is worth showing, so it isn't capped like the upload preview.
+export const materializeQueueCountSql =
+  'SELECT COUNT(*) AS count FROM blocks_synced_changes'
+
 export const formatPendingChanges = (
   count: number,
   localOnly: boolean,

--- a/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
+++ b/src/plugins/sync-status/test/SyncStatusHeaderItem.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SyncStatusHeaderItem } from '../SyncStatusHeaderItem.tsx'
 import {
+  materializeQueueCountSql,
   uploadQueueCountCap,
   uploadQueueExactCountSql,
   uploadQueuePreviewCountSql,
@@ -121,6 +122,39 @@ describe('SyncStatusHeaderItem', () => {
 
     expect(await screen.findByText('1,032,688 blocks changed, stored locally')).toBeInTheDocument()
     expect(mocks.queryCalls.some(call => call.sql === uploadQueueExactCountSql)).toBe(true)
+  })
+
+  it('surfaces the materialization backlog as a processing state with a count', async () => {
+    // No pending uploads — just a staged backlog the observer hasn't applied yet.
+    mocks.queryResponses.set(uploadQueuePreviewCountSql, {data: [{count: 0}]})
+    mocks.queryResponses.set(materializeQueueCountSql, {data: [{count: 12_340}]})
+
+    render(<SyncStatusHeaderItem/>)
+
+    const button = screen.getByRole('button')
+    expect(button.getAttribute('aria-label')).toContain('Applying 12340 blocks of synced data')
+
+    fireEvent.pointerDown(button)
+    expect(await screen.findByText('12,340 blocks')).toBeInTheDocument()
+  })
+
+  it('shows the materializing state over a pending upload backlog (content is still missing)', () => {
+    // Default mock has a capped (1000+) pending-upload count → would be "pending";
+    // an unapplied staged backlog is the more important signal.
+    mocks.queryResponses.set(materializeQueueCountSql, {data: [{count: 5}]})
+
+    render(<SyncStatusHeaderItem/>)
+
+    expect(screen.getByRole('button').getAttribute('aria-label'))
+      .toContain('Applying 5 blocks of synced data')
+  })
+
+  it('does not watch the materialization queue for the local-only header state', () => {
+    mocks.localOnly = true
+
+    render(<SyncStatusHeaderItem/>)
+
+    expect(mocks.queryCalls.some(call => call.sql === materializeQueueCountSql)).toBe(false)
   })
 
   it('shows a calm "offline" state instead of the websocket error when the device is offline', () => {

--- a/src/plugins/sync-status/test/model.test.ts
+++ b/src/plugins/sync-status/test/model.test.ts
@@ -79,6 +79,67 @@ describe('getSyncIndicatorView', () => {
     expect(view.pendingLabel).toBe('2')
   })
 
+  describe('materializing backlog (Layout B observer catch-up)', () => {
+    // Rows can be downloaded into the `blocks_synced` staging table but not yet
+    // applied to the app-visible `blocks` table — a large initial sync drains in
+    // bounded windows. While that backlog is non-zero the content isn't on
+    // screen yet, so "Synced"/"Offline" would misreport; surface a catch-up.
+
+    it('shows a processing state with the remaining count', () => {
+      const view = getSyncIndicatorView({
+        ...baseInput,
+        materializingChanges: 12_340,
+      })
+
+      expect(view.state).toBe('materializing')
+      expect(view.label).toBe('Processing')
+      expect(view.spinning).toBe(true)
+      expect(view.title).toContain('12340 blocks')
+    })
+
+    it('outranks the synced chip — downloaded data that is not applied is not "done"', () => {
+      const view = getSyncIndicatorView({
+        ...baseInput,
+        hasSynced: true,
+        materializingChanges: 5,
+      })
+
+      expect(view.state).toBe('materializing')
+    })
+
+    it('surfaces over offline so a disconnected backlog is still visible', () => {
+      const view = getSyncIndicatorView({
+        ...baseInput,
+        connected: false,
+        hasSynced: true,
+        materializingChanges: 500,
+      })
+
+      expect(view.state).toBe('materializing')
+    })
+
+    it('yields to an active download (its percentage is the leading progress)', () => {
+      const view = getSyncIndicatorView({
+        ...baseInput,
+        downloading: true,
+        downloadFraction: 0.4,
+        materializingChanges: 9_000,
+      })
+
+      expect(view.state).toBe('downloading')
+    })
+
+    it('yields to a hard error', () => {
+      const view = getSyncIndicatorView({
+        ...baseInput,
+        errorMessage: 'JWT expired',
+        materializingChanges: 9_000,
+      })
+
+      expect(view.state).toBe('error')
+    })
+  })
+
   describe('quarantined / rejected changes', () => {
     // When the bucket is otherwise drained, a green "Synced" check
     // misrepresents the state of the data: the server refused some

--- a/src/sync/observer/materialize.test.ts
+++ b/src/sync/observer/materialize.test.ts
@@ -245,6 +245,40 @@ describe('materializeStagingRows — skip-stale (local edit must win)', () => {
   })
 })
 
+describe('materializeStagingRows — batched gate (mixed outcomes, chunked)', () => {
+  it('keeps each id\'s gate state separate when the local reads are bulked across chunks', async () => {
+    // The Phase-1/Phase-2 gate reads (local updated_at, pending uploads, before
+    // rows) are bulked per batch rather than probed per row. Drive three ids to
+    // three different outcomes in ONE pass, with a chunk size that splits them,
+    // so a map that crossed an id with another's state would surface here.
+
+    // apply: strictly-newer staging snapshot, no local row.
+    await stageRow(blockData({ id: 'apply', content: 'fresh', updatedAt: 300 }))
+    // skip: local row is newer than the staging snapshot.
+    await seedLocalBlock(blockData({ id: 'newer', content: 'local newer', updatedAt: 500 }))
+    await stageRow(blockData({ id: 'newer', content: 'stale server', updatedAt: 200 }))
+    // skip: an unsent local edit is queued for this id (pending always wins).
+    await seedLocalBlock(blockData({ id: 'pending', content: 'local pending', updatedAt: 100 }))
+    await env.db.execute(
+      "INSERT INTO ps_crud (tx_id, data) VALUES (1, json_object('op','PATCH','type','blocks','id',?,'data',json_object()))",
+      ['pending'],
+    )
+    await stageRow(blockData({ id: 'pending', content: 'server snapshot', updatedAt: 999 }))
+
+    const out = await materializeStagingRows(
+      env.db,
+      { upserted: ['apply', 'newer', 'pending'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey },
+      { readChunkSize: 2 }, // 3 ids → 2 read chunks, so the bulk maps span a boundary
+    )
+
+    expect(out.applied).toEqual(['apply'])
+    expect([...out.skippedStale].sort()).toEqual(['newer', 'pending'])
+    const byId = Object.fromEntries((await allBlocks()).map(b => [b.id, b.content]))
+    expect(byId).toEqual({ apply: 'fresh', newer: 'local newer', pending: 'local pending' })
+  })
+})
+
 describe('materializeStagingRows — quarantine (undecryptable)', () => {
   it('quarantines a row whose ciphertext fails AEAD, still applying a valid sibling', async () => {
     const key = await importWorkspaceKey(generateWorkspaceKeyBytes())

--- a/src/sync/observer/materialize.ts
+++ b/src/sync/observer/materialize.ts
@@ -59,36 +59,27 @@ const UPSERT_BLOCK_SQL = `
 
 const DELETE_BLOCK_SQL = 'DELETE FROM blocks WHERE id = ?'
 
-// Full pre-write row, both for the LWW gate (updated_at) and for the
-// invalidation `before` snapshot the observer emits (parent-edge / plugin
-// channels need the prior parent_id, content, properties, etc.).
-const SELECT_BLOCK_BY_ID_SQL = `SELECT ${COLUMN_NAMES.join(', ')} FROM blocks WHERE id = ?`
-
-const PENDING_UPLOAD_SQL = `
-  SELECT 1 AS one FROM ps_crud
-   WHERE json_extract(data, '$.id') = ?
-     AND json_extract(data, '$.type') = 'blocks'
-   LIMIT 1
+// All block ids with an unsent local edit queued for upload. A pending edit
+// always wins over an incoming snapshot (the echo reconciles), so the gate
+// needs this set. `ps_crud.data` is the upload envelope the blocks_upload_*
+// triggers write: `{op, type, id, data}`. DISTINCT ids only — an editing burst
+// fans out to many crud rows for one block. Read once per pass instead of a
+// per-row probe: the queue holds only local, not-yet-synced edits (tiny in
+// steady state, empty during a large initial download).
+const PENDING_UPLOAD_IDS_SQL = `
+  SELECT DISTINCT json_extract(data, '$.id') AS id FROM ps_crud
+   WHERE json_extract(data, '$.type') = 'blocks'
 `
 
 const blockRowParams = (row: BlockRow): unknown[] =>
   COLUMN_NAMES.map(name => row[name])
 
-/** Read-only surface both the auto-commit DB and an open `TxDb` satisfy, so
- *  the reconcile reads can run either outside the write tx (Phase 1 pre-gate)
- *  or inside it (Phase 2 authoritative re-check). */
-type Reader = {
-  getOptional<T>(sql: string, params?: unknown[]): Promise<T | null>
+/** Minimal read surface both the auto-commit DB and an open write-tx (`TxDb`)
+ *  satisfy, so the bulk gate reads run either outside the write tx (Phase 1
+ *  pre-gate) or inside it (Phase 2 authoritative re-check). */
+type RowsReader = {
+  getAll<T>(sql: string, params?: unknown[]): Promise<T[]>
 }
-
-/** True if PowerSync's upload queue holds an unsent local edit for this id. */
-const hasPendingUpload = async (db: Reader, id: string): Promise<boolean> =>
-  (await db.getOptional<{ one: number }>(PENDING_UPLOAD_SQL, [id])) !== null
-
-const localUpdatedAt = async (db: Reader, id: string): Promise<number | null> =>
-  (await db.getOptional<{ updated_at: number }>(
-    'SELECT updated_at FROM blocks WHERE id = ?', [id],
-  ))?.updated_at ?? null
 
 /** Resolve how a workspace's rows can be materialized right now. The policy
  *  (pin lookup, WK presence, §6 quarantine) is injected; the observer core
@@ -175,6 +166,50 @@ const readStagingRows = async (
   return out
 }
 
+/** Local `updated_at` for the `ids` the app already has a `blocks` row for (the
+ *  LWW gate's local stamp), keyed by id. Chunked so the IN-clause never exceeds
+ *  SQLite's bound-parameter limit. Absent ids = no local row. */
+const readLocalUpdatedAt = async (
+  db: RowsReader, ids: readonly string[], chunkSize: number,
+): Promise<Map<string, number>> => {
+  const out = new Map<string, number>()
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    const chunk = ids.slice(i, i + chunkSize)
+    const rows = await db.getAll<{ id: string; updated_at: number }>(
+      `SELECT id, updated_at FROM blocks WHERE id IN (${buildInClause(chunk.length)})`,
+      chunk,
+    )
+    for (const row of rows) out.set(row.id, row.updated_at)
+  }
+  return out
+}
+
+/** Full pre-write `blocks` rows for `ids`, keyed by id — serves both the LWW
+ *  gate's local stamp and the invalidation `before` snapshot (parent-edge /
+ *  plugin channels need the prior parent_id, content, properties, etc.).
+ *  Chunked like the staging read. */
+const readBlocksByIds = async (
+  db: RowsReader, ids: readonly string[], chunkSize: number,
+): Promise<Map<string, BlockRow>> => {
+  const out = new Map<string, BlockRow>()
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    const chunk = ids.slice(i, i + chunkSize)
+    const rows = await db.getAll<BlockRow>(
+      `SELECT ${COLUMN_NAMES.join(', ')} FROM blocks WHERE id IN (${buildInClause(chunk.length)})`,
+      chunk,
+    )
+    for (const row of rows) out.set(row.id, row)
+  }
+  return out
+}
+
+/** Block ids with an unsent local edit queued for upload (a single read of the
+ *  whole upload queue, not a per-row probe). */
+const readPendingUploadIds = async (db: RowsReader): Promise<Set<string>> => {
+  const rows = await db.getAll<{ id: string }>(PENDING_UPLOAD_IDS_SQL)
+  return new Set(rows.map(row => row.id))
+}
+
 /** Tunables (batch sizing). Defaults are production values; tests override. */
 export interface MaterializeOptions {
   readonly readChunkSize?: number
@@ -209,6 +244,15 @@ export const materializeStagingRows = async (
 
   const stagingRows = await readStagingRows(db, change.upserted, readChunkSize)
 
+  // Bulk-read the gate's local state for the whole batch up front, rather than
+  // two awaited probes per row. On a large backlog those per-row probes — a
+  // `blocks` lookup plus a `ps_crud` json_extract scan, each a serialized
+  // round-trip to the SQLite worker — were the dominant cost, not the copy.
+  const localUpdatedAtById = await readLocalUpdatedAt(
+    db, stagingRows.map(row => row.id), readChunkSize,
+  )
+  const pendingUploadIds = await readPendingUploadIds(db)
+
   const materializabilityByWs = new Map<string, Materializability>()
   const resolveMaterializability = async (workspaceId: string): Promise<Materializability> => {
     const cached = materializabilityByWs.get(workspaceId)
@@ -227,8 +271,8 @@ export const materializeStagingRows = async (
       continue
     }
     const action = decideStagingRow(materializability, row.updated_at, {
-      localUpdatedAt: await localUpdatedAt(db, row.id),
-      hasPendingUpload: await hasPendingUpload(db, row.id),
+      localUpdatedAt: localUpdatedAtById.get(row.id) ?? null,
+      hasPendingUpload: pendingUploadIds.has(row.id),
     })
     if (action.kind !== 'apply') {
       // Skip-stale BEFORE decrypt: a stale ciphertext never gets decoded.
@@ -270,13 +314,23 @@ export const materializeStagingRows = async (
     // set it explicitly to defend against any stale value.
     await tx.execute('UPDATE tx_context SET source = NULL WHERE id = 1')
 
+    // Re-gate authoritatively INSIDE the lock, but bulk-read the inputs once.
+    // Candidate ids are distinct (deduped upstream) so no upsert below feeds a
+    // later candidate's before-row, and the NULL-source upserts never touch
+    // `ps_crud` — so one up-front read of each input equals a per-row probe,
+    // with far fewer round-trips. The before-rows double as the `before`
+    // invalidation snapshots.
+    const beforeRowById = await readBlocksByIds(
+      tx, candidates.map(candidate => candidate.plaintext.id), readChunkSize,
+    )
+    const pendingNow = await readPendingUploadIds(tx)
+
     for (const candidate of candidates) {
       const { plaintext, stagingUpdatedAt, materializability } = candidate
-      // The before-row read is also the LWW gate's local state — one read.
-      const beforeRow = await tx.getOptional<BlockRow>(SELECT_BLOCK_BY_ID_SQL, [plaintext.id])
+      const beforeRow = beforeRowById.get(plaintext.id) ?? null
       const action = decideStagingRow(materializability, stagingUpdatedAt, {
         localUpdatedAt: beforeRow?.updated_at ?? null,
-        hasPendingUpload: await hasPendingUpload(tx, plaintext.id),
+        hasPendingUpload: pendingNow.has(plaintext.id),
       })
       if (action.kind === 'apply') {
         await tx.execute(UPSERT_BLOCK_SQL, blockRowParams(plaintext))
@@ -291,11 +345,12 @@ export const materializeStagingRows = async (
       }
     }
 
+    const removedBeforeById = await readBlocksByIds(tx, change.removed, readChunkSize)
     for (const id of change.removed) {
-      const beforeRow = await tx.getOptional<BlockRow>(SELECT_BLOCK_BY_ID_SQL, [id])
       await tx.execute(DELETE_BLOCK_SQL, [id])
       deleted.push(id)
       // Only a row that actually existed locally has anything to invalidate.
+      const beforeRow = removedBeforeById.get(id)
       if (beforeRow) snapshots.set(id, { before: parseBlockRow(beforeRow), after: null })
     }
   })

--- a/src/sync/observer/observer.test.ts
+++ b/src/sync/observer/observer.test.ts
@@ -63,6 +63,8 @@ const start = (opts: {
   getMaterializability: GetMaterializability
   getCek?: GetCek
   onCycleDetected?: (e: CycleDetectedEvent) => void
+  drainChunkSize?: number
+  onError?: (err: unknown) => void
 }): Harness => {
   const cache = new BlockCache()
   const notifications: ChangeNotification[] = []
@@ -73,6 +75,8 @@ const start = (opts: {
     deps: { getMaterializability: opts.getMaterializability, getCek: opts.getCek ?? noKey },
     onCycleDetected: opts.onCycleDetected,
     throttleMs: 5,
+    drainChunkSize: opts.drainChunkSize,
+    onError: opts.onError,
   })
   observers.push(observer)
   return { observer, cache, notifications }
@@ -209,6 +213,50 @@ describe('blocksSyncedObserver — robustness', () => {
     // materialize unit level.)
     expect(await blocks()).toEqual([{ id: 'good', content: 'readable' }])
     expect(await queueLen()).toBe(0)
+  })
+
+  it('drains a backlog larger than the chunk size across bounded windows', async () => {
+    // 5 distinct queued rows, chunk size 2 → three windows (2 + 2 + 1). One
+    // flush must loop until the whole backlog is materialized and the queue is
+    // empty — the regression was a single unbounded pass over the entire queue.
+    for (let i = 0; i < 5; i++) await put(data({ id: `b${i}`, content: `c${i}` }))
+    const { observer } = start({ getMaterializability: constMat('copy'), drainChunkSize: 2 })
+
+    await observer.flush()
+
+    expect(await blocks()).toEqual([
+      { id: 'b0', content: 'c0' }, { id: 'b1', content: 'c1' },
+      { id: 'b2', content: 'c2' }, { id: 'b3', content: 'c3' },
+      { id: 'b4', content: 'c4' },
+    ])
+    expect(await queueLen()).toBe(0)
+  })
+
+  it('commits each window independently, so a mid-backlog failure keeps prior progress', async () => {
+    for (let i = 0; i < 4; i++) await put(data({ id: `b${i}`, content: `c${i}` }))
+    // getMaterializability is resolved once per window (all rows share a
+    // workspace); throw on the second window so its materialize aborts.
+    let windows = 0
+    const getMaterializability: GetMaterializability = () => {
+      windows += 1
+      if (windows >= 2) throw new Error('boom')
+      return 'copy'
+    }
+    const errors: unknown[] = []
+    const { observer } = start({
+      getMaterializability, drainChunkSize: 2, onError: e => errors.push(e),
+    })
+
+    await observer.flush()
+
+    // First window (b0,b1) committed and consumed; the second window's failure
+    // left its rows queued for a later retry rather than rolling back everything.
+    expect(await blocks()).toEqual([{ id: 'b0', content: 'c0' }, { id: 'b1', content: 'c1' }])
+    expect(await queueLen()).toBe(2)
+    // The failure surfaced via onError (the initial start() drain and the
+    // explicit flush both reach the throwing window); it never rejects flush().
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    expect(errors.every(e => e instanceof Error && e.message === 'boom')).toBe(true)
   })
 
   it('survives a restart: a queued change persists for a fresh observer (durable queue)', async () => {

--- a/src/sync/observer/observer.ts
+++ b/src/sync/observer/observer.ts
@@ -7,14 +7,19 @@
  * append `(seq, id, op)` to `blocks_synced_changes`; this driver drains that
  * log and turns each change into the app-visible plaintext `blocks` table.
  *
- * DRAIN (race- and failure-safe, the row_events watermark pattern):
- *   1. read the queue up to MAX(seq),
- *   2. dedup per id (latest op wins — a hot row materializes once per batch),
+ * DRAIN (race- and failure-safe, the row_events watermark pattern). Loops over
+ * the queue in bounded seq-ordered windows ({@link DEFAULT_DRAIN_CHUNK}) until
+ * it's empty — a large initial sync or a long observer-down backlog can queue
+ * hundreds of thousands of changes, and one unbounded pass would build the whole
+ * working set in memory and wrap every write in a single transaction. Per window:
+ *   1. read the next <= chunk changes (ORDER BY seq LIMIT chunk),
+ *   2. dedup per id (latest op wins — a hot row materializes once per window),
  *   3. `materializeStagingRows` (decrypt/copy/defer/skip/delete) +
  *      `applySyncInvalidation` (cache + handles, one LWW gate),
- *   4. `DELETE … WHERE seq <= <that max>`.
- * A delivery that lands mid-drain gets a higher seq, so step 4 can't drop it;
- * if any step throws, the delete is skipped and the rows retry next tick.
+ *   4. `DELETE … WHERE seq <= <that window's max>`.
+ * A delivery that lands mid-drain gets a higher seq, so step 4 can't drop it —
+ * it's picked up by a later window. If any step throws, that window's delete is
+ * skipped (prior committed windows survive) and the rows retry next tick.
  *
  * Drains serialize on a single promise chain, so two never overlap (duplicate
  * invalidations) and `flush()` is a real settle barrier for tests.
@@ -48,6 +53,13 @@ import {
  *  sync-burst arrivals into one batched drain. */
 const DEFAULT_THROTTLE_MS = 100
 
+/** Max queued changes materialized per drain window. Draining a large backlog in
+ *  bounded, individually-committed windows (rather than one unbounded pass) keeps
+ *  memory flat, makes progress durable across reloads/crashes, and lets the UI
+ *  fill in as it goes: the queue is consumed per window, so an interrupted drain
+ *  resumes from the last committed window instead of restarting from zero. */
+const DEFAULT_DRAIN_CHUNK = 1000
+
 export interface BlocksSyncedObserverArgs {
   readonly db: PowerSyncDb
   readonly cache: SyncCache
@@ -61,6 +73,9 @@ export interface BlocksSyncedObserverArgs {
    *  rowEventsTail. txIdsInvolved is always empty (sync writes carry no tx_id). */
   readonly onCycleDetected?: (event: CycleDetectedEvent) => void
   readonly throttleMs?: number
+  /** Max changes materialized per drain window (default {@link DEFAULT_DRAIN_CHUNK}).
+   *  Tests shrink it to exercise multi-window backlogs. */
+  readonly drainChunkSize?: number
   readonly onError?: (err: unknown) => void
 }
 
@@ -116,6 +131,7 @@ export const startBlocksSyncedObserver = (
 ): BlocksSyncedObserver => {
   const { db, cache, handleStore, deps, getInvalidationRules, onCycleDetected } = args
   const throttleMs = args.throttleMs ?? DEFAULT_THROTTLE_MS
+  const drainChunk = Math.max(1, args.drainChunkSize ?? DEFAULT_DRAIN_CHUNK)
   const rules = (): readonly InvalidationRule[] => getInvalidationRules?.() ?? []
   const onError = args.onError ?? ((err: unknown) => {
     if (!isConnectionClosedError(err)) console.warn('[blocksSyncedObserver] drain error:', err)
@@ -151,26 +167,41 @@ export const startBlocksSyncedObserver = (
   }
 
   const drainQueueOnce = async (): Promise<void> => {
-    if (disposed) return
-    const rows = await db.getAll<QueueRow>(
-      'SELECT seq, id, op FROM blocks_synced_changes ORDER BY seq',
-    )
-    if (rows.length === 0) return
-    const maxSeq = rows[rows.length - 1]!.seq
+    // Loop over the queue in bounded seq-ordered windows until it's empty, so a
+    // large backlog never builds the whole working set in one in-memory pass /
+    // one transaction. Each window commits independently (step 4), so the next
+    // window — and any retry after a throw — resumes from the last consumed seq.
+    for (;;) {
+      if (disposed) return
+      const rows = await db.getAll<QueueRow>(
+        'SELECT seq, id, op FROM blocks_synced_changes ORDER BY seq LIMIT ?',
+        [drainChunk],
+      )
+      if (rows.length === 0) return
+      const maxSeq = rows[rows.length - 1]!.seq
 
-    // Latest op per id (rows are seq-ordered, so a later op overwrites).
-    const opById = new Map<string, 'upsert' | 'delete'>()
-    for (const row of rows) opById.set(row.id, row.op)
-    const upserted: string[] = []
-    const removed: string[] = []
-    for (const [id, op] of opById) (op === 'upsert' ? upserted : removed).push(id)
+      // Latest op per id within this window (rows are seq-ordered, so a later op
+      // overwrites). Cross-window order holds too: windows run in seq order, so a
+      // hot id's final state is set by whichever window holds its last change, and
+      // re-materializing it in a later window is an idempotent LWW-gated write.
+      const opById = new Map<string, 'upsert' | 'delete'>()
+      for (const row of rows) opById.set(row.id, row.op)
+      const upserted: string[] = []
+      const removed: string[] = []
+      for (const [id, op] of opById) (op === 'upsert' ? upserted : removed).push(id)
 
-    const outcome = await materializeStagingRows(db, { upserted, removed }, deps)
-    await applyOutcome(outcome)
+      const outcome = await materializeStagingRows(db, { upserted, removed }, deps)
+      await applyOutcome(outcome)
 
-    // Consume only what we read. Rows appended mid-drain have seq > maxSeq and
-    // survive for the next pass. Done last so a throw above leaves them queued.
-    await db.execute('DELETE FROM blocks_synced_changes WHERE seq <= ?', [maxSeq])
+      // Consume only this window. Rows appended mid-drain have seq > maxSeq and
+      // survive for a later window. Done last so a throw above leaves this window
+      // queued (prior committed windows are not rolled back).
+      await db.execute('DELETE FROM blocks_synced_changes WHERE seq <= ?', [maxSeq])
+
+      // A short final window means the queue is drained; stop without an extra
+      // empty read. (Rows arriving after this still re-trigger via onChange.)
+      if (rows.length < drainChunk) return
+    }
   }
 
   const materializeWorkspace = async (workspaceId: string): Promise<void> => {


### PR DESCRIPTION
The observer's drainQueueOnce read the ENTIRE blocks_synced_changes queue
and passed every id to materializeStagingRows in one pass: a single in-memory
working set plus one giant writeTransaction. On a large initial sync or a long
observer-down backlog (e.g. ~339k rows after the Layout B cutover) that pass
either grinds for many minutes or OOM-crashes the tab before committing — and
since the queue is consumed only after a full successful pass, every reload
restarts it from zero. The data lands in blocks_synced but never materializes
into blocks, so the app shows almost no content despite "synced" data.

Drain in bounded seq-ordered windows (DEFAULT_DRAIN_CHUNK) until empty, each
window committed and consumed independently. seq is a unique AUTOINCREMENT PK,
so `ORDER BY seq LIMIT n` + `DELETE WHERE seq <= maxSeq` consumes exactly the
window; rows arriving mid-drain get higher seqs and are picked up by a later
window. Memory stays flat, progress is durable across reloads/crashes, and the
UI fills in as windows commit. Clients that accreted data incrementally were
unaffected; only a single large backlog tripped the old path.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>