### PR TITLE
Fix #85 reprojection-quiescence flake + module-singleton reset audit

### DIFF
--- a/docs/module-singleton-audit.md
+++ b/docs/module-singleton-audit.md
@@ -1,0 +1,111 @@
+# Module-singleton reset audit (test-isolation sweep)
+
+Follow-up to the test-flakiness work in #112 (last open item: "module-singleton
+reset audit — verify-only; no observed failure"). Vitest runs with `isolate: true`
+(`maxWorkers: '100%'`), so each test **file** gets a fresh module graph. The only
+state-leak vector module singletons can introduce is therefore **within-file,
+cross-test** contamination: a module-scope mutable value that code-under-test
+writes and that is not reset between tests in the same file.
+
+## Conclusion
+
+**No unguarded contamination vector found.** Every module-level singleton that is
+*both* mutated at runtime *and* exercised across more than one test in a file is
+already reset — either through a dedicated `__reset*` hook wired into the file's
+`beforeEach`/`afterEach`, or by the test setting the value back to its default.
+Everything else is structurally safe (write-once, `WeakMap`, immutable, keyed so
+collisions can't happen, or only reachable from app-bootstrap code that no test
+drives across tests). No production change was required for this item; the
+`#85` reprojection-quiescence fix shipped in the same PR is unrelated to this
+conclusion.
+
+## Method
+
+Swept `src/` (excluding tests) for module-scope mutable state: top-level `let`,
+`const x = new Map/Set/WeakMap()/[]` used as a registry/cache, lazy singletons
+(`let instance; … instance ??= …`), and mutable module objects. For each, asked:
+is it mutated at runtime, is it reachable from a test that runs >1 case, and is
+it reset between those cases? Only the intersection (mutated ∧ multi-test ∧
+not-reset) is a flake risk.
+
+## Already guarded — has a reset hook wired into tests
+
+| Singleton | Reset hook |
+| --- | --- |
+| `data/repo.ts` `reprojectionMarkers` | `__resetReprojectionMarkerCache` |
+| `extensions/blockGestureConflicts.ts` `activeGestureByBlockId` | `__resetBlockGestureClaimsForTest` |
+| `extensions/compileExtensionModule.ts` `compileImpl` / `defaultCache` | `__setCompileImplForTest` / `__resetCompileCacheForTest` |
+| `plugins/agent-runtime/describeRuntime.ts` `cachedApiSurface` | `__resetApiSurfaceCacheForTest` |
+| `plugins/app-intents/appIntents.ts` `consumed` | `__resetAppIntentForTesting` |
+| `plugins/spatial-navigation/walker.ts` `lastPositionByPanel` | `__resetSpatialNavigationForTesting` |
+| `utils/dialogs.ts` `nextId` / `queue` | `__resetDialogsForTests` |
+| `utils/layoutSessionId.ts` `memoizedLayoutSessionId` | `__resetLayoutSessionIdForTesting` |
+
+## Already guarded — reset in-test (no dedicated hook needed)
+
+- **`plugins/theme-toggle/theme.ts`** `registry` / `registryById` — both
+  `effect.test.ts` and `plugin.test.ts` call `setThemeRegistry([FALLBACK_THEME])`
+  in `beforeEach` *and* `afterEach`. (This is the same global state that made
+  the "theme-toggle `dispose()`" item in #112 a verified non-issue.)
+- **`plugins/srs-rescheduling/srsClipboard.ts`** `entry` — every `setSrsClipboard`
+  mutation lives inside the `srs.cut / srs.paste flow` describe, which has
+  `afterEach(clearSrsClipboard)`.
+
+## Structurally safe — no reset required
+
+- **Write-once / idempotent memoization (stable value):**
+  `agent-runtime/bridge.ts` `bridgeClientId` (a `crypto.randomUUID()` cached
+  once), `data/repoProvider.ts` `opfsProbe` (a probe that settles once per
+  process). The cached value does not depend on per-test state, so reuse across
+  tests is benign.
+- **`WeakMap` decorator caches:** `plugins/todo/index.tsx` `todoDecoratorCache`,
+  `plugins/geo/geoContentDecorator.tsx` `cache`. Keyed by `BlockRenderer`
+  identity; entries are GC'd when the renderer is dropped — no cross-test bleed.
+- **Immutable-after-init constants:** `data/repo.ts` `KERNEL_TYPES` /
+  `KERNEL_PROPERTY_SCHEMA_MAP`, `spatial-navigation/walker.ts`
+  `NON_NAVIGABLE_SURFACES`, `roam-import/plan.ts` `ROAM_COMMANDS_*`,
+  `typedBlockQuery.ts` comparator sets, the various `uploadErrorClassifier.ts`
+  code sets. Built at import, never written.
+- **Error-swallowing FIFO chain:** `plugins/references/renameProcessor.ts`
+  `renameQueue`. The chain anchor is re-armed as
+  `next.then(() => {}, () => {})`, so it can never settle rejected — a failed or
+  pending rename in one test cannot block or contaminate the next. Renames are
+  post-commit and awaited via `awaitProcessors()`, so the queue is drained at
+  test end anyway.
+- **Monotonic counters:** `DateScrubOverlay.tsx` `nextScrubSession`,
+  `utils/propertyNavigation.ts` `propertyCreateRequestSeq`. Only ever increment;
+  uniqueness (their sole purpose) is preserved across tests — the same property
+  the dueCards `tx_id` fix in #112 relied on. No test asserts a specific value.
+- **Gesture-lifecycle maps:** `daily-notes/dateScrubGesture.ts`
+  `singleByBlockId` / `multiByBlockId`, `vim-normal-mode/interactions.ts` and
+  `swipe-quick-actions/swipeGesture.ts` `touchStartByBlockId`. Written on
+  `touchstart`, deleted on `touchend`/`touchcancel`; empty once a gesture
+  completes. A test would have to abandon a gesture mid-flight to leak, and none
+  do.
+- **Idempotency / guard flags:** `roam-import/runtime.ts` and
+  `data/metricsConsoleHook.ts` `installed`, `utils/viewTransition.ts`
+  `inTransition`. "Install once" / re-entrancy guards; no test re-installs across
+  cases.
+
+## Reachable only from app-bootstrap — not exercised across tests
+
+`data/repoProvider.ts` (`dbsByUser`, `initPromises`, `activeUserId`,
+`connectChain`) and `App.tsx` (`initialLayoutCache`, `landingRuntimeCache`) are
+per-user / per-workspace caches on the live provider + root component. No test
+imports these modules, so there is no within-file multi-test path that mutates
+them. **If** a future full-app render test mounts the root across cases reusing a
+workspace id / user id, give these a `__reset*` hook and wire it into that test's
+`beforeEach` — until then there is nothing to reset.
+
+> Out of scope (noted, not a test issue): `dbsByUser` / `initPromises` are never
+> evicted, so a very long-lived app session accumulates one entry per user ever
+> signed in. That is a production memory observation for `docs/follow-ups.md`,
+> not a test-isolation flake.
+
+## How to extend this audit
+
+When adding module-scope mutable state, check the intersection above. If it is
+mutated at runtime and a test exercises it across more than one case, add a
+`__reset<Name>ForTest()` export and call it from the test's `beforeEach`
+(matching the eight files in the first table). If it is write-once, a `WeakMap`,
+immutable, a monotonic counter, or gesture-lifecycle-scoped, it needs nothing.

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -601,6 +601,13 @@ export class Repo {
    *  this set without further SQL. Tests / migrations that wipe the
    *  table can call `__resetReprojectionMarkerCache` to force a reload. */
   private reprojectionMarkers: Set<string> | null = null
+  /** In-flight reprojection runs whose deferral timer has already
+   *  fired. `scheduleReprojection` is fire-and-forget (the cold-start
+   *  path must not block on it), so this set is the only handle on
+   *  those promises; `awaitReprojections()` drains it for deterministic
+   *  test quiescence and to keep a stray reprojection from writing into
+   *  the next test on a shared DB. Entries remove themselves on settle. */
+  private readonly pendingReprojections = new Set<Promise<void>>()
   /** Slowest writeTransaction observed since the last reset, by
    *  description (`opts.description` passed to `repo.tx`). Updated only
    *  when a tx exceeds the previous high-water mark, so the field is
@@ -1676,7 +1683,11 @@ export class Repo {
     names: readonly string[],
     schemas: ReadonlyMap<string, AnyPropertySchema>,
   ): void {
-    const run = () => { void this.reprojectRefTypedProperties(names, schemas) }
+    const run = () => {
+      const p = this.reprojectRefTypedProperties(names, schemas)
+        .finally(() => { this.pendingReprojections.delete(p) })
+      this.pendingReprojections.add(p)
+    }
     const idle = (globalThis as {requestIdleCallback?: (cb: () => void, opts?: {timeout: number}) => void}).requestIdleCallback
     if (typeof idle === 'function') {
       idle(run, {timeout: 2000})
@@ -2010,6 +2021,20 @@ export class Repo {
    *  pending set when the timer fires. */
   async awaitProcessors(): Promise<void> {
     await this.processorRunner.awaitIdle()
+  }
+
+  /** Wait until every reprojection whose deferral timer has already
+   *  fired has finished writing. Like `awaitProcessors()`, this does
+   *  NOT advance timers — a reprojection only enters the pending set
+   *  once its `setTimeout`/`requestIdleCallback` callback runs, so
+   *  callers using fake timers must advance the clock first. Loops so
+   *  that a reprojection settling while we await an earlier one is
+   *  still drained. Reprojection runs never schedule further
+   *  reprojections, so this terminates. */
+  async awaitReprojections(): Promise<void> {
+    while (this.pendingReprojections.size > 0) {
+      await Promise.all([...this.pendingReprojections])
+    }
   }
 
   /** Test-only escape hatch retained for stage-level tests that wire

--- a/src/plugins/references/test/referencesProcessor.test.ts
+++ b/src/plugins/references/test/referencesProcessor.test.ts
@@ -92,6 +92,10 @@ beforeEach(async () => {
   vi.useFakeTimers({shouldAdvanceTime: true})
 })
 afterEach(async () => {
+  // Drain any in-flight reprojection before swapping back to real timers
+  // and resetting the shared DB — otherwise a fire-and-forget reprojection
+  // from this test can write into the next one (the DB is shared per file).
+  await env.repo.awaitReprojections()
   vi.useRealTimers()
   await env.h.cleanup()
 })
@@ -109,9 +113,16 @@ const dailyId = (date: string) => dailyNoteBlockId(WS, date)
  *  tests still see the pre-cleanup intermediate state. */
 const flush = async (delayMs = 0) => {
   await vi.advanceTimersByTimeAsync(1)
+  // Schema-swap reprojections are fire-and-forget (scheduled via
+  // setTimeout(0) off the cold-start path); advancing the timer starts
+  // them but does not await their write. Drain them — then processors —
+  // so callers see a fully-settled references_json without racing
+  // vi.waitFor (issue #85).
+  await env.repo.awaitReprojections()
   await env.repo.awaitProcessors()
   if (delayMs > 0) {
     await vi.advanceTimersByTimeAsync(delayMs)
+    await env.repo.awaitReprojections()
     await env.repo.awaitProcessors()
   }
 }
@@ -360,11 +371,11 @@ describe('parseReferences — schema-swap reprojection', () => {
     env.repo.setFacetRuntime(runtimeWithoutReviewer())
     await flush()
 
-    await vi.waitFor(async () => {
-      expect(JSON.parse((await env.read('src'))!.references_json)).toEqual([
-        {id: aliasId('content-target'), alias: 'content-target'},
-      ])
-    })
+    // flush() drains the schema-swap reprojection, so the stale `reviewer`
+    // field ref is already gone — no vi.waitFor race (issue #85).
+    expect(JSON.parse((await env.read('src'))!.references_json)).toEqual([
+      {id: aliasId('content-target'), alias: 'content-target'},
+    ])
   })
 
   it('does not let an older ref-typed reprojection re-add refs after schema removal', async () => {


### PR DESCRIPTION
Closes the last two items in #112: the `referencesProcessor` schema-swap flake (#85) and the module-singleton reset audit.

Validated by `yarn run check` (**268 files / 2907 tests, 0 errors**) plus 2 extra full-suite runs and 5× isolated runs of the references file, all green.

---

## 1. Fix #85 — `referencesProcessor.test.ts` schema-swap flake (`9a6a494`)

**Symptom:** `parseReferences — schema-swap reprojection > removes stale field refs when a property stops being ref-typed` failed intermittently in the full suite — the assertion saw the stale `reviewer` field ref still present.

**Examined the prior fix skeptically first.** `a227774` ("Fix flaky releaseScan race…") hardened the *sibling* scan-parking tests with a `scanParkedPromise`; sound, but it never touched the `removes stale field refs` test, which still relied on `flush()` + `vi.waitFor`.

**Root cause (instrumented, not guessed).** Snapshotting `references_json` + reprojection metrics the instant `flush()` returns:

```
refs right after flush(): [ {…content-target}, {id:"target-a", sourceField:"reviewer"} ]   ← stale ref still there
reprojection metrics after flush():  { calls:2, blocksUpdated:0, msTotal:0 }                ← SELECT ran, removal tx NOT committed
reprojection metrics after waitFor:  { calls:2, blocksUpdated:1, msTotal:123 }              ← committed only during the poll
```

Schema-swap reprojection is **fire-and-forget**: `scheduleReprojection` defers it via `setTimeout(0)` off the cold-start path and `void`s the promise. `flush()` (`advanceTimers` + `awaitProcessors`) returns *between the reprojection's SELECT and its commit* — `awaitProcessors()` only drains the processor runner, not reprojections. The test passed only because `vi.waitFor` polled up to 1 s; under full-suite parallel load that window is exceeded → stale ref persists → failure. The shared per-file DB (from merging the references/roam-import/userSchemas suites) also let a stray in-flight reprojection write into the next test.

**Fix — make reprojections awaitable, mirroring `awaitProcessors()`** (`src/data/repo.ts`):
- `Repo` tracks in-flight reprojections in a set; new `awaitReprojections()` drains it.
- Test `flush()` now drains reprojections before asserting → the #85 test asserts **directly, no `vi.waitFor`**.
- `afterEach` drains them before resetting the shared DB → closes the cross-test leak.
- Production behavior unchanged: `scheduleReprojection` stays fire-and-forget; the set is purely a quiescence handle. Confirmed only `referencesProcessor.test.ts` references reprojection internals.

## 2. Module-singleton reset audit — verify-only (`a4d3b14`)

#112's last item. Swept `src/` for module-scope mutable singletons that could leak across tests (vitest `isolate:true` → the only vector is *within-file, cross-test*). Full write-up in `docs/module-singleton-audit.md`.

**Conclusion: no unguarded vector.** Every singleton that is both mutated and exercised across >1 test is already reset:
- **8 files** via `__reset*` hooks (repo, blockGestureConflicts, compileExtensionModule, describeRuntime, appIntents, spatial-navigation, dialogs, layoutSessionId).
- **theme registry** and **srsClipboard** via in-test resets (`setThemeRegistry([FALLBACK_THEME])` / `afterEach(clearSrsClipboard)`) — this is also why the "theme-toggle `dispose()`" item was a verified non-issue.

The rest are structurally safe: write-once UUIDs/probes, `WeakMap` decorator caches, immutable consts, an error-swallowing FIFO chain (`renameQueue`), monotonic counters, and gesture-lifecycle maps. `repoProvider`/`App.tsx` caches are reachable only from app-bootstrap code no test drives across cases (with a documented note on what to do if that ever changes). No production change required.

https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB)_