### PR TITLE
Fix test-suite flakiness (userSchemas, roam-import, no-fire sleeps, dueCards tx_id)

### DIFF
--- a/src/data/internals/kernelQueries.test.ts
+++ b/src/data/internals/kernelQueries.test.ts
@@ -705,15 +705,20 @@ describe('invalidation', () => {
     const handle = env.repo.query.childIds(args)
     await handle.load()
 
-    const fired: number[] = []
-    const unsub = handle.subscribe(() => { fired.push(1) })
+    const fired: string[][] = []
+    const unsub = handle.subscribe(v => { fired.push(asIds(v as string[])) })
     try {
       // Content-only edit on c1 — bumps rowIds in the tx fast path but
-      // the lean childIds dep set has no row entry, so `matches` is
-      // false and the listener never fires.
+      // the lean childIds dep set has no row entry, so the list must not
+      // re-project.
       await env.repo.tx(tx => tx.update('c1', {content: 'edited'}), {scope: ChangeScope.BlockDefault})
-      await new Promise(r => setTimeout(r, 10))
-      expect(fired.length).toBe(0)
+      // Tracer-bullet: adding a real child DOES invalidate (parent-edge).
+      // Wait for that single emission; a content-edit re-projection would
+      // surface as an extra one. (Replaces a 10 ms sleep that raced the
+      // reader pool under full-suite parallelism.)
+      await create({id: 'c3', parentId: 'p', orderKey: 'a2'})
+      await vi.waitFor(() => expect([...(fired.at(-1) ?? [])].sort()).toEqual(['c1', 'c2', 'c3']))
+      expect(fired.length).toBe(1)
     } finally {
       unsub()
     }
@@ -784,17 +789,21 @@ describe('invalidation', () => {
     const handle = env.repo.query.byType({workspaceId: WS, type: 'note'})
     await handle.load()
 
-    const fired: number[] = []
-    const unsub = handle.subscribe(() => { fired.push(1) })
+    const fired: string[][] = []
+    const unsub = handle.subscribe(v => { fired.push(asBlocks(v as BlockData[]).map(b => b.id)) })
     try {
       await env.repo.tx(async tx => {
         const block = env.repo.block('panel')
         await block.load()
         await tx.update('panel', {properties: {focusedBlockLocation: {blockId: 'something', renderScopeId: 'scope:something'}}})
       }, {scope: ChangeScope.UiState})
-      // Give the handle plenty of opportunity to (incorrectly) re-resolve.
-      await new Promise(r => setTimeout(r, 30))
-      expect(fired.length).toBe(0)
+      // Tracer-bullet: a new matching note DOES invalidate the type channel.
+      // Wait for that single emission; a UiState-triggered re-resolve would
+      // surface as an extra one. (Replaces a 30 ms "give it a chance to
+      // misfire" sleep with a deterministic positive control.)
+      await create({id: 'b', type: 'note'})
+      await vi.waitFor(() => expect([...(fired.at(-1) ?? [])].sort()).toEqual(['a', 'b']))
+      expect(fired.length).toBe(1)
     } finally {
       unsub()
     }
@@ -806,15 +815,19 @@ describe('invalidation', () => {
     const handle = env.repo.query.byType({workspaceId: WS, type: 'note'})
     await handle.load()
 
-    const fired: number[] = []
-    const unsub = handle.subscribe(() => { fired.push(1) })
+    const fired: string[][] = []
+    const unsub = handle.subscribe(v => { fired.push(asBlocks(v as BlockData[]).map(b => b.id)) })
     try {
       await env.repo.tx(
         tx => tx.update('plain', {content: 'edited'}),
         {scope: ChangeScope.BlockDefault},
       )
-      await new Promise(r => setTimeout(r, 30))
-      expect(fired.length).toBe(0)
+      // Tracer-bullet: a new note DOES invalidate. Wait for that single
+      // emission; had the non-matching content edit leaked 'plain' into the
+      // result, it would surface as an earlier (wrong-valued) emission.
+      await create({id: 'b', type: 'note'})
+      await vi.waitFor(() => expect([...(fired.at(-1) ?? [])].sort()).toEqual(['a', 'b']))
+      expect(fired.length).toBe(1)
     } finally {
       unsub()
     }

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -230,9 +230,15 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
     env = await setup()
     const id = await createExternalSchemaBlock('tags')
 
-    const resolved = env.service.getSchemaForBlockId(id)
-    expect(resolved?.name).toBe('tags')
-    expect(resolved?.codec.type).toBe('string')
+    // The block subscription settles over one or more rebuild ticks;
+    // waitForPropertySchemasChange resolves on the first change event, which
+    // under full-suite load can precede the rebuild that registers this
+    // schema. Poll the reverse-map rather than reading it synchronously.
+    await vi.waitFor(() => {
+      const resolved = env.service.getSchemaForBlockId(id)
+      expect(resolved?.name).toBe('tags')
+      expect(resolved?.codec.type).toBe('string')
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
   })
 
   it('returns undefined for unknown block ids', async () => {
@@ -243,7 +249,9 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
   it('drops the reverse-map entry when a block stops resolving to a schema', async () => {
     env = await setup()
     const id = await createExternalSchemaBlock('tags')
-    expect(env.service.getSchemaForBlockId(id)?.name).toBe('tags')
+    await vi.waitFor(() => {
+      expect(env.service.getSchemaForBlockId(id)?.name).toBe('tags')
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
 
     // Blank the name — tryBuildSchema will now drop the block on the
     // next rebuild tick.
@@ -253,7 +261,9 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
       }, {scope: ChangeScope.BlockDefault})
     })
 
-    expect(env.service.getSchemaForBlockId(id)).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(env.service.getSchemaForBlockId(id)).toBeUndefined()
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
   })
 })
 

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -176,7 +176,12 @@ describe('UserSchemasService subscription', () => {
       Editor: (): JSX.Element => createElement('span', null, null),
     })
     env.repo.setRuntimeContributions(valuePresetsFacet, 'plugin', [priorityPreset])
-    expect(env.repo.propertySchemas.get('priority')?.codec.type).toBe('string')
+    // The preset arrival re-resolves the previously-skipped schema on the
+    // valuePresets-change tick. Poll for it rather than assuming the
+    // listener fires synchronously within setRuntimeContributions.
+    await vi.waitFor(() => {
+      expect(env.repo.propertySchemas.get('priority')?.codec.type).toBe('string')
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
   })
 
   it('addSchema-followed-by-immediate-write does not race the subscription tick', async () => {
@@ -222,9 +227,15 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
     env = await setup()
     const id = await createExternalSchemaBlock('tags')
 
-    const resolved = env.service.getSchemaForBlockId(id)
-    expect(resolved?.name).toBe('tags')
-    expect(resolved?.codec.type).toBe('string')
+    // The reverse-map is repopulated by the service's own subscriber, which
+    // can lag the first onPropertySchemasChange: a rebuild pass may run
+    // before the block facade hydrates (tryBuildSchema then skips it). Poll
+    // until the hydrated rebuild lands.
+    await vi.waitFor(() => {
+      const resolved = env.service.getSchemaForBlockId(id)
+      expect(resolved?.name).toBe('tags')
+      expect(resolved?.codec.type).toBe('string')
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
   })
 
   it('returns undefined for unknown block ids', async () => {
@@ -235,7 +246,9 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
   it('drops the reverse-map entry when a block stops resolving to a schema', async () => {
     env = await setup()
     const id = await createExternalSchemaBlock('tags')
-    expect(env.service.getSchemaForBlockId(id)?.name).toBe('tags')
+    await vi.waitFor(() => {
+      expect(env.service.getSchemaForBlockId(id)?.name).toBe('tags')
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
 
     // Blank the name — tryBuildSchema will now drop the block on the
     // next rebuild tick.
@@ -245,7 +258,9 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
       }, {scope: ChangeScope.BlockDefault})
     })
 
-    expect(env.service.getSchemaForBlockId(id)).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(env.service.getSchemaForBlockId(id)).toBeUndefined()
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
   })
 })
 

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -176,12 +176,7 @@ describe('UserSchemasService subscription', () => {
       Editor: (): JSX.Element => createElement('span', null, null),
     })
     env.repo.setRuntimeContributions(valuePresetsFacet, 'plugin', [priorityPreset])
-    // The preset arrival re-resolves the previously-skipped schema on the
-    // valuePresets-change tick. Poll for it rather than assuming the
-    // listener fires synchronously within setRuntimeContributions.
-    await vi.waitFor(() => {
-      expect(env.repo.propertySchemas.get('priority')?.codec.type).toBe('string')
-    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
+    expect(env.repo.propertySchemas.get('priority')?.codec.type).toBe('string')
   })
 
   it('addSchema-followed-by-immediate-write does not race the subscription tick', async () => {
@@ -227,15 +222,9 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
     env = await setup()
     const id = await createExternalSchemaBlock('tags')
 
-    // The reverse-map is repopulated by the service's own subscriber, which
-    // can lag the first onPropertySchemasChange: a rebuild pass may run
-    // before the block facade hydrates (tryBuildSchema then skips it). Poll
-    // until the hydrated rebuild lands.
-    await vi.waitFor(() => {
-      const resolved = env.service.getSchemaForBlockId(id)
-      expect(resolved?.name).toBe('tags')
-      expect(resolved?.codec.type).toBe('string')
-    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
+    const resolved = env.service.getSchemaForBlockId(id)
+    expect(resolved?.name).toBe('tags')
+    expect(resolved?.codec.type).toBe('string')
   })
 
   it('returns undefined for unknown block ids', async () => {
@@ -246,9 +235,7 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
   it('drops the reverse-map entry when a block stops resolving to a schema', async () => {
     env = await setup()
     const id = await createExternalSchemaBlock('tags')
-    await vi.waitFor(() => {
-      expect(env.service.getSchemaForBlockId(id)?.name).toBe('tags')
-    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
+    expect(env.service.getSchemaForBlockId(id)?.name).toBe('tags')
 
     // Blank the name — tryBuildSchema will now drop the block on the
     // next rebuild tick.
@@ -258,9 +245,7 @@ describe('UserSchemasService.getSchemaForBlockId', () => {
       }, {scope: ChangeScope.BlockDefault})
     })
 
-    await vi.waitFor(() => {
-      expect(env.service.getSchemaForBlockId(id)).toBeUndefined()
-    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
+    expect(env.service.getSchemaForBlockId(id)).toBeUndefined()
   })
 })
 

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -176,7 +176,15 @@ describe('UserSchemasService subscription', () => {
       Editor: (): JSX.Element => createElement('span', null, null),
     })
     env.repo.setRuntimeContributions(valuePresetsFacet, 'plugin', [priorityPreset])
-    expect(env.repo.propertySchemas.get('priority')?.codec.type).toBe('string')
+    // The preset arrival re-resolves the previously-skipped schema on the
+    // valuePresets-change tick. Unlike the subscription-path assertions, this
+    // read isn't preceded by an awaited change event, and the
+    // valuePresets-change -> rebuild chain does NOT settle synchronously
+    // within setRuntimeContributions (it flakes under full-suite load), so
+    // poll for the resolved schema.
+    await vi.waitFor(() => {
+      expect(env.repo.propertySchemas.get('priority')?.codec.type).toBe('string')
+    }, {timeout: SUBSCRIPTION_TIMEOUT_MS})
   })
 
   it('addSchema-followed-by-immediate-write does not race the subscription tick', async () => {

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -6,9 +6,10 @@ import {
   ChangeScope,
   type AnyPropertySchema,
   type AnyValuePreset,
+  type BlockData,
+  type PropertySchema,
   type Unsubscribe,
 } from '@/data/api'
-import type { Block } from '@/data/block'
 import type { Repo } from '@/data/repo'
 import {
   presetConfigProp,
@@ -19,6 +20,17 @@ import { PROPERTY_SCHEMA_TYPE } from '@/data/blockTypes'
 import { propertySchemasFacet } from '@/data/facets'
 
 const USER_DATA_SOURCE_ID = 'user-data'
+
+/** Decode a single property straight off a raw row — same logic as
+ *  `Block.peekProperty`, minus the cache-backed facade. The block
+ *  subscription already hands us the authoritative `BlockData`, so
+ *  reading it directly avoids the hydration race where `repo.block(id)`
+ *  could transiently read an un-hydrated facade (peekProperty → undefined)
+ *  and drop a freshly-created schema from the rebuild. */
+const peekRowProperty = <T>(row: BlockData, schema: PropertySchema<T>): T | undefined => {
+  const stored = row.properties[schema.name]
+  return stored === undefined ? undefined : schema.codec.decode(stored)
+}
 
 export interface AddSchemaArgs {
   name: string
@@ -59,9 +71,11 @@ export class UserSchemasService {
    *  previously-skipped schemas resolvable). */
   private presetsListenerDisposer: (() => void) | null = null
 
-  /** Latest blocks list captured by the subscription. Stored so the
-   *  value-preset change path can re-resolve without a fresh DB read. */
-  private latestBlocks: readonly Block[] = []
+  /** Latest rows captured by the subscription. Stored so the value-preset
+   *  change path can re-resolve without a fresh DB read. Kept as raw
+   *  `BlockData` (not Block facades) so rebuilds read the authoritative
+   *  delivered snapshot directly — see `peekRowProperty`. */
+  private latestBlocks: readonly BlockData[] = []
 
   constructor(private readonly repo: Repo) {}
 
@@ -96,7 +110,7 @@ export class UserSchemasService {
       throw new Error('[UserSchemasService] no active workspace at start()')
     }
 
-    const rebuildFromBlocks = (blocks: readonly Block[]) => {
+    const rebuildFromBlocks = (blocks: readonly BlockData[]) => {
       this.latestBlocks = blocks
       const presets = this.repo.valuePresets
       const next: AnyPropertySchema[] = []
@@ -118,12 +132,11 @@ export class UserSchemasService {
 
     this.subscriptionDisposer = this.repo.subscribeBlocks(
       {workspaceId, types: [PROPERTY_SCHEMA_TYPE]},
-      blocks => {
-        // Hydrate to Block facades so we can read codec-decoded
-        // properties (block.get) rather than poking at raw
-        // properties_json shapes.
-        rebuildFromBlocks(blocks.map(b => this.repo.block(b.id)))
-      },
+      // Build straight from the delivered rows: they're the authoritative
+      // query snapshot. Going through repo.block(id) facades instead raced
+      // the BlockCache — an un-hydrated facade would read undefined and
+      // drop a freshly-created schema until a later rebuild tick.
+      blocks => rebuildFromBlocks(blocks),
     )
 
     this.presetsListenerDisposer = this.repo.onValuePresetsChange(() => {
@@ -146,31 +159,31 @@ export class UserSchemasService {
    *  (3) configCodec.decode throws. The block stays in the database
    *  untouched; a fix re-runs this on the next subscription tick. */
   private tryBuildSchema(
-    block: Block,
+    row: BlockData,
     presets: ReadonlyMap<string, AnyValuePreset>,
   ): AnyPropertySchema | null {
-    const presetId = block.peekProperty(presetIdProp) ?? ''
+    const presetId = peekRowProperty(row, presetIdProp) ?? ''
     if (!presetId) {
-      console.warn(`[UserSchemasService] schema block ${block.id} has no presetId`)
+      console.warn(`[UserSchemasService] schema block ${row.id} has no presetId`)
       return null
     }
     const preset = presets.get(presetId)
     if (!preset) {
       console.warn(
-        `[UserSchemasService] schema block ${block.id} references unknown preset ${JSON.stringify(presetId)}; ` +
+        `[UserSchemasService] schema block ${row.id} references unknown preset ${JSON.stringify(presetId)}; ` +
         `preset's plugin may not be loaded`,
       )
       return null
     }
-    const name = block.peekProperty(propertyNameProp) ?? ''
+    const name = peekRowProperty(row, propertyNameProp) ?? ''
     if (!name) {
-      console.warn(`[UserSchemasService] schema block ${block.id} has empty propertyName`)
+      console.warn(`[UserSchemasService] schema block ${row.id} has empty propertyName`)
       return null
     }
     let config: unknown
     if (preset.configCodec) {
       try {
-        const raw = block.peekProperty(presetConfigProp) ?? {}
+        const raw = peekRowProperty(row, presetConfigProp) ?? {}
         config = preset.configCodec.decode(raw)
       } catch (err) {
         console.warn(

--- a/src/plugins/grouped-backlinks/test/query.test.ts
+++ b/src/plugins/grouped-backlinks/test/query.test.ts
@@ -583,12 +583,23 @@ describe('groupedBacklinksDataExtension query', () => {
     })
     await vi.waitFor(() => expect(fired).toEqual([['Project']]))
 
+    // A content-only edit on a source must not re-project the grouping.
     await env.repo.tx(
       tx => tx.update('src-1', {content: 'source content edited'}),
       {scope: ChangeScope.BlockDefault},
     )
-    await new Promise(r => setTimeout(r, 30))
-    expect(fired).toEqual([['Project']])
+    // Tracer-bullet: a reference change DOES re-resolve. Deleting src-2 drops
+    // the 2-member 'Project' group below minGroupSize, so the lone remaining
+    // source falls into the 'Other' fallback. Asserting `fired` ends at
+    // exactly [['Project'], ['Other']] proves the content edit emitted nothing
+    // in between — robust against the loader's structural-diff dedup, which
+    // would let a same-value re-resolve slip past a bare timeout.
+    await env.repo.tx(
+      tx => tx.delete('src-2'),
+      {scope: ChangeScope.BlockDefault},
+    )
+    await vi.waitFor(() => expect(fired.at(-1)).toEqual(['Other']))
+    expect(fired).toEqual([['Project'], ['Other']])
   })
 
   it('re-resolves when a source moves to a different root grouping context', async () => {

--- a/src/plugins/roam-import/test/import.test.ts
+++ b/src/plugins/roam-import/test/import.test.ts
@@ -20,7 +20,7 @@
  * production.
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeScope } from '@/data/api'
 import { aliasesProp, typesProp } from '@/data/properties'
 import { getOrCreatePropertiesPage } from '@/data/propertiesPage'
@@ -99,8 +99,20 @@ let sharedDb: TestDb
 let env: Harness
 beforeAll(async () => { sharedDb = await createTestDb() })
 afterAll(async () => { await sharedDb.cleanup() })
-beforeEach(async () => { env = await setup() })
-afterEach(async () => { await env.h.cleanup() })
+beforeEach(async () => {
+  // Freeze the wall clock (Date only — timers/async stay real) so the
+  // import-log tests that place output on "today's" daily note can't race
+  // the UTC midnight rollover between writeImportLog()'s todayIso() and
+  // the assertion's todayIso(). Block timestamps use the repo's timeCursor,
+  // not Date, so this only pins the daily-note lookup.
+  vi.useFakeTimers({toFake: ['Date']})
+  vi.setSystemTime(new Date('2026-04-28T12:00:00Z'))
+  env = await setup()
+})
+afterEach(async () => {
+  await env.h.cleanup()
+  vi.useRealTimers()
+})
 
 const minimalExport: RoamExport = [
   {

--- a/src/plugins/srs-review/test/dueCards.integration.test.ts
+++ b/src/plugins/srs-review/test/dueCards.integration.test.ts
@@ -34,7 +34,6 @@ const setup = async (): Promise<Harness> => {
   const h = sharedDb
   const cache = new BlockCache()
   let timeCursor = 1700_000_000_000
-  let idCursor = 0
   const repo = new Repo({
     db: h.db,
     cache,
@@ -64,6 +63,15 @@ const setup = async (): Promise<Harness> => {
 
 let sharedDb: TestDb
 let env: Harness
+// Monotonic across the whole file (NOT reset per test). The suite shares one
+// PowerSync DB; tx_id comes from this counter, and an awaited write's
+// command_events insert can land just after the next test's resetTestDb (PS
+// write-behind). A per-test reset to gen-1 made those late ids collide with
+// the next test's own ids on the UNIQUE command_events.tx_id; keeping it
+// monotonic means a leaked id is always lower than the live test's, so it
+// can never collide. Nothing here asserts on generated ids (blocks use
+// explicit ids), so the values themselves don't matter.
+let idCursor = 0
 beforeAll(async () => { sharedDb = await createTestDb() })
 afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })

--- a/src/plugins/srs-review/test/dueCards.integration.test.ts
+++ b/src/plugins/srs-review/test/dueCards.integration.test.ts
@@ -6,7 +6,7 @@
 // excluded — the bug lived in the query engine's three-valued handling
 // of `exclude`, not in the query we build. These tests run the actual
 // query so that regression stays caught.
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { resolveFacetRuntimeSync } from '@/extensions/facet'
 import { ChangeScope, type BlockReference } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
@@ -42,6 +42,13 @@ const setup = async (): Promise<Harness> => {
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
     registerKernelProcessors: false,
+    // No live sync observer (the sanctioned deterministic-timing pattern).
+    // This suite does explicit local writes + queries and never needs
+    // materialization. With it on, a prior test's async observer write — whose
+    // tx_id comes from the per-test `newId` counter (reset to gen-1 each test)
+    // — could land after this test's resetTestDb cleared command_events and
+    // collide on the UNIQUE command_events.tx_id under full-suite load.
+    startSyncObserver: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,
@@ -60,9 +67,6 @@ let env: Harness
 beforeAll(async () => { sharedDb = await createTestDb() })
 afterAll(async () => { await sharedDb.cleanup() })
 beforeEach(async () => { env = await setup() })
-// Dispose the per-test Repo's sync observer so its db.onChange subscription
-// doesn't leak onto the shared DB (closed once in afterAll).
-afterEach(() => { env.repo.stopSyncObserver() })
 
 const create = async (args: {
   id: string


### PR DESCRIPTION
Sweep of latent test-suite nondeterminism, including the flake behind PR #115's red CI. Tracked in #112.

Every fix below was validated by **6 consecutive full-suite runs** (`npx vitest run`, 268 files / 2894 tests) with zero failures after the final commit.

## Fixes

### 1. userSchemasService subscription-rebuild flake — the #115 CI flake
Failed intermittently at `userSchemasService.test.ts:238/226/179` across #115 CI attempts. Two parts:

- **Production** (`842e0e6`): the service rebuilt its `blockId → schema` reverse-map by reading codec-decoded properties through `repo.block(id)` facades, which read the `BlockCache` and can lag the typed-blocks query result — an un-hydrated facade made `tryBuildSchema` skip a freshly-created schema while `onPropertySchemasChange` still fired. Now it builds straight from the authoritative `BlockData` the subscription already delivers (`peekRowProperty` decodes off the row — identical logic to `Block.peekProperty`, minus the cache facade).
- **Tests** (`9e2db90`, `42f8c66`): the subscription still settles over **multiple rebuild ticks** under load, and `waitForPropertySchemasChange` resolves on the *first* change event — which can precede the tick that registers the schema. So the subscription-path and valuePresets-path reads `vi.waitFor`. The synchronous `addSchema`/`appendUserSchema` path stays synchronous.

### 2. roam-import import-log midnight race (`91e1b09`)
`writeImportLog` places output on "today's" daily note via `todayIso()`, and several assertions independently called `todayIso()`; a UTC rollover between them diverged. Froze `Date` only (timers/async stay real) in `beforeEach`.

### 3. "No-fire" fixed sleeps (`ceffab5`)
`kernelQueries.test.ts` (L715/796/816) and `grouped-backlinks/query.test.ts` asserted "an unrelated write does NOT re-resolve" by sleeping 10–30 ms then checking nothing fired. The loader's structural-diff dedup makes a same-value re-resolve fire nothing anyway, so the sleep was a pure wall-clock bet (the 10 ms one was already documented as racing the reader pool). Replaced with a deterministic **control-write fence**: after the unrelated write, issue a write that *does* change the value, `vi.waitFor` that single emission, then assert the exact emission sequence — robust against the dedup + mid-load coalescing, and faster.

### 4. dueCards `command_events.tx_id` UNIQUE collision (`92b9be6`, `ce5baab`)
Surfaced while validating the above (~50% under full-suite load): `SqliteError: UNIQUE constraint failed: command_events.tx_id`. The suite shares one PowerSync DB across its tests; an awaited write's `command_events` insert can land just after the next test's `resetTestDb` cleared the table (PS write-behind), and `tx_id` came from a `newId` counter reset to `gen-1` each test → the late id collided with the next test's own ids. Fixed by adopting the sanctioned `startSyncObserver: false` pattern **and** making the `newId` counter **monotonic across the file**, so a leaked id is always lower than the live test's and can never collide. Production is unaffected (real unique ids).

## Not in scope (see #112)
- **theme-toggle `dispose()`** — verified a non-issue (`afterEach` covers the only global state).
- **`shouldAdvanceTime` processors / #85** — a subtle in-flight-reprojection race the issue says to *instrument on next failure*; rewriting the timer machinery blind would risk adding flakiness.

## Note on history
8 commits reflecting honest iteration — including an add→remove→re-add of the `vi.waitFor` guards: after the production fix I tried making the reads synchronous (passed 50× in isolation) but they flaked under full-suite load, so polling was restored. Isolation stress ≠ full-suite stress for async-subscription state.

https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB)_