### PR TITLE
test: audit cleanup — tautology removal (#111) + coverage gaps (#113)

### DIFF
--- a/packages/agent-cli/test/config.test.ts
+++ b/packages/agent-cli/test/config.test.ts
@@ -83,6 +83,35 @@ describe('agent runtime config', () => {
     expect(bridgeUrl()).toBe('http://127.0.0.1:9876')
   })
 
+  it('rethrows on a corrupt (non-JSON) config file instead of silently resetting it', async () => {
+    // A garbled file is not the same as a missing one (ENOENT → {}); resetting
+    // it would clobber a secret the user might still recover by hand, so the
+    // read surfaces the parse error.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-runtime-config-'))
+    const configFile = path.join(dir, 'agent-bridge.json')
+    await fs.writeFile(configFile, 'not json {{{')
+    process.env.AGENT_RUNTIME_CONFIG_FILE = configFile
+    delete process.env.AGENT_RUNTIME_BRIDGE_SECRET
+
+    const {loadOrCreateBridgeConfig} = await loadConfigModule()
+    await expect(loadOrCreateBridgeConfig()).rejects.toThrow()
+  })
+
+  it('mints a fresh secret when the stored config has a wrong-typed bridgeSecret', async () => {
+    // Valid JSON but the wrong shape (bridgeSecret not a string) normalises to
+    // an empty secret, so load-or-create generates a new one rather than
+    // returning the bogus value.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-runtime-config-'))
+    const configFile = path.join(dir, 'agent-bridge.json')
+    await fs.writeFile(configFile, JSON.stringify({bridgeSecret: 42, createdAt: 'soon'}))
+    process.env.AGENT_RUNTIME_CONFIG_FILE = configFile
+    delete process.env.AGENT_RUNTIME_BRIDGE_SECRET
+
+    const {loadOrCreateBridgeConfig} = await loadConfigModule()
+    const resolved = await loadOrCreateBridgeConfig()
+    expect(resolved.bridgeSecret).toMatch(/^[0-9a-f]{64}$/)
+  })
+
   it('can request the token dialog in pairing URLs', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-runtime-config-'))
     process.env.AGENT_RUNTIME_CONFIG_FILE = path.join(dir, 'agent-bridge.json')

--- a/packages/agent-cli/test/packageManifest.test.ts
+++ b/packages/agent-cli/test/packageManifest.test.ts
@@ -17,11 +17,17 @@ const readPackageJson = async (): Promise<PackageJson> => {
 }
 
 describe('@knowledge-medium/agent-cli package manifest', () => {
+  // The invariant npm relies on for `npm exec <name>` is that there is a bin
+  // entry *keyed by the unscoped package name* pointing at the built CLI —
+  // a relationship the build/type system doesn't enforce. Assert that, not
+  // the literal name/path (which would just restate package.json).
   it('exposes a bin matching the unscoped package name for npm exec', async () => {
     const pkg = await readPackageJson()
     const unscopedName = pkg.name.split('/').at(-1)
+    expect(unscopedName).toBeTruthy()
 
-    expect(unscopedName).toBe('agent-cli')
-    expect(pkg.bin?.[unscopedName]).toBe('./dist/cli.js')
+    const binTarget = pkg.bin?.[unscopedName!]
+    expect(binTarget).toBeDefined()
+    expect(binTarget).toMatch(/dist\/.*\.js$/)
   })
 })

--- a/packages/agent-cli/test/protocol.test.ts
+++ b/packages/agent-cli/test/protocol.test.ts
@@ -9,6 +9,8 @@ import {describe, expect, it} from 'vitest'
 import {
   commandPayloadSchema,
   commandStatusResponseSchema,
+  knownAgentCommandSchema,
+  knownCommandSchema,
   registerClientMetadataSchema,
   registerTokenSpecSchema,
   whoamiInfoSchema,
@@ -41,6 +43,28 @@ describe('commandPayloadSchema', () => {
     expect(commandPayloadSchema.safeParse(null).success).toBe(false)
     expect(commandPayloadSchema.safeParse('hello').success).toBe(false)
     expect(commandPayloadSchema.safeParse([]).success).toBe(false)
+  })
+})
+
+describe('known command unions (strict per-verb validation)', () => {
+  it('rejects an unknown command type and a known type missing a required field', () => {
+    expect(knownAgentCommandSchema.safeParse({type: 'bogus'}).success).toBe(false)
+    // sql requires `sql`; the discriminated branch enforces it (unlike the
+    // loose commandPayloadSchema, which would forward it to the kernel).
+    expect(knownAgentCommandSchema.safeParse({type: 'sql'}).success).toBe(false)
+    expect(knownAgentCommandSchema.safeParse({type: 'sql', sql: 'SELECT 1'}).success).toBe(true)
+  })
+
+  it('keeps legacy aliases in the kernel union but not in the CLI canonical union', () => {
+    // `action` / `set-extension-enabled` are back-compat aliases the kernel
+    // still dispatches, so they validate against knownAgentCommandSchema...
+    expect(knownAgentCommandSchema.safeParse({type: 'action', id: 'a'}).success).toBe(true)
+    expect(knownAgentCommandSchema.safeParse({type: 'set-extension-enabled', id: 'x', enabled: true}).success).toBe(true)
+    // ...but the CLI never emits them, so they're absent from the canonical set.
+    expect(knownCommandSchema.safeParse({type: 'action', id: 'a'}).success).toBe(false)
+    expect(knownCommandSchema.safeParse({type: 'set-extension-enabled', id: 'x', enabled: true}).success).toBe(false)
+    // run-action is the canonical form both unions accept.
+    expect(knownCommandSchema.safeParse({type: 'run-action', id: 'a'}).success).toBe(true)
   })
 })
 

--- a/src/components/BlockProperties.component.test.tsx
+++ b/src/components/BlockProperties.component.test.tsx
@@ -322,8 +322,9 @@ describe('BlockProperties component', () => {
     })
 
     const listbox = screen.getByRole('listbox')
+    // Portaled to <body> so it escapes the property panel's overflow
+    // clipping; how it's then positioned is a styling concern, not asserted.
     expect(listbox.parentElement).toBe(document.body)
-    expect(listbox.classList.contains('fixed')).toBe(true)
 
     await act(async () => {
       fireEvent.keyDown(input, {key: 'Enter'})
@@ -609,8 +610,8 @@ describe('BlockProperties component', () => {
     })
 
     const listbox = await screen.findByRole('listbox')
+    // Portaled to <body> (escapes overflow clipping); positioning is styling.
     expect(listbox.parentElement).toBe(document.body)
-    expect(listbox.classList.contains('fixed')).toBe(true)
     expect(await screen.findByRole('option', {name: /Target Alias/})).toBeTruthy()
     expect(await screen.findByRole('option', {name: /Recent target content/})).toBeTruthy()
     expect(screen.queryByRole('option', {name: /Unrelated target content/})).toBeNull()

--- a/src/components/renderer/CodeMirrorContentRenderer.tsx
+++ b/src/components/renderer/CodeMirrorContentRenderer.tsx
@@ -1,6 +1,5 @@
 import { BlockRendererProps } from '@/types.js'
 import { useMemo, ClipboardEvent, KeyboardEvent, useRef } from 'react'
-import { EditorView } from '@codemirror/view'
 import { EditorSelection } from '@codemirror/state'
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror'
 import { createMinimalMarkdownConfig } from '@/utils/codemirror.js'
@@ -16,7 +15,7 @@ import {
 import { useRepo } from '@/context/repo.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { codeMirrorExtensionsFacet } from '@/extensions/editor.js'
-import { convertEmptyChildBlockToProperty } from '@/utils/propertyCreation.js'
+import { createFieldCreationKeydownExtension } from './fieldCreationKeydown.js'
 import { useBlockContext } from '@/context/block.js'
 
 export function CodeMirrorContentRenderer({block}: BlockRendererProps) {
@@ -33,35 +32,7 @@ export function CodeMirrorContentRenderer({block}: BlockRendererProps) {
   const pasteIntentRef = useRef<'split' | 'single-block'>('split')
 
   const extensions = useMemo(() => {
-    const fieldCreationExtension = EditorView.domEventHandlers({
-      keydown: (event, view) => {
-        if (
-          repo.isReadOnly ||
-          event.key !== '>' ||
-          event.defaultPrevented ||
-          event.metaKey ||
-          event.ctrlKey ||
-          event.altKey
-        ) {
-          return false
-        }
-
-        const selection = view.state.selection.main
-        if (!selection.empty || selection.from !== 0 || view.state.doc.length !== 0) {
-          return false
-        }
-        if (!block.peek()?.parentId) return false
-
-        event.preventDefault()
-        event.stopPropagation()
-
-        void convertEmptyChildBlockToProperty(block, repo).catch(error => {
-          console.error('[CodeMirrorContentRenderer] Failed to create property field', error)
-        })
-
-        return true
-      },
-    })
+    const fieldCreationExtension = createFieldCreationKeydownExtension(block, repo)
     const pluginExtensions = runtime.read(codeMirrorExtensionsFacet)({repo, block})
     return createMinimalMarkdownConfig([...pluginExtensions, fieldCreationExtension])
   }, [block, repo, runtime])

--- a/src/components/renderer/fieldCreationKeydown.ts
+++ b/src/components/renderer/fieldCreationKeydown.ts
@@ -1,0 +1,51 @@
+import { EditorView } from '@codemirror/view'
+import type { BlockRendererProps } from '@/types.js'
+import type { Repo } from '@/data/repo.js'
+import { convertEmptyChildBlockToProperty } from '@/utils/propertyCreation.js'
+
+/** The `>` field-creation shortcut for CodeMirrorContentRenderer: typing `>` in
+ *  an empty, top-of-doc child block converts it into a property field. Guarded
+ *  so it never hijacks a normal `>` — a non-empty doc, mid-line cursor, modifier
+ *  chord, read-only repo, or a parentless/root block all fall through, returning
+ *  false so CodeMirror inserts the character. The effect itself
+ *  (`convertEmptyChildBlockToProperty`) is covered separately. */
+export const handleFieldCreationKeydown = (
+  event: KeyboardEvent,
+  view: EditorView,
+  block: BlockRendererProps['block'],
+  repo: Repo,
+): boolean => {
+  if (
+    repo.isReadOnly ||
+    event.key !== '>' ||
+    event.defaultPrevented ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey
+  ) {
+    return false
+  }
+
+  const selection = view.state.selection.main
+  if (!selection.empty || selection.from !== 0 || view.state.doc.length !== 0) {
+    return false
+  }
+  if (!block.peek()?.parentId) return false
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  void convertEmptyChildBlockToProperty(block, repo).catch(error => {
+    console.error('[CodeMirrorContentRenderer] Failed to create property field', error)
+  })
+
+  return true
+}
+
+export const createFieldCreationKeydownExtension = (
+  block: BlockRendererProps['block'],
+  repo: Repo,
+) =>
+  EditorView.domEventHandlers({
+    keydown: (event, view) => handleFieldCreationKeydown(event, view, block, repo),
+  })

--- a/src/components/renderer/test/fieldCreationKeydown.test.ts
+++ b/src/components/renderer/test/fieldCreationKeydown.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+/**
+ * The `>` field-creation keydown guard from CodeMirrorContentRenderer. The
+ * effect (convertEmptyChildBlockToProperty) is tested in propertyCreation.test;
+ * this pins WHEN the shortcut fires — only a plain `>` in an empty, top-of-doc
+ * child block, never a normal `>` in prose, a chord, a read-only repo, or a
+ * root/parentless block. The guard returns true (handled) only when it fires,
+ * so a fall-through leaves CodeMirror to insert the character.
+ */
+
+import { EditorState } from '@codemirror/state'
+import type { EditorView } from '@codemirror/view'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/utils/propertyCreation.js', () => ({
+  convertEmptyChildBlockToProperty: vi.fn(async () => undefined),
+}))
+
+import { convertEmptyChildBlockToProperty } from '@/utils/propertyCreation.js'
+import { handleFieldCreationKeydown } from '../fieldCreationKeydown.ts'
+import type { Repo } from '@/data/repo'
+import type { BlockRendererProps } from '@/types'
+
+const convertMock = vi.mocked(convertEmptyChildBlockToProperty)
+
+interface Opts {
+  doc?: string
+  readOnly?: boolean
+  parentId?: string | null
+}
+
+// Only `view.state` is read by the guard, so a state-only stand-in is enough.
+const fire = (opts: Opts = {}, eventInit: KeyboardEventInit = {}): boolean => {
+  const block = {
+    id: 'b1',
+    peek: () => ({ parentId: opts.parentId === undefined ? 'parent-1' : opts.parentId }),
+  } as unknown as BlockRendererProps['block']
+  const repo = { isReadOnly: opts.readOnly ?? false } as unknown as Repo
+  const view = { state: EditorState.create({ doc: opts.doc ?? '' }) } as unknown as EditorView
+  const event = new KeyboardEvent('keydown', { key: '>', cancelable: true, ...eventInit })
+  return handleFieldCreationKeydown(event, view, block, repo)
+}
+
+afterEach(() => convertMock.mockClear())
+
+describe('handleFieldCreationKeydown', () => {
+  it('converts an empty child block to a property field on a plain ">"', () => {
+    expect(fire()).toBe(true)
+    expect(convertMock).toHaveBeenCalledTimes(1)
+    expect(convertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'b1' }),
+      expect.anything(),
+    )
+  })
+
+  it('falls through when the block already has content', () => {
+    expect(fire({ doc: 'already typed' })).toBe(false)
+    expect(convertMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through on a read-only repo', () => {
+    expect(fire({ readOnly: true })).toBe(false)
+    expect(convertMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through on a root block (no parent to attach the field to)', () => {
+    expect(fire({ parentId: null })).toBe(false)
+    expect(convertMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through on a ">" chord so the shortcut layer can own it', () => {
+    expect(fire({}, { metaKey: true })).toBe(false)
+    expect(convertMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through on any non-">" key', () => {
+    expect(fire({}, { key: 'a' })).toBe(false)
+    expect(convertMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/data/api/changeScope.test.ts
+++ b/src/data/api/changeScope.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  CHANGE_SCOPE_POLICIES,
   ChangeScope,
   scopeAllowedInReadOnly,
   scopeIsUndoable,
@@ -9,9 +8,10 @@ import {
 } from './changeScope'
 
 describe('change scope policies', () => {
-  it('defines every scope in the policy table', () => {
-    expect(Object.keys(CHANGE_SCOPE_POLICIES).sort()).toEqual(Object.values(ChangeScope).sort())
-  })
+  // The "every scope is in the policy table" invariant is enforced at
+  // compile time by `CHANGE_SCOPE_POLICIES satisfies Readonly<Record<
+  // ChangeScope, ChangeScopePolicy>>` — a runtime restatement can't catch
+  // anything the type checker doesn't already reject.
 
   it('routes every writable scope through source="user"', () => {
     // Every repo.tx invocation queues to ps_crud now; UI-state used to

--- a/src/data/blockSchema.test.ts
+++ b/src/data/blockSchema.test.ts
@@ -38,23 +38,13 @@ const rowFromParams = (params: ReturnType<typeof blockToRowParams>): BlockRow =>
 })
 
 describe('BLOCK_STORAGE_COLUMNS', () => {
-  it('declares the v2 column set; childIds-shaped columns are gone', () => {
+  // The exact column set + order is exercised end-to-end by the
+  // blockToRowParams / parseBlockRow round-trip below (which maps every
+  // column positionally), so a literal copy of the list here would only
+  // restate the source. What that round-trip can't catch is a *legacy*
+  // column name silently reappearing, so keep just those guards.
+  it('never reintroduces legacy / renamed columns', () => {
     const names = BLOCK_STORAGE_COLUMNS.map(c => c.name)
-    expect(names).toEqual([
-      'id',
-      'workspace_id',
-      'parent_id',
-      'order_key',
-      'content',
-      'properties_json',
-      'references_json',
-      'created_at',
-      'updated_at',
-      'created_by',
-      'updated_by',
-      'deleted',
-    ])
-    // Hard guard against the legacy column ever sneaking back in.
     expect(names).not.toContain('child_ids_json')
     expect(names).not.toContain('create_time')
     expect(names).not.toContain('update_time')

--- a/src/data/internals/clientSchema.test.ts
+++ b/src/data/internals/clientSchema.test.ts
@@ -44,7 +44,6 @@ import {
   BACKFILL_BLOCKS_FTS_SQL,
   BLOCKS_FTS_BACKFILL_MARKER_KEY,
   CLIENT_SCHEMA_STATEMENTS,
-  CLIENT_SCHEMA_TRIGGER_NAMES,
   backfillBlockAliasesIfEmpty,
   backfillBlocksFtsIfEmpty,
   runAnalyzeIfDue,
@@ -205,21 +204,11 @@ beforeEach(() => { h = setupDb() })
 afterEach(() => { h.db.close() })
 
 describe('client schema bootstrap', () => {
-  it('creates the documented set of client-schema triggers', () => {
-    // CLIENT_SCHEMA_TRIGGER_NAMES covers triggers on `blocks` (the
-    // bulk of them — row_events audit/history, upload routing, workspace
-    // invariants, side-index maintenance), on `block_aliases`
-    // (the uniqueness-enforcement trigger), and on `blocks_synced`
-    // (the Layout B change-capture triggers). Query against all three
-    // tables so the inventory test catches additions on any side.
-    const triggers = (h.db
-      .prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name IN ('blocks', 'block_aliases', 'blocks_synced') ORDER BY name")
-      .all() as Array<{name: string}>)
-      .map(r => r.name)
-    expect(triggers.sort()).toEqual([...CLIENT_SCHEMA_TRIGGER_NAMES].sort())
-    expect(triggers).toHaveLength(CLIENT_SCHEMA_TRIGGER_NAMES.length)
-  })
-
+  // The trigger *names* are exported as CLIENT_SCHEMA_TRIGGER_NAMES purely so
+  // a test can re-list them; asserting "the DB has exactly that list" only
+  // restates the constant. What the triggers actually *do* is covered by the
+  // row_events / upload-routing behavior tests below, and the harness already
+  // verifies the production trigger set installs (createTestDb.test.ts).
   it('seeds tx_context with one row that starts NULL across all five tx fields', () => {
     const ctx = h.db.prepare('SELECT * FROM tx_context').get() as Record<string, unknown>
     expect(ctx).toEqual({id: 1, tx_id: null, tx_seq: null, user_id: null, scope: null, source: null})

--- a/src/data/internals/kernelMutators.test.ts
+++ b/src/data/internals/kernelMutators.test.ts
@@ -13,7 +13,7 @@
  * (stage 1.6) will migrate to.
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   CORE_BLOCK_MERGED_EVENT,
   ChangeScope,
@@ -28,7 +28,6 @@ import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb
 import { Repo } from '../repo'
 import { isCollapsedProp } from '@/data/properties'
 import { aliasesProp } from './coreProperties'
-import { TxImpl } from './txEngine'
 
 interface Harness {
   h: TestDb
@@ -289,18 +288,6 @@ describe('core.createSiblingAbove / createSiblingBelow', () => {
     await seedABC()
     const id = await env.repo.mutate.createSiblingBelow({siblingId: 'C', id: 'X'})
     expect(await env.childIds('root')).toEqual(['A', 'B', 'C', id])
-  })
-
-  it('createSiblingBelow avoids full sibling-list enumeration', async () => {
-    await seedABC()
-    const childrenOfSpy = vi.spyOn(TxImpl.prototype, 'childrenOf')
-    try {
-      const id = await env.repo.mutate.createSiblingBelow({siblingId: 'C', id: 'X'})
-      expect(childrenOfSpy).not.toHaveBeenCalled()
-      expect(await env.childIds('root')).toEqual(['A', 'B', 'C', id])
-    } finally {
-      childrenOfSpy.mockRestore()
-    }
   })
 
   it('createSiblingAbove works on a workspace-root block (parentId = null)', async () => {

--- a/src/data/internals/txEngine.test.ts
+++ b/src/data/internals/txEngine.test.ts
@@ -466,6 +466,43 @@ describe('tx.move (cycle validation, §4.7 Layer 1)', () => {
     )).rejects.toThrow(CycleError)
   })
 
+  it('detects a cycle several levels deep, not just an immediate child', async () => {
+    // Extend root→A→B→C with D under C, then try to move A under D. D is A's
+    // descendant four hops down, so the ancestor walk has to traverse
+    // D→C→B→A to catch it — exercises multi-hop recursion, not a 2-cycle.
+    await env.repo.tx(
+      tx => tx.create({id: 'mv-D', workspaceId: 'ws-1', parentId: 'mv-C', orderKey: 'a0'}),
+      {scope: ChangeScope.BlockDefault},
+    )
+    await expect(env.repo.tx(
+      tx => tx.move('mv-A', {parentId: 'mv-D', orderKey: 'a0'}),
+      {scope: ChangeScope.BlockDefault},
+    )).rejects.toThrow(CycleError)
+    expect(env.cache.getSnapshot('mv-A')!.parentId).toBe('mv-root')
+  })
+
+  it('does NOT catch a loop deeper than the §4.7 depth-guard cap (documented truncation)', async () => {
+    // The ancestor walk is bounded by `depth < 100` so a pathological chain
+    // can't run the recursion away. The trade-off: a loop that closes past the
+    // cap is knowingly missed. CHAIN must stay above the cap; if the cap moves,
+    // this is the test that flags it.
+    const CHAIN = 110
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'deep-0', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'})
+      for (let i = 1; i <= CHAIN; i++) {
+        await tx.create({id: `deep-${i}`, workspaceId: 'ws-1', parentId: `deep-${i - 1}`, orderKey: 'a0'})
+      }
+    }, {scope: ChangeScope.BlockDefault})
+
+    // deep-110 is a descendant of deep-0, so this closes a loop — but it's past
+    // the cap, so the guard truncates before reaching deep-0 and the move lands.
+    await env.repo.tx(
+      tx => tx.move('deep-0', {parentId: `deep-${CHAIN}`, orderKey: 'b0'}),
+      {scope: ChangeScope.BlockDefault},
+    )
+    expect(env.cache.getSnapshot('deep-0')).toMatchObject({parentId: `deep-${CHAIN}`})
+  })
+
   it('throws ParentNotFoundError when target parent_id is missing', async () => {
     await expect(env.repo.tx(
       tx => tx.move('mv-A', {parentId: 'missing-parent', orderKey: 'a0'}),

--- a/src/extensions/test/discoverToggleTree.test.ts
+++ b/src/extensions/test/discoverToggleTree.test.ts
@@ -112,17 +112,18 @@ describe('discoverToggleTreeSync', () => {
     ).toThrow(/function-valued AppExtension/i)
   })
 
-  it('deduplicates roots that share a handle reference', () => {
+  it('surfaces a repeated handle without crashing the walk', () => {
     const handle = systemToggle({id: 'system:dup', name: 'Dup'})
     const tree = [handle.of([]), handle.of([])]
 
     const result = discoverToggleTreeSync(tree)
 
-    // Two wraps of the same handle = two separate boundary arrays.
-    // Each surfaces as a node, but the *handles* are identical. The
-    // settings UI keys by handle.id, so this is informational —
-    // codify the current behaviour rather than enforce dedup.
-    expect(allIds(result)).toEqual(['system:dup', 'system:dup'])
+    // Two wraps of the same handle = two separate boundary arrays. The
+    // settings UI keys by handle.id, so whether the walk dedups or not is
+    // an implementation detail — assert only that the handle surfaces.
+    // (Pinning the exact count here would force a future real dedup fix to
+    // update this test for the wrong reason.)
+    expect(allIds(result)).toContain('system:dup')
   })
 })
 

--- a/src/plugins/extensions-settings/test/config.test.ts
+++ b/src/plugins/extensions-settings/test/config.test.ts
@@ -8,17 +8,14 @@
  */
 import {describe, expect, it} from 'vitest'
 import {CodecError} from '@/data/api'
-import {
-  overridesCodec,
-  extensionsPrefsType,
-} from '@/plugins/extensions-settings/config.js'
+import {overridesCodec} from '@/plugins/extensions-settings/config.js'
 import type {Overrides} from '@/extensions/togglable.js'
 
+// The codec id (`overridesCodec.type`) and the prefs block-type id/label are
+// source literals — restating them here can't catch a regression the way the
+// round-trip / decode-error cases below do. A persisted identifier is better
+// guarded by a dedicated snapshot/migration test than by mirroring the string.
 describe('overridesCodec', () => {
-  it('uses the Extensions overrides codec id', () => {
-    expect(overridesCodec.type).toBe('extensions:overrides')
-  })
-
   it('round-trips a populated map through encode/decode', () => {
     const original: Overrides = new Map([
       ['system:a', false],
@@ -59,12 +56,5 @@ describe('overridesCodec', () => {
 
   it('does not have a `where` capability (overrides map is never filtered)', () => {
     expect(overridesCodec.where).toBeUndefined()
-  })
-})
-
-describe('extensionsPrefsType', () => {
-  it('uses Extensions ids and label for the prefs block type', () => {
-    expect(extensionsPrefsType.id).toBe('extensions-prefs')
-    expect(extensionsPrefsType.label).toBe('Extensions')
   })
 })

--- a/src/plugins/find-replace/test/search.test.ts
+++ b/src/plugins/find-replace/test/search.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildContentSearchMatch,
   findLiteralMatches,
+  previewForMatch,
   replaceLiteralMatches,
 } from '../search.ts'
 
@@ -38,5 +40,47 @@ describe('find/replace literal matching', () => {
       content: 'x a?b x',
       replacementCount: 2,
     })
+  })
+})
+
+describe('previewForMatch', () => {
+  it('returns the surrounding text verbatim when it fits inside the context window', () => {
+    // 'world' at index 6; default context (48) covers the whole string, so no
+    // ellipsis on either side.
+    expect(previewForMatch('hello world', {index: 6, length: 5})).toBe('hello world')
+  })
+
+  it('windows long content and marks both truncated sides with ellipses', () => {
+    const content = 'left padding here MATCH right padding here'
+    const index = content.indexOf('MATCH')
+    const preview = previewForMatch(content, {index, length: 5}, 4)
+    expect(preview.startsWith('...')).toBe(true)
+    expect(preview.endsWith('...')).toBe(true)
+    expect(preview).toContain('MATCH')
+  })
+
+  it('collapses runs of whitespace so multi-line content previews on one line', () => {
+    expect(previewForMatch('a\n\n  b  MATCH  c\t\td', {index: 8, length: 5}))
+      .toBe('a b MATCH c d')
+  })
+})
+
+describe('buildContentSearchMatch', () => {
+  it('summarizes the first hit with the total match count and a preview', () => {
+    const match = buildContentSearchMatch('b1', 'find me and me again', 'me', insensitive)
+    expect(match).toEqual({
+      blockId: 'b1',
+      originalContent: 'find me and me again',
+      matchCount: 2,
+      preview: 'find me and me again',
+    })
+  })
+
+  it('returns null when the query does not occur in the content', () => {
+    expect(buildContentSearchMatch('b1', 'nothing here', 'zzz', insensitive)).toBeNull()
+  })
+
+  it('short-circuits an empty query to null (no match, no preview)', () => {
+    expect(buildContentSearchMatch('b1', 'any content', '', insensitive)).toBeNull()
   })
 })

--- a/src/plugins/geo/test/usePlaceSearch.test.tsx
+++ b/src/plugins/geo/test/usePlaceSearch.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+/**
+ * usePlaceSearch combines a local Place-block scan with Google autocomplete.
+ * The behaviour worth pinning is the failure handling the `@`/property pickers
+ * depend on: a Google HTTP/network error must NOT blank the dropdown — local
+ * matches stay, and the error is surfaced for the UI to show.
+ *
+ * The Google client is mocked at the module boundary (real GooglePlacesError
+ * kept, so the `instanceof` branch runs); the repo is a thin stub so the test
+ * needs no DB.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { aliasesProp } from '@/data/internals/coreProperties'
+import { typesProp } from '@/data/properties'
+import type { Repo } from '@/data/repo'
+import { PLACE_TYPE } from '../blockTypes'
+
+const mock = vi.hoisted(() => ({ autocomplete: vi.fn() }))
+
+vi.mock('../googlePlacesClient', async (importActual) => {
+  const actual = await importActual<typeof import('../googlePlacesClient')>()
+  return {
+    ...actual,
+    resolveApiKey: () => 'test-key', // force the Google path on
+    createGooglePlacesClient: () => ({
+      autocomplete: mock.autocomplete,
+      getDetails: vi.fn(),
+      searchNearby: vi.fn(),
+    }),
+  }
+})
+
+import { usePlaceSearch } from '../usePlaceSearch'
+import { GooglePlacesError } from '../googlePlacesClient'
+
+const placeBlock = {
+  id: 'p1',
+  content: 'Cafe Blue',
+  properties: {
+    [typesProp.name]: [PLACE_TYPE],
+    [aliasesProp.name]: ['Cafe Blue'],
+  },
+}
+
+const stubRepo = (): Repo => ({
+  activeWorkspaceId: 'ws-1',
+  query: { byType: () => ({ load: async () => [placeBlock] }) },
+}) as unknown as Repo
+
+const localResult = { id: 'p1', source: 'local', label: 'Cafe Blue', detail: undefined }
+
+beforeEach(() => { vi.useFakeTimers(); mock.autocomplete.mockReset() })
+afterEach(() => { vi.useRealTimers() })
+
+describe('usePlaceSearch', () => {
+  it('appends Google suggestions after local matches on success', async () => {
+    mock.autocomplete.mockResolvedValue([{ placeId: 'g1', primary: 'Cafe Green', secondary: 'Main St' }])
+    const repo = stubRepo()
+    const { result } = renderHook(() => usePlaceSearch(repo))
+
+    act(() => { result.current.search('cafe') })
+    await act(async () => { await vi.advanceTimersByTimeAsync(300) }) // past the 250ms debounce
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.results).toEqual([
+      localResult,
+      { id: 'google:g1', source: 'google', label: 'Cafe Green', detail: 'Main St' },
+    ])
+  })
+
+  it('keeps local results and surfaces the error when Google autocomplete fails', async () => {
+    mock.autocomplete.mockRejectedValue(new GooglePlacesError('network', null, 'socket reset'))
+    const repo = stubRepo()
+    const { result } = renderHook(() => usePlaceSearch(repo))
+
+    act(() => { result.current.search('cafe') })
+    await act(async () => { await vi.advanceTimersByTimeAsync(300) })
+
+    expect(result.current.results).toEqual([localResult])
+    expect(result.current.error).toMatch(/^Google network \(/)
+  })
+})

--- a/src/plugins/merge-blocks/test/mergeAction.test.ts
+++ b/src/plugins/merge-blocks/test/mergeAction.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+/**
+ * "Merge into…" action — the thin handler that opens the merge-target picker
+ * over the focused block. The merge *strategy* is covered in strategy.test.ts;
+ * this covers the handler's own logic: resolve the block's data (peek, else
+ * load), bail if it has none, otherwise fire the open-picker event with the
+ * source id + its workspace.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mergeIntoAction } from '../mergeAction.ts'
+import { openMergePickerEvent, type OpenMergePickerEventDetail } from '../events.ts'
+import type { BlockData } from '@/data/api'
+import type { BlockShortcutDependencies } from '@/shortcuts/types.js'
+
+const blockData = (o: Partial<BlockData> = {}): BlockData => ({
+  id: 'src', workspaceId: 'ws-1', parentId: null, orderKey: 'a0', content: '',
+  properties: {}, references: [], createdAt: 1, updatedAt: 1, createdBy: 'u',
+  updatedBy: 'u', deleted: false, ...o,
+})
+
+/** Minimal block the handler needs: id + peek()/load(). */
+const blockStub = (id: string, peek: BlockData | null, load: BlockData | null = peek) => ({
+  id,
+  peek: () => peek,
+  load: async () => load,
+}) as unknown as BlockShortcutDependencies['block']
+
+const run = (block: BlockShortcutDependencies['block']) =>
+  mergeIntoAction.handler(
+    { block, uiStateBlock: block } as BlockShortcutDependencies,
+    {} as KeyboardEvent,
+  )
+
+let opened: OpenMergePickerEventDetail[]
+let listener: (e: Event) => void
+beforeEach(() => {
+  opened = []
+  listener = (e: Event) => opened.push((e as CustomEvent<OpenMergePickerEventDetail>).detail)
+  window.addEventListener(openMergePickerEvent, listener)
+})
+afterEach(() => window.removeEventListener(openMergePickerEvent, listener))
+
+describe('mergeIntoAction', () => {
+  it('opens the picker for the focused block, carrying its own workspace', async () => {
+    await run(blockStub('src', blockData({ id: 'src', workspaceId: 'ws-9' })))
+    expect(opened).toEqual([{ sourceBlockId: 'src', workspaceId: 'ws-9' }])
+  })
+
+  it('falls back to load() when the block is not yet in the peek cache', async () => {
+    await run(blockStub('src', null, blockData({ id: 'src', workspaceId: 'ws-2' })))
+    expect(opened).toEqual([{ sourceBlockId: 'src', workspaceId: 'ws-2' }])
+  })
+
+  it('does nothing when the block has no data to merge', async () => {
+    await run(blockStub('gone', null, null))
+    expect(opened).toEqual([])
+  })
+})

--- a/src/plugins/todo/test/actions.test.ts
+++ b/src/plugins/todo/test/actions.test.ts
@@ -65,6 +65,16 @@ describe('cycleTodoState', () => {
     expect(block.peekProperty(statusProp)).toBeUndefined()
   })
 
+  it('is a no-op on a read-only repo (read-only guard short-circuits before any write)', async () => {
+    const block = repo.block('block-1')
+    repo.isReadOnly = true
+
+    await cycleTodoState(block)
+
+    expect(block.types).not.toContain(TODO_TYPE)
+    expect(block.peekProperty(statusProp)).toBeUndefined()
+  })
+
   it('reopens as open even when a stale status property exists without todo type', async () => {
     await repo.tx(async tx => {
       await tx.update('block-1', {

--- a/src/plugins/vim-normal-mode/actions.ts
+++ b/src/plugins/vim-normal-mode/actions.ts
@@ -28,7 +28,11 @@ import { outlineRenderScopeId } from '@/utils/renderScope.js'
 
 const JUMP_BLOCK_COUNT = 8
 
-const jumpVisibleBlocks = async (
+/** Walk up to `count` visible blocks in `direction`, stopping early at the
+ *  scope boundary. Returns the landing block, or null when the start block is
+ *  already at the boundary (no movement). Exported for direct testing — the
+ *  jump_many_{up,down} actions are thin focus wrappers around it. */
+export const jumpVisibleBlocks = async (
   startBlock: BlockShortcutDependencies['block'],
   scopeRootId: string,
   count: number,

--- a/src/plugins/vim-normal-mode/test/jumpVisibleBlocks.test.ts
+++ b/src/plugins/vim-normal-mode/test/jumpVisibleBlocks.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+/**
+ * jumpVisibleBlocks is the count/boundary core behind Ctrl-d / Ctrl-u. The
+ * single-step visible-traversal it builds on (next/previousVisibleBlock) lives
+ * in utils/selection; this pins what jumpVisibleBlocks adds on top — counting N
+ * steps, clamping at the scope edge, and reporting "no movement" as null.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { BlockCache } from '@/data/blockCache'
+import { ChangeScope } from '@/data/api'
+import { Repo } from '@/data/repo'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
+import { jumpVisibleBlocks } from '../actions.ts'
+
+const WS = 'ws-1'
+const ROOT = 'root'
+// A flat, fully-visible outline: root → c0..c11 (single-char order keys so they
+// sort correctly). c0 is the first navigable block, c11 the last.
+const COUNT = 12
+const childId = (i: number) => `c${i}`
+
+let sharedDb: TestDb
+let repo: Repo
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+
+beforeEach(async () => {
+  await resetTestDb(sharedDb.db)
+  repo = new Repo({
+    db: sharedDb.db,
+    cache: new BlockCache(),
+    user: {id: 'user-1'},
+    registerKernelProcessors: false,
+    startSyncObserver: false,
+  })
+  repo.setActiveWorkspaceId(WS)
+  await repo.tx(async tx => {
+    await tx.create({id: ROOT, workspaceId: WS, parentId: null, orderKey: 'a'})
+    for (let i = 0; i < COUNT; i++) {
+      await tx.create({
+        id: childId(i),
+        workspaceId: WS,
+        parentId: ROOT,
+        orderKey: String.fromCharCode(97 + i), // 'a'..'l'
+        content: childId(i),
+      })
+    }
+  }, {scope: ChangeScope.BlockDefault})
+})
+afterEach(() => { repo.stopSyncObserver() })
+
+const jump = (from: string, count: number, direction: 'up' | 'down') =>
+  jumpVisibleBlocks(repo.block(from), ROOT, count, direction)
+
+describe('jumpVisibleBlocks', () => {
+  it('lands exactly `count` visible blocks down', async () => {
+    expect((await jump('c0', 8, 'down'))?.id).toBe('c8')
+  })
+
+  it('lands exactly `count` visible blocks up', async () => {
+    expect((await jump('c11', 8, 'up'))?.id).toBe('c3')
+  })
+
+  it('clamps to the last visible block when fewer than `count` remain', async () => {
+    // c5 has only 6 blocks below it; a jump of 8 stops at the boundary.
+    expect((await jump('c5', 8, 'down'))?.id).toBe('c11')
+  })
+
+  it('clamps to the scope root jumping up past the first child', async () => {
+    // The panel's top block is itself navigable, so jumping up past c0 lands
+    // on the scope root rather than stopping at c0.
+    expect((await jump('c5', 8, 'up'))?.id).toBe(ROOT)
+  })
+
+  it('returns null when already at the bottom boundary (no movement)', async () => {
+    expect(await jump('c11', 8, 'down')).toBeNull()
+  })
+
+  it('returns null when already at the top boundary — the scope root (no movement)', async () => {
+    expect(await jump(ROOT, 8, 'up')).toBeNull()
+  })
+})

--- a/src/sync/observer/cycleScanCandidates.test.ts
+++ b/src/sync/observer/cycleScanCandidates.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+/**
+ * Layout B observer — cycle-scan candidate selection (design doc §4.7).
+ *
+ * `cycleScanCandidatesByWorkspace` is the pure predicate that decides which
+ * just-materialized rows are worth a (bounded, expensive) reachability scan:
+ * only a row that *moved parents while staying live* can newly close a loop.
+ * The end-to-end SQL scan is covered in observer.test.ts; this pins the
+ * selection rules directly so each skip branch is exercised in isolation
+ * (the scan is detection-only telemetry, so a wrong predicate fails silent).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { cycleScanCandidatesByWorkspace } from './observer.js'
+import type { SyncSnapshot } from './materialize.js'
+import type { BlockData } from '@/data/api'
+
+const block = (o: Partial<BlockData> = {}): BlockData => ({
+  id: 'b', workspaceId: 'ws', parentId: null, orderKey: 'a0', content: '',
+  properties: {}, references: [], createdAt: 1, updatedAt: 1, createdBy: 'u',
+  updatedBy: 'u', deleted: false, ...o,
+})
+
+/** A live row whose parent moved p1 -> p2 in workspace `ws` — the one shape
+ *  that qualifies. */
+const reparented = (id: string, ws = 'ws'): SyncSnapshot => ({
+  before: block({ id, workspaceId: ws, parentId: 'p1' }),
+  after: block({ id, workspaceId: ws, parentId: 'p2' }),
+})
+
+const run = (entries: Array<[string, SyncSnapshot]>) =>
+  cycleScanCandidatesByWorkspace(new Map(entries))
+
+describe('cycleScanCandidatesByWorkspace', () => {
+  it('selects a live row that moved parents, keyed by its current workspace', () => {
+    const result = run([['x', reparented('x')]])
+    expect(Object.fromEntries(result)).toEqual({ ws: ['x'] })
+  })
+
+  it('groups multiple reparented rows by their after-workspace', () => {
+    const result = run([
+      ['a', reparented('a', 'ws-1')],
+      ['b', reparented('b', 'ws-2')],
+      ['c', reparented('c', 'ws-1')],
+    ])
+    expect(result.get('ws-1')?.sort()).toEqual(['a', 'c'])
+    expect(result.get('ws-2')).toEqual(['b'])
+  })
+
+  it('ignores a fresh insert (no before-row can close a loop on its own)', () => {
+    const result = run([['x', { before: null, after: block({ parentId: 'p2' }) }]])
+    expect(result.size).toBe(0)
+  })
+
+  it('ignores a hard-deleted row (no after-row)', () => {
+    const result = run([['x', { before: block({ parentId: 'p1' }), after: null }]])
+    expect(result.size).toBe(0)
+  })
+
+  it('ignores a row that was a tombstone before or became one after', () => {
+    const wasTombstone: SyncSnapshot = {
+      before: block({ parentId: 'p1', deleted: true }),
+      after: block({ parentId: 'p2' }),
+    }
+    const becameTombstone: SyncSnapshot = {
+      before: block({ parentId: 'p1' }),
+      after: block({ parentId: 'p2', deleted: true }),
+    }
+    expect(run([['was', wasTombstone], ['became', becameTombstone]]).size).toBe(0)
+  })
+
+  it('ignores a content-only edit (parent unchanged → reachability unchanged)', () => {
+    const result = run([['x', {
+      before: block({ parentId: 'p1', content: 'v1' }),
+      after: block({ parentId: 'p1', content: 'v2' }),
+    }]])
+    expect(result.size).toBe(0)
+  })
+
+  it('ignores a reparent whose after-row has no workspace id', () => {
+    const result = run([['x', {
+      before: block({ parentId: 'p1', workspaceId: 'ws' }),
+      after: block({ parentId: 'p2', workspaceId: '' }),
+    }]])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns an empty map for an empty snapshot set', () => {
+    expect(run([]).size).toBe(0)
+  })
+})

--- a/src/sync/observer/materialize.test.ts
+++ b/src/sync/observer/materialize.test.ts
@@ -25,6 +25,7 @@ import { materializeStagingRows, type Materializability } from './materialize.js
 import { encodeForWire, type GetCek } from '../transform.js'
 import { generateWorkspaceKeyBytes, importWorkspaceKey } from '../crypto/workspaceKey.js'
 import type { BlockData } from '@/data/api'
+import type { PowerSyncDb } from '@/data/internals/commitPipeline.js'
 
 const COLUMN_NAMES = BLOCK_STORAGE_COLUMNS.map(c => c.name)
 const INSERT_BLOCK_SQL = `INSERT INTO blocks (${COLUMN_NAMES.join(', ')}) VALUES (${COLUMN_NAMES.map(() => '?').join(', ')})`
@@ -82,6 +83,35 @@ const crudCount = async () =>
 const constMat = (m: Materializability) => () => m
 
 const noKey: GetCek = async () => null
+
+/** Wrap the test DB so a racing local write fires exactly once, AFTER the
+ *  Phase-1 reads (which use the auto-commit `db`) but BEFORE the Phase-2 write
+ *  transaction opens — the precise TOCTOU window the authoritative in-tx
+ *  re-gate has to close. Everything else proxies straight through to the real
+ *  DB, so the materialization runs against the production schema as usual. */
+const racingDb = (real: PowerSyncDb, raceOnce: () => Promise<unknown>): PowerSyncDb => {
+  let raced = false
+  return new Proxy(real as object, {
+    get(target, prop, receiver) {
+      if (prop === 'writeTransaction') {
+        return async (fn: Parameters<PowerSyncDb['writeTransaction']>[0]) => {
+          if (!raced) { raced = true; await raceOnce() }
+          return real.writeTransaction(fn)
+        }
+      }
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function'
+        ? (value as (...a: unknown[]) => unknown).bind(real)
+        : value
+    },
+  }) as PowerSyncDb
+}
+
+const queuePendingUpload = (id: string) =>
+  env.db.execute(
+    "INSERT INTO ps_crud (tx_id, data) VALUES (1, json_object('op','PATCH','type','blocks','id',?,'data',json_object()))",
+    [id],
+  )
 
 describe('materializeStagingRows — copy-through (plaintext workspace)', () => {
   it('copies a staged plaintext row into blocks verbatim, with no upload echo', async () => {
@@ -378,5 +408,92 @@ describe('materializeStagingRows — removed (stream-exit)', () => {
 
     expect(out.deleted).toEqual([])
     expect((await allBlocks())[0]?.content).toBe('local edit')
+  })
+})
+
+describe('materializeStagingRows — Phase-1/Phase-2 TOCTOU re-gate', () => {
+  // The Phase-1 staleness reads run outside the write tx, so a local edit can
+  // land between them and the lock. The clean path (Phase 1 passes and stays
+  // clean) is covered by "applies when the staging snapshot is strictly newer"
+  // above; these cover the race the second phase exists to close — Phase 1 sees
+  // a clean gate, a local edit lands in the window, and the in-tx re-gate must
+  // catch it and skip the write rather than clobber the unsynced edit.
+
+  it('skips a candidate when a local edit is queued for upload in the window', async () => {
+    await seedLocalBlock(blockData({ content: 'local v1', updatedAt: 200 }))
+    await stageRow(blockData({ content: 'server v2', updatedAt: 300 }))
+
+    const out = await materializeStagingRows(
+      racingDb(env.db, () => queuePendingUpload('b1')),
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey },
+    )
+
+    expect(out.applied).toEqual([])
+    expect(out.skippedStale).toEqual(['b1'])
+    expect(out.snapshots.has('b1')).toBe(false) // nothing written ⇒ nothing to invalidate
+    expect((await allBlocks())[0]!.content).toBe('local v1')
+  })
+
+  it('skips a candidate when the local row is bumped newer in the window', async () => {
+    await seedLocalBlock(blockData({ content: 'local v1', updatedAt: 200 }))
+    await stageRow(blockData({ content: 'server v2', updatedAt: 300 }))
+
+    const out = await materializeStagingRows(
+      racingDb(env.db, async () => {
+        await env.db.execute('UPDATE blocks SET updated_at = ? WHERE id = ?', [999, 'b1'])
+      }),
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey },
+    )
+
+    expect(out.applied).toEqual([])
+    expect(out.skippedStale).toEqual(['b1'])
+    expect((await allBlocks())[0]!.content).toBe('local v1')
+  })
+})
+
+describe('materializeStagingRows — soft-delete (tombstone) materialization', () => {
+  const deletedFlag = (id: string) =>
+    env.db.getAll<{ deleted: number }>('SELECT deleted FROM blocks WHERE id = ?', [id])
+
+  it('materializes a deleted=true snapshot as a soft-deleted row, not a hard delete', async () => {
+    // A tombstone arrives as an UPSERT (still in the synced set, just flagged
+    // deleted) — distinct from the `removed` stream-exit path. It must land in
+    // `blocks` as deleted=1 so it can still sync / LWW-merge, not vanish.
+    await stageRow(blockData({ content: 'tombstone', deleted: true }))
+
+    const out = await materializeStagingRows(
+      env.db,
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey },
+    )
+
+    expect(out.applied).toEqual(['b1'])
+    expect(out.deleted).toEqual([]) // not the hard-delete path
+    expect(await deletedFlag('b1')).toEqual([{ deleted: 1 }])
+    expect(out.snapshots.get('b1')).toMatchObject({
+      before: null,
+      after: { id: 'b1', deleted: true },
+    })
+  })
+
+  it('soft-deletes a previously-live local row when a newer tombstone arrives', async () => {
+    await seedLocalBlock(blockData({ content: 'alive', updatedAt: 100 }))
+    await stageRow(blockData({ content: 'alive', deleted: true, updatedAt: 200 }))
+
+    const out = await materializeStagingRows(
+      env.db,
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey },
+    )
+
+    expect(out.applied).toEqual(['b1'])
+    expect(out.deleted).toEqual([])
+    expect(await deletedFlag('b1')).toEqual([{ deleted: 1 }])
+    expect(out.snapshots.get('b1')).toMatchObject({
+      before: { deleted: false },
+      after: { deleted: true },
+    })
   })
 })

--- a/src/sync/observer/observer.test.ts
+++ b/src/sync/observer/observer.test.ts
@@ -352,6 +352,37 @@ describe('blocksSyncedObserver — cycle detection (§4.7)', () => {
     warn.mockRestore()
   })
 
+  it('emits cycleDetected for a sync-applied 3-cycle (startIds cover all three members)', async () => {
+    // The 2-cycle test above only walks one hop; this drives the cycleScanSql
+    // recursion across three members (A→B→C→A) to confirm n>2 loops are caught.
+    const events: CycleDetectedEvent[] = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { observer } = start({
+      getMaterializability: constMat('copy'),
+      onCycleDetected: e => events.push(e),
+    })
+
+    await put(data({ id: 'A', parentId: null, updatedAt: 1 }))
+    await put(data({ id: 'B', parentId: null, updatedAt: 1 }))
+    await put(data({ id: 'C', parentId: null, updatedAt: 1 }))
+    await observer.flush()
+
+    // Three sync-applied moves close the loop A→B→C→A (all strictly newer).
+    await put(data({ id: 'A', parentId: 'B', updatedAt: 2 }))
+    await put(data({ id: 'B', parentId: 'C', updatedAt: 2 }))
+    await put(data({ id: 'C', parentId: 'A', updatedAt: 2 }))
+    await observer.flush()
+
+    expect(events.length).toBeGreaterThanOrEqual(1)
+    const startIds = new Set<string>()
+    for (const ev of events) {
+      expect(ev.workspaceId).toBe('ws-plain')
+      ev.startIds.forEach(id => startIds.add(id))
+    }
+    expect([...startIds].sort()).toEqual(['A', 'B', 'C'])
+    warn.mockRestore()
+  })
+
   it('does not fire when a sync-applied move does not close a loop', async () => {
     const events: CycleDetectedEvent[] = []
     const { observer } = start({


### PR DESCRIPTION
Finishes the test-suite audit follow-ups (#114). With flakiness/leaks (#112) and per-test perf (#110) already landed, this covers the last two sub-issues: **quality cleanup (#111)** and **coverage gaps (#113)** — both now complete.

## #111 — remove source-literal tautologies & brittle mocks (`fde6374`)

Drop assertions that restate a source literal (can never catch a regression) or couple to an implementation detail (fail for the wrong reason). Per AGENTS.md "don't add tests that just re-state the code."

- **changeScope**: drop "defines every scope" — guaranteed at compile time by `satisfies Readonly<Record<ChangeScope, …>>`.
- **blockSchema**: drop the exact column-name `toEqual` (round-trip already exercises every column positionally); keep the legacy-column `not.toContain` guards.
- **kernelMutators**: drop "avoids full sibling-list enumeration" — spied on the private `TxImpl.childrenOf`, passes silently if inlined.
- **discoverToggleTree**: stop codifying accidental non-dedup → assert the handle surfaces via `toContain`.
- **BlockProperties**: drop the raw `.fixed` CSS-class asserts; keep the `parentElement === document.body` portal assertions.
- **clientSchema**: drop the trigger-name inventory restatement.
- **extensions-settings/config**: drop the codec-id / prefs-type id/label restatements.
- **agent-cli/packageManifest**: assert the real invariant (a bin keyed by the unscoped name resolves into `dist/`), not the literal name/path.

Left intact after a skeptical pass: **geo/blockTypes** (tests the type-lift against property *objects*, with a real "location not lifted" guard) and the **SRS SM-2.5** tests (scheduling behavior; no tautological parameter list exists).

## #113 — coverage gaps

### Observer correctness (`8448700`)
- **`cycleScanCandidatesByWorkspace`** — new DB-free unit test pins every skip branch + workspace grouping (the SQL scan was covered, but the predicate only transitively; the scan is detection-only telemetry).
- **Phase-1/Phase-2 TOCTOU re-gate** (relates to #69) — a `racingDb` proxy injects a local edit *in the window* before the write tx; the in-tx re-gate must skip, not clobber.
- **Soft-delete materialization** — a `deleted=true` upsert lands as `deleted=1` (still syncs), not a hard delete.

### Bounded logic (`b4738bc`)
- **find-replace**: `previewForMatch` (window/ellipsis/whitespace) + `buildContentSearchMatch` (count, no-match null, empty-query short-circuit).
- **todo/cycleTodoState**: the read-only guard early-return.
- **merge-blocks/mergeAction**: opens the picker with source id + workspace, peek→load fallback, no-data bail.
- **txEngine cycle validation**: a several-levels-deep n-cycle + the `depth < 100` guard-truncation limitation.
- **observer**: a sync-applied 3-cycle (n>2 members through `cycleScanSql`).

### Integration (`bc95b4e`)
- **agent-cli/config**: corrupt (non-JSON) config rethrows vs missing → {}; wrong-typed secret mints a fresh one.
- **agent-cli/protocol**: the strict command unions — unknown-type / missing-field rejection, and legacy aliases present in the kernel union but not the CLI canonical union.
- **geo/usePlaceSearch**: a Google HTTP/network error keeps local results + surfaces the error (the picker's failure contract); plus success-merge.
- **vim/jumpVisibleBlocks**: exported for testing; counting, scope-edge clamping (incl. the navigable scope root), "no movement" → null.
- **codemirror field-creation**: extracted the `>` keydown guard into `fieldCreationKeydown.ts`; pins when it fires (empty top-of-doc child block) vs falls through.

---

Validation: full `yarn run check` green after every commit — currently **273 files / 2945 tests, 0 errors**.

Closes #111. Closes #113.

https://claude.ai/code/session_01Qb9hPUtry6z6YrC4hf9EyB