### PR TITLE
Collapse swipe + click-to-edit onto the unified pointer dispatch

### DIFF
--- a/src/extensions/api.ts
+++ b/src/extensions/api.ts
@@ -81,7 +81,6 @@ export {
   shortcutSurfaceActivationsFacet,
   enterBlockEditMode,
   getBlockContentRendererSlot,
-  handleBlockSelectionClick,
   isSelectionClick,
   type BlockChildrenFooterContribution,
   type BlockClickContribution,

--- a/src/extensions/blockInteraction.ts
+++ b/src/extensions/blockInteraction.ts
@@ -456,15 +456,17 @@ export const isInteractiveContentEvent = (event: { target: EventTarget | null })
   return Boolean(element?.closest(interactiveContentSelector))
 }
 
-export const enterBlockEditMode = async (
-  context: BlockResolveContext,
+/**
+ * Enter edit mode for a block from its flat dependencies — the core used by
+ * both the `BlockResolveContext` wrapper below and the pointer-dispatched
+ * click-to-edit action (which only carries `{block, uiStateBlock, renderScopeId}`).
+ */
+export const enterEditModeForBlock = async (
+  block: Block,
+  uiStateBlock: Block,
+  renderScopeId?: string,
   selection?: EditorActivationSelection,
 ) => {
-  const {block, uiStateBlock} = context
-  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
-    ? context.blockContext.renderScopeId
-    : undefined
-
   // Read-only workspace: clicks/keyboard shouldn't drop into edit mode, but
   // we still want the click target to register as focused so navigation
   // affordances (highlight, keyboard nav anchor) work. `focusBlock` honors
@@ -486,6 +488,31 @@ export const enterBlockEditMode = async (
   }
 
   requestEditorFocus(uiStateBlock)
+}
+
+export const enterBlockEditMode = async (
+  context: BlockResolveContext,
+  selection?: EditorActivationSelection,
+) => {
+  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
+    ? context.blockContext.renderScopeId
+    : undefined
+  await enterEditModeForBlock(context.block, context.uiStateBlock, renderScopeId, selection)
+}
+
+/**
+ * Focus a block without entering edit mode, clearing any active block
+ * selection first — the "single click focuses" behaviour vim normal mode wants
+ * (and the plain-click branch of `handleBlockSelectionClick`). Operates on the
+ * flat deps a pointer-dispatched action carries.
+ */
+export const focusBlockWithoutEditing = async (
+  block: Block,
+  uiStateBlock: Block,
+  renderScopeId?: string,
+) => {
+  await resetBlockSelection(uiStateBlock)
+  void focusBlock(uiStateBlock, block.id, renderScopeId ? {renderScopeId} : undefined)
 }
 
 export const handleBlockSelectionClick = async (

--- a/src/extensions/blockInteraction.ts
+++ b/src/extensions/blockInteraction.ts
@@ -14,13 +14,9 @@ import { Block } from '../data/block'
 import {
   editorSelection,
   focusBlock,
-  selectionStateProp,
   requestEditorFocus,
 } from '@/data/properties.js'
-import {
-  getSelectionStateSnapshot,
-  resetBlockSelection,
-} from '@/data/stateBlocks.js'
+import { resetBlockSelection } from '@/data/stateBlocks.js'
 import { Repo } from '../data/repo'
 import { combineLastContributionResult, defineFacet, isFunction } from '@/extensions/facet.js'
 import {
@@ -31,7 +27,6 @@ import {
 } from '@/extensions/variantFacet.js'
 import type { ActionContextActivation } from '@/shortcuts/types.js'
 import type { BlockContextType, BlockRenderer } from '@/types.js'
-import { extendSelection, validateSelectionHierarchy } from '@/utils/selection.js'
 
 export interface BlockContentRendererSlot {
   id: string
@@ -513,44 +508,6 @@ export const focusBlockWithoutEditing = async (
 ) => {
   await resetBlockSelection(uiStateBlock)
   void focusBlock(uiStateBlock, block.id, renderScopeId ? {renderScopeId} : undefined)
-}
-
-export const handleBlockSelectionClick = async (
-  context: BlockResolveContext,
-  event: MouseEvent,
-) => {
-  if (isInteractiveContentEvent(event)) return
-
-  const {block, repo, uiStateBlock} = context
-  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
-    ? context.blockContext.renderScopeId
-    : undefined
-
-  event.preventDefault()
-  event.stopPropagation()
-
-  if (event.ctrlKey || event.metaKey) {
-    const selectionState = getSelectionStateSnapshot(uiStateBlock)
-    const isSelected = selectionState.selectedBlockIds.includes(block.id)
-    const newSelectedIds = isSelected
-      ? selectionState.selectedBlockIds.filter(id => id !== block.id)
-      : [...selectionState.selectedBlockIds, block.id]
-
-    const validatedIds = await validateSelectionHierarchy(newSelectedIds, repo)
-
-    void uiStateBlock.set(selectionStateProp, {
-      selectedBlockIds: validatedIds,
-      anchorBlockId: validatedIds.length > 0
-        ? (selectionState.anchorBlockId || block.id)
-        : null,
-    })
-  } else if (event.shiftKey) {
-    await extendSelection(block.id, uiStateBlock, repo, context.scopeRootId, !context.blockContext?.isNestedSurface)
-  } else {
-    await resetBlockSelection(uiStateBlock)
-  }
-
-  void focusBlock(uiStateBlock, block.id, {renderScopeId})
 }
 
 export const isSelectionClick = (event: MouseEvent) =>

--- a/src/extensions/blockSelectionAction.ts
+++ b/src/extensions/blockSelectionAction.ts
@@ -1,8 +1,10 @@
-import { focusBlock } from '@/data/properties.js'
+import { focusBlock, selectionStateProp } from '@/data/properties.js'
+import { getSelectionStateSnapshot } from '@/data/stateBlocks.js'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types.js'
-import { extendSelection } from '@/utils/selection.js'
+import { extendSelection, validateSelectionHierarchy } from '@/utils/selection.js'
 
 export const EXTEND_BLOCK_SELECTION_ACTION_ID = 'extend_block_selection'
+export const TOGGLE_BLOCK_SELECTION_ACTION_ID = 'toggle_block_selection'
 
 /**
  * Shift-click block selection, structural variant: extend the data-tree
@@ -30,6 +32,47 @@ export const extendBlockSelectionAction: ActionConfig<typeof ActionContextTypes.
       scopeRootId,
       scopeRootForcesOpen ?? true,
     )
+    void focusBlock(uiStateBlock, block.id, renderScopeId ? {renderScopeId} : undefined)
+  },
+}
+
+/**
+ * Ctrl/Cmd-click block selection: toggle the clicked block in or out of the
+ * selection set (with hierarchy validation), then focus it. The pointer
+ * counterpart of the structural ctrl/meta branch that used to live in
+ * `handleBlockSelectionClick`.
+ *
+ * Two bindings because modifier matching is exact-set: `$mod` (Cmd on macOS,
+ * Ctrl elsewhere) AND literal `Control` (so Ctrl-click toggles on macOS too,
+ * matching the prior `ctrlKey || metaKey` behaviour). Lives in `block-pointer`
+ * like the extend action; the context's `pointerTargetFilter` keeps it off
+ * interactive descendants.
+ */
+export const toggleBlockSelectionAction: ActionConfig<typeof ActionContextTypes.BLOCK_POINTER> = {
+  id: TOGGLE_BLOCK_SELECTION_ACTION_ID,
+  description: 'Toggle the clicked block in the selection',
+  context: ActionContextTypes.BLOCK_POINTER,
+  pointerBinding: [
+    {kind: 'mouse', mods: ['$mod'], phase: 'click'},
+    {kind: 'mouse', mods: ['Control'], phase: 'click'},
+  ],
+  handler: async ({block, uiStateBlock, renderScopeId}) => {
+    const repo = uiStateBlock.repo
+    const selectionState = getSelectionStateSnapshot(uiStateBlock)
+    const isSelected = selectionState.selectedBlockIds.includes(block.id)
+    const newSelectedIds = isSelected
+      ? selectionState.selectedBlockIds.filter(id => id !== block.id)
+      : [...selectionState.selectedBlockIds, block.id]
+
+    const validatedIds = await validateSelectionHierarchy(newSelectedIds, repo)
+
+    void uiStateBlock.set(selectionStateProp, {
+      selectedBlockIds: validatedIds,
+      anchorBlockId: validatedIds.length > 0
+        ? (selectionState.anchorBlockId || block.id)
+        : null,
+    })
+
     void focusBlock(uiStateBlock, block.id, renderScopeId ? {renderScopeId} : undefined)
   },
 }

--- a/src/extensions/blockSelectionAction.ts
+++ b/src/extensions/blockSelectionAction.ts
@@ -47,6 +47,14 @@ export const extendBlockSelectionAction: ActionConfig<typeof ActionContextTypes.
  * matching the prior `ctrlKey || metaKey` behaviour). Lives in `block-pointer`
  * like the extend action; the context's `pointerTargetFilter` keeps it off
  * interactive descendants.
+ *
+ * Behaviour note: exact-set matching means a COMBINED-modifier click
+ * (ctrl/cmd+shift, ctrl+alt, …) matches neither toggle, extend, nor edit, so it
+ * falls through to native — a deliberate change from the old precedence chain
+ * (`if (ctrl||meta) toggle; else if (shift) extend`), where ctrl/meta + any
+ * other modifier still toggled. That combined-modifier toggling was incidental,
+ * not designed; if a real additive-range gesture is wanted later, bind it
+ * explicitly (e.g. `['$mod','Shift']`) rather than reviving the precedence.
  */
 export const toggleBlockSelectionAction: ActionConfig<typeof ActionContextTypes.BLOCK_POINTER> = {
   id: TOGGLE_BLOCK_SELECTION_ACTION_ID,

--- a/src/extensions/defaultEditorInteractions.ts
+++ b/src/extensions/defaultEditorInteractions.ts
@@ -97,6 +97,15 @@ export const createBlockSelectionShellState = (
         dispatchSelectionClick(resolveContext, event)
         return
       }
+      // Interactive descendants (links, buttons, …) keep their native behavior.
+      // Pointer actions match on button + modifiers alone and don't re-check the
+      // target, so a Shift-click on a link would otherwise be claimed as block
+      // selection (extend_block_selection) and preventDefault'd — bypass pointer
+      // dispatch entirely here, as the pre-migration click handlers did.
+      if (isInteractiveContentEvent(event)) {
+        state.shellProps.onClick?.(event)
+        return
+      }
       // Plain (un-modified) click: route through the unified pointer dispatch
       // so click-to-edit (plain-outliner, vim-decorated) resolves the same way
       // selection gestures do. Falls back to any remaining facet click handler

--- a/src/extensions/defaultEditorInteractions.ts
+++ b/src/extensions/defaultEditorInteractions.ts
@@ -41,32 +41,38 @@ const isBlockSelectionGesture = (event: MouseEvent<HTMLElement>): boolean =>
   isSelectionClick(event) && !isInteractiveContentEvent(event)
 
 /**
- * Dispatch a selection-gesture click through the unified pointer path. The
- * clicked block's deps are SUPPLIED (the gesture's context isn't keyboard-
- * active), and `currentTarget` — the block shell the spatial walker tags — is
- * captured synchronously before React nulls it. A pointer-bound action
- * (shift-click → `extend_block_selection`, possibly decorated by spatial nav)
- * may claim it; if none does (ctrl/meta toggle, plain reset), fall back to the
- * structural handler that still owns those branches.
+ * Build the deps a pointer-dispatched block gesture needs from a block's
+ * resolve context plus the live event. `currentTarget` — the block shell the
+ * spatial walker tags — is captured synchronously before React nulls it.
+ */
+const suppliedPointerDeps = (
+  resolveContext: BlockResolveContext,
+  event: MouseEvent<HTMLElement>,
+): BlockPointerDependencies => {
+  const renderScopeId = typeof resolveContext.blockContext?.renderScopeId === 'string'
+    ? resolveContext.blockContext.renderScopeId
+    : undefined
+  return {
+    block: resolveContext.block,
+    uiStateBlock: resolveContext.uiStateBlock,
+    scopeRootId: resolveContext.scopeRootId,
+    scopeRootForcesOpen: !resolveContext.blockContext?.isNestedSurface,
+    targetElement: event.currentTarget,
+    ...(renderScopeId ? {renderScopeId} : {}),
+  }
+}
+
+/**
+ * Dispatch a selection-gesture click through the unified pointer path. A
+ * pointer-bound action (shift-click → `extend_block_selection`, possibly
+ * decorated by spatial nav) may claim it; if none does (ctrl/meta toggle, plain
+ * reset), fall back to the structural handler that still owns those branches.
  */
 const dispatchSelectionClick = (
   resolveContext: BlockResolveContext,
   event: MouseEvent<HTMLElement>,
 ): void => {
-  const targetElement = event.currentTarget
-  const renderScopeId = typeof resolveContext.blockContext?.renderScopeId === 'string'
-    ? resolveContext.blockContext.renderScopeId
-    : undefined
-  const supplied: BlockPointerDependencies = {
-    block: resolveContext.block,
-    uiStateBlock: resolveContext.uiStateBlock,
-    scopeRootId: resolveContext.scopeRootId,
-    scopeRootForcesOpen: !resolveContext.blockContext?.isNestedSurface,
-    targetElement,
-    ...(renderScopeId ? {renderScopeId} : {}),
-  }
-
-  if (!dispatchPointerAction(event, supplied)) {
+  if (!dispatchPointerAction(event, suppliedPointerDeps(resolveContext, event))) {
     void handleBlockSelectionClick(resolveContext, event)
   }
 }
@@ -91,7 +97,13 @@ export const createBlockSelectionShellState = (
         dispatchSelectionClick(resolveContext, event)
         return
       }
-      state.shellProps.onClick?.(event)
+      // Plain (un-modified) click: route through the unified pointer dispatch
+      // so click-to-edit (plain-outliner, vim-decorated) resolves the same way
+      // selection gestures do. Falls back to any remaining facet click handler
+      // when no pointer action claims the gesture.
+      if (!dispatchPointerAction(event, suppliedPointerDeps(resolveContext, event))) {
+        state.shellProps.onClick?.(event)
+      }
     },
   },
   shortcutSurfaceOptions: state.shortcutSurfaceOptions,

--- a/src/extensions/defaultEditorInteractions.ts
+++ b/src/extensions/defaultEditorInteractions.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import type { MouseEvent } from 'react'
 import {
   blockShellDecoratorsFacet,
-  handleBlockSelectionClick,
   isInteractiveContentEvent,
   isSelectionClick,
   type BlockResolveContext,
@@ -17,7 +16,10 @@ import { AppExtension } from '@/extensions/facet.js'
 import { actionsFacet } from '@/extensions/core.js'
 import { ActionContextTypes, type BlockPointerDependencies } from '@/shortcuts/types.js'
 import { dispatchPointerAction } from '@/shortcuts/pointerAction.js'
-import { extendBlockSelectionAction } from '@/extensions/blockSelectionAction.js'
+import {
+  extendBlockSelectionAction,
+  toggleBlockSelectionAction,
+} from '@/extensions/blockSelectionAction.js'
 import { blockFocusShellDecorator } from '@/extensions/BlockFocusShellDecorator.js'
 import { systemToggle } from '@/extensions/togglable.js'
 
@@ -62,21 +64,6 @@ const suppliedPointerDeps = (
   }
 }
 
-/**
- * Dispatch a selection-gesture click through the unified pointer path. A
- * pointer-bound action (shift-click → `extend_block_selection`, possibly
- * decorated by spatial nav) may claim it; if none does (ctrl/meta toggle, plain
- * reset), fall back to the structural handler that still owns those branches.
- */
-const dispatchSelectionClick = (
-  resolveContext: BlockResolveContext,
-  event: MouseEvent<HTMLElement>,
-): void => {
-  if (!dispatchPointerAction(event, suppliedPointerDeps(resolveContext, event))) {
-    void handleBlockSelectionClick(resolveContext, event)
-  }
-}
-
 export const createBlockSelectionShellState = (
   resolveContext: BlockResolveContext,
   state: BlockShellState,
@@ -85,31 +72,20 @@ export const createBlockSelectionShellState = (
     ...state.shellProps,
     onMouseDownCapture: event => {
       if (isBlockSelectionGesture(event)) {
-        // Suppress the browser's native text-selection drag a shift-click
-        // would otherwise start before the click resolves.
+        // Suppress the browser's native text-selection drag a modifier-click
+        // would otherwise start before the click resolves. (click-phase
+        // pointer actions are too late for this; it stays a mousedown concern.)
         event.preventDefault()
         return
       }
       state.shellProps.onMouseDownCapture?.(event)
     },
     onClick: event => {
-      if (isBlockSelectionGesture(event)) {
-        dispatchSelectionClick(resolveContext, event)
-        return
-      }
-      // Interactive descendants (links, buttons, …) keep their native behavior.
-      // Pointer actions match on button + modifiers alone and don't re-check the
-      // target, so a Shift-click on a link would otherwise be claimed as block
-      // selection (extend_block_selection) and preventDefault'd — bypass pointer
-      // dispatch entirely here, as the pre-migration click handlers did.
-      if (isInteractiveContentEvent(event)) {
-        state.shellProps.onClick?.(event)
-        return
-      }
-      // Plain (un-modified) click: route through the unified pointer dispatch
-      // so click-to-edit (plain-outliner, vim-decorated) resolves the same way
-      // selection gestures do. Falls back to any remaining facet click handler
-      // when no pointer action claims the gesture.
+      // Every block pointer gesture resolves through one dispatch: shift-click →
+      // extend selection, ctrl/cmd-click → toggle, plain click → edit/focus. The
+      // block-pointer context's pointerTargetFilter keeps interactive descendants
+      // native (no candidate matches). Fall back to any residual facet click
+      // handler only when nothing claims the gesture.
       if (!dispatchPointerAction(event, suppliedPointerDeps(resolveContext, event))) {
         state.shellProps.onClick?.(event)
       }
@@ -148,9 +124,10 @@ export const defaultEditorInteractionExtension: AppExtension = systemToggle({
   shortcutSurfaceActivationsFacet.of(codeMirrorEditModeActivation, {
     source: 'codemirror-edit-mode',
   }),
-  // Shift-click selection as a pointer-bound action — spatial navigation
-  // decorates it (ActionTransform) for visible-DOM-order ranges, mirroring how
-  // it decorates the keyboard extend-selection actions.
+  // Block selection as pointer-bound actions — shift-click extends (spatial
+  // navigation decorates it via ActionTransform for visible-DOM-order ranges),
+  // ctrl/cmd-click toggles. Both replace the structural handleBlockSelectionClick.
   actionsFacet.of(extendBlockSelectionAction, {source: 'default-block-selection'}),
+  actionsFacet.of(toggleBlockSelectionAction, {source: 'default-block-selection'}),
   editorAutocompleteExtension,
 ])

--- a/src/extensions/test/blockSelectionAction.test.ts
+++ b/src/extensions/test/blockSelectionAction.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BlockCache } from '@/data/blockCache.js'
+import { ChangeScope, type User } from '@/data/api'
+import { Repo } from '@/data/repo.js'
+import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb.js'
+import { selectionStateProp } from '@/data/properties.js'
+import type { ActionTrigger, BlockPointerDependencies } from '@/shortcuts/types.js'
+import { toggleBlockSelectionAction } from '@/extensions/blockSelectionAction.js'
+
+const WS = 'ws-1'
+const USER: User = {id: 'user-1'}
+
+let sharedDb: TestDb
+let repo: Repo
+
+beforeAll(async () => { sharedDb = await createTestDb() })
+afterAll(async () => { await sharedDb.cleanup() })
+
+beforeEach(async () => {
+  await resetTestDb(sharedDb.db)
+  repo = new Repo({db: sharedDb.db, cache: new BlockCache(), user: USER, registerKernelProcessors: false})
+  repo.setActiveWorkspaceId(WS)
+  await repo.tx(async tx => {
+    await tx.create({id: 'panel', workspaceId: WS, parentId: null, orderKey: 'a0'})
+    await tx.create({id: 'A', workspaceId: WS, parentId: null, orderKey: 'b0', content: 'A'})
+    await tx.create({id: 'B', workspaceId: WS, parentId: null, orderKey: 'c0', content: 'B'})
+  }, {scope: ChangeScope.UiState})
+})
+
+afterEach(() => { repo.stopSyncObserver() })
+
+describe('toggleBlockSelectionAction', () => {
+  const toggle = (blockId: string) =>
+    toggleBlockSelectionAction.handler({
+      block: repo.block(blockId),
+      uiStateBlock: repo.block('panel'),
+    } as BlockPointerDependencies, {} as ActionTrigger)
+
+  it('adds and removes the clicked block from the selection, tracking the anchor', async () => {
+    const panel = repo.block('panel')
+    // The handler fire-and-forgets the selection-state set, and each toggle
+    // reads the prior committed state — so wait for each commit before the next.
+    const expectSelection = (state: {selectedBlockIds: string[]; anchorBlockId: string | null}) =>
+      vi.waitFor(() => expect(panel.peekProperty(selectionStateProp)).toEqual(state))
+
+    await toggle('A')
+    await expectSelection({selectedBlockIds: ['A'], anchorBlockId: 'A'})
+
+    await toggle('B')
+    await expectSelection({selectedBlockIds: ['A', 'B'], anchorBlockId: 'A'})
+
+    // Toggling A back out keeps B and the original anchor.
+    await toggle('A')
+    await expectSelection({selectedBlockIds: ['B'], anchorBlockId: 'A'})
+
+    // Removing the last block clears the anchor.
+    await toggle('B')
+    await expectSelection({selectedBlockIds: [], anchorBlockId: null})
+  })
+})

--- a/src/extensions/test/defaultEditorInteractions.test.ts
+++ b/src/extensions/test/defaultEditorInteractions.test.ts
@@ -105,6 +105,29 @@ describe('default editor interactions', () => {
     expect(event.preventDefault).not.toHaveBeenCalled()
   })
 
+  it('does not dispatch pointer actions for a selection-click on an interactive descendant', () => {
+    // A Shift-click on a link is not a block selection gesture (interactive
+    // targets are excluded), but it must not fall into the pointer dispatch
+    // either — extend_block_selection matches Shift-clicks without re-checking
+    // the target and would preventDefault the link. It stays native.
+    const pluginClick = vi.fn()
+    const link = document.createElement('a')
+    link.href = 'https://example.com'
+    const target = document.createElement('span')
+    link.appendChild(target)
+    const event = selectionMouseEvent(target, {
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: true,
+    })
+    const nextState = createBlockSelectionShellState(context, shellState({onClick: pluginClick}))
+
+    nextState.shellProps.onClick?.(event)
+
+    expect(mockDispatchPointerAction).not.toHaveBeenCalled()
+    expect(pluginClick).toHaveBeenCalledWith(event)
+  })
+
   it('routes selection clicks through the pointer dispatcher with the clicked block supplied', () => {
     const pluginClick = vi.fn()
     const target = document.createElement('span')

--- a/src/extensions/test/defaultEditorInteractions.test.ts
+++ b/src/extensions/test/defaultEditorInteractions.test.ts
@@ -177,7 +177,10 @@ describe('default editor interactions', () => {
     })
   })
 
-  it('passes non-selection clicks through to the plugin click handler', () => {
+  it('routes plain clicks through the pointer dispatcher (click-to-edit) ahead of any plugin handler', () => {
+    // Click-to-edit is now a pointer-bound action; a plain click dispatches it
+    // with the clicked block supplied, and a handled gesture never reaches the
+    // residual plugin click handler.
     const pluginClick = vi.fn()
     const target = document.createElement('span')
     const event = selectionMouseEvent(target, {
@@ -189,7 +192,27 @@ describe('default editor interactions', () => {
 
     nextState.shellProps.onClick?.(event)
 
+    expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
+    const [dispatchedEvent, supplied] = mockDispatchPointerAction.mock.calls[0]!
+    expect(dispatchedEvent).toBe(event)
+    expect(supplied).toMatchObject({block: context.block, uiStateBlock: context.uiStateBlock})
+    expect(pluginClick).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the plugin click handler when no pointer action claims a plain click', () => {
+    mockDispatchPointerAction.mockReturnValue(false)
+    const pluginClick = vi.fn()
+    const target = document.createElement('span')
+    const event = selectionMouseEvent(target, {
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    })
+    const nextState = createBlockSelectionShellState(context, shellState({onClick: pluginClick}))
+
+    nextState.shellProps.onClick?.(event)
+
+    expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
     expect(pluginClick).toHaveBeenCalledWith(event)
-    expect(mockDispatchPointerAction).not.toHaveBeenCalled()
   })
 })

--- a/src/extensions/test/defaultEditorInteractions.test.ts
+++ b/src/extensions/test/defaultEditorInteractions.test.ts
@@ -9,26 +9,19 @@ import type {
 import {
   createBlockSelectionShellState,
 } from '@/extensions/defaultEditorInteractions'
-import { handleBlockSelectionClick } from '@/extensions/blockInteraction'
 import { dispatchPointerAction } from '@/shortcuts/pointerAction'
 
-// Selection clicks route through the unified pointer dispatcher; mock it so
+// All block clicks route through the unified pointer dispatcher; mock it so
 // these unit tests don't need a mounted coordinator. Returning true = "a
-// pointer-bound action handled it" (no structural fallback); false exercises
-// the fallback branch.
+// pointer-bound action handled it"; false exercises the facet fallback branch.
+// (Interactive-target exclusion now lives on the block-pointer context's
+// pointerTargetFilter — exercised in HotkeyReconciler's dispatch tests, not at
+// the shell, which dispatches uniformly.)
 vi.mock('@/shortcuts/pointerAction', () => ({
   dispatchPointerAction: vi.fn(() => true),
 }))
 
-// The structural fallback runs against real data; stub it so the fallback-
-// wiring test can assert it's reached without standing up a repo/block.
-vi.mock('@/extensions/blockInteraction', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/extensions/blockInteraction')>()),
-  handleBlockSelectionClick: vi.fn(),
-}))
-
 const mockDispatchPointerAction = vi.mocked(dispatchPointerAction)
-const mockHandleBlockSelectionClick = vi.mocked(handleBlockSelectionClick)
 
 const context = {
   block: {id: 'block-1'} as Block,
@@ -71,7 +64,6 @@ describe('default editor interactions', () => {
   beforeEach(() => {
     mockDispatchPointerAction.mockClear()
     mockDispatchPointerAction.mockReturnValue(true)
-    mockHandleBlockSelectionClick.mockClear()
   })
 
   it('prevents native text selection when a block selection gesture starts on the shell', () => {
@@ -89,7 +81,7 @@ describe('default editor interactions', () => {
     expect(event.stopPropagation).not.toHaveBeenCalled()
   })
 
-  it('leaves interactive descendants to their native mouse handling', () => {
+  it('leaves interactive descendants to their native mouse handling on mousedown', () => {
     const button = document.createElement('button')
     const target = document.createElement('span')
     button.appendChild(target)
@@ -105,30 +97,7 @@ describe('default editor interactions', () => {
     expect(event.preventDefault).not.toHaveBeenCalled()
   })
 
-  it('does not dispatch pointer actions for a selection-click on an interactive descendant', () => {
-    // A Shift-click on a link is not a block selection gesture (interactive
-    // targets are excluded), but it must not fall into the pointer dispatch
-    // either — extend_block_selection matches Shift-clicks without re-checking
-    // the target and would preventDefault the link. It stays native.
-    const pluginClick = vi.fn()
-    const link = document.createElement('a')
-    link.href = 'https://example.com'
-    const target = document.createElement('span')
-    link.appendChild(target)
-    const event = selectionMouseEvent(target, {
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: true,
-    })
-    const nextState = createBlockSelectionShellState(context, shellState({onClick: pluginClick}))
-
-    nextState.shellProps.onClick?.(event)
-
-    expect(mockDispatchPointerAction).not.toHaveBeenCalled()
-    expect(pluginClick).toHaveBeenCalledWith(event)
-  })
-
-  it('routes selection clicks through the pointer dispatcher with the clicked block supplied', () => {
+  it('routes a click through the pointer dispatcher with the clicked block supplied', () => {
     const pluginClick = vi.fn()
     const target = document.createElement('span')
     const event = selectionMouseEvent(target, {
@@ -148,35 +117,29 @@ describe('default editor interactions', () => {
       uiStateBlock: context.uiStateBlock,
       targetElement: event.currentTarget,
     })
-    // A handled gesture never reaches the plugin click handler.
+    // A handled gesture never reaches the residual plugin click handler.
     expect(pluginClick).not.toHaveBeenCalled()
   })
 
-  it('falls back to the structural handler when no pointer action claims the gesture', () => {
-    // ctrl/meta toggle and plain reset have no pointer binding, so the
-    // dispatcher returns false and the structural handler runs — never the
-    // plugin click handler.
-    mockDispatchPointerAction.mockReturnValue(false)
-    const pluginClick = vi.fn()
-    const target = document.createElement('span')
-    const event = selectionMouseEvent(target, {
-      ctrlKey: true,
-      metaKey: false,
-      shiftKey: false,
-    })
-    const nextState = createBlockSelectionShellState(context, shellState({onClick: pluginClick}))
-
-    nextState.shellProps.onClick?.(event)
-
-    expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
-    expect(mockHandleBlockSelectionClick).toHaveBeenCalledWith(context, event)
-    expect(pluginClick).not.toHaveBeenCalled()
+  it('dispatches plain and modifier clicks uniformly (no shell-level branching)', () => {
+    // shift (extend), ctrl/cmd (toggle), and plain (edit/focus) all resolve
+    // through the same dispatch — the shell no longer special-cases by modifier.
+    const nextState = createBlockSelectionShellState(context, shellState())
+    for (const modifiers of [
+      {ctrlKey: false, metaKey: false, shiftKey: true},
+      {ctrlKey: true, metaKey: false, shiftKey: false},
+      {ctrlKey: false, metaKey: false, shiftKey: false},
+    ]) {
+      mockDispatchPointerAction.mockClear()
+      nextState.shellProps.onClick?.(selectionMouseEvent(document.createElement('span'), modifiers))
+      expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
+    }
   })
 
   it('supplies scope + render-scope deps derived from a nested surface context', () => {
-    // The deps the spatial transform and structural handler actually consume —
-    // scopeRootId, scopeRootForcesOpen (= !isNestedSurface), renderScopeId — must
-    // be forwarded faithfully, not just block/uiStateBlock/targetElement.
+    // The deps the pointer actions consume — scopeRootId, scopeRootForcesOpen
+    // (= !isNestedSurface), renderScopeId — must be forwarded faithfully, not
+    // just block/uiStateBlock/targetElement.
     const nestedContext = {
       ...context,
       scopeRootId: 'scope-root',
@@ -200,29 +163,7 @@ describe('default editor interactions', () => {
     })
   })
 
-  it('routes plain clicks through the pointer dispatcher (click-to-edit) ahead of any plugin handler', () => {
-    // Click-to-edit is now a pointer-bound action; a plain click dispatches it
-    // with the clicked block supplied, and a handled gesture never reaches the
-    // residual plugin click handler.
-    const pluginClick = vi.fn()
-    const target = document.createElement('span')
-    const event = selectionMouseEvent(target, {
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: false,
-    })
-    const nextState = createBlockSelectionShellState(context, shellState({onClick: pluginClick}))
-
-    nextState.shellProps.onClick?.(event)
-
-    expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
-    const [dispatchedEvent, supplied] = mockDispatchPointerAction.mock.calls[0]!
-    expect(dispatchedEvent).toBe(event)
-    expect(supplied).toMatchObject({block: context.block, uiStateBlock: context.uiStateBlock})
-    expect(pluginClick).not.toHaveBeenCalled()
-  })
-
-  it('falls back to the plugin click handler when no pointer action claims a plain click', () => {
+  it('falls back to the plugin click handler when no pointer action claims the click', () => {
     mockDispatchPointerAction.mockReturnValue(false)
     const pluginClick = vi.fn()
     const target = document.createElement('span')

--- a/src/plugins/plain-outliner/clickToEditAction.ts
+++ b/src/plugins/plain-outliner/clickToEditAction.ts
@@ -1,0 +1,43 @@
+import type { MouseEvent as ReactMouseEvent } from 'react'
+import {
+  enterEditModeForBlock,
+  isInteractiveContentEvent,
+} from '@/extensions/blockInteraction.js'
+import {
+  ActionContextTypes,
+  type ActionConfig,
+  type ActionTrigger,
+} from '@/shortcuts/types.js'
+
+export const ENTER_BLOCK_EDIT_MODE_ACTION_ID = 'block.enter-edit-mode'
+
+/**
+ * Click-to-edit as a pointer-bound action: a plain (un-modified) click on a
+ * block's shell enters edit mode at the click position. The pointer binding's
+ * exact-modifier match means it only fires on a bare click — ctrl/meta/shift
+ * selection gestures match the selection action instead and never reach here.
+ *
+ * Declines (returns `false`) on clicks landing inside interactive content
+ * (links, buttons, …) so those fall through to native handling — the "this is
+ * not my gesture" contract the unified dispatch relies on, replacing the
+ * plain-outliner click handler's early `return`.
+ *
+ * Lives in the `block-pointer` context: never keyboard-active, dispatched only
+ * via the pointer path with the clicked block's deps supplied. Vim normal mode
+ * decorates it (an `ActionTransform`) to focus-without-editing, the same way it
+ * used to win the `blockClickHandlersFacet` last-contribution race.
+ */
+export const enterBlockEditModeOnClickAction: ActionConfig<typeof ActionContextTypes.BLOCK_POINTER> = {
+  id: ENTER_BLOCK_EDIT_MODE_ACTION_ID,
+  description: 'Enter edit mode on click',
+  context: ActionContextTypes.BLOCK_POINTER,
+  pointerBinding: {kind: 'mouse', mods: [], phase: 'click'},
+  handler: ({block, uiStateBlock, renderScopeId}, trigger: ActionTrigger) => {
+    const event = trigger as ReactMouseEvent<HTMLElement>
+    if (isInteractiveContentEvent(event)) return false
+    void enterEditModeForBlock(block, uiStateBlock, renderScopeId, {
+      x: event.clientX,
+      y: event.clientY,
+    })
+  },
+}

--- a/src/plugins/plain-outliner/clickToEditAction.ts
+++ b/src/plugins/plain-outliner/clickToEditAction.ts
@@ -1,8 +1,5 @@
 import type { MouseEvent as ReactMouseEvent } from 'react'
-import {
-  enterEditModeForBlock,
-  isInteractiveContentEvent,
-} from '@/extensions/blockInteraction.js'
+import { enterEditModeForBlock } from '@/extensions/blockInteraction.js'
 import {
   ActionContextTypes,
   type ActionConfig,
@@ -15,12 +12,12 @@ export const ENTER_BLOCK_EDIT_MODE_ACTION_ID = 'block.enter-edit-mode'
  * Click-to-edit as a pointer-bound action: a plain (un-modified) click on a
  * block's shell enters edit mode at the click position. The pointer binding's
  * exact-modifier match means it only fires on a bare click — ctrl/meta/shift
- * selection gestures match the selection action instead and never reach here.
+ * selection gestures match the selection actions instead and never reach here.
  *
- * Declines (returns `false`) on clicks landing inside interactive content
- * (links, buttons, …) so those fall through to native handling — the "this is
- * not my gesture" contract the unified dispatch relies on, replacing the
- * plain-outliner click handler's early `return`.
+ * Interactive descendants (links, buttons, …) are excluded by the
+ * `block-pointer` context's `pointerTargetFilter`, so this action never sees
+ * them and doesn't re-check — that "not my gesture" decision lives once, on the
+ * context, rather than in every block pointer action.
  *
  * Lives in the `block-pointer` context: never keyboard-active, dispatched only
  * via the pointer path with the clicked block's deps supplied. Vim normal mode
@@ -34,7 +31,6 @@ export const enterBlockEditModeOnClickAction: ActionConfig<typeof ActionContextT
   pointerBinding: {kind: 'mouse', mods: [], phase: 'click'},
   handler: ({block, uiStateBlock, renderScopeId}, trigger: ActionTrigger) => {
     const event = trigger as ReactMouseEvent<HTMLElement>
-    if (isInteractiveContentEvent(event)) return false
     void enterEditModeForBlock(block, uiStateBlock, renderScopeId, {
       x: event.clientX,
       y: event.clientY,

--- a/src/plugins/plain-outliner/index.ts
+++ b/src/plugins/plain-outliner/index.ts
@@ -1,13 +1,11 @@
 import {
-  blockClickHandlersFacet,
   blockContentRendererFacet,
 } from '@/extensions/blockInteraction.js'
+import { actionsFacet } from '@/extensions/core.js'
 import { AppExtension } from '@/extensions/facet.js'
 import { systemToggle } from '@/extensions/togglable.js'
-import {
-  blockEditingContentRenderer,
-  plainOutlinerBlockClickBehavior,
-} from './interactions.tsx'
+import { blockEditingContentRenderer } from './interactions.tsx'
+import { enterBlockEditModeOnClickAction } from './clickToEditAction.ts'
 
 export const plainOutlinerPlugin: AppExtension = systemToggle({
   id: 'system:plain-outliner',
@@ -15,5 +13,7 @@ export const plainOutlinerPlugin: AppExtension = systemToggle({
   description: 'Editable text content renderer + click-to-edit behaviour used for plain text blocks.',
 }).of([
   blockContentRendererFacet.of(blockEditingContentRenderer, {source: 'plain-outliner'}),
-  blockClickHandlersFacet.of(plainOutlinerBlockClickBehavior, {source: 'plain-outliner'}),
+  // Click-to-edit as a pointer-bound action dispatched through resolve, rather
+  // than a blockClickHandlersFacet contribution that silently last-wins.
+  actionsFacet.of(enterBlockEditModeOnClickAction, {source: 'plain-outliner'}),
 ])

--- a/src/plugins/plain-outliner/interactions.tsx
+++ b/src/plugins/plain-outliner/interactions.tsx
@@ -1,11 +1,6 @@
-import type { MouseEvent } from 'react'
 import {
-  BlockClickContribution,
   BlockContentRendererContribution,
-  enterBlockEditMode,
   getBlockContentRendererSlot,
-  isInteractiveContentEvent,
-  isSelectionClick,
 } from '@/extensions/blockInteraction.js'
 import { useInEditMode } from '@/data/globalState.js'
 import type { BlockRenderer } from '@/types.js'
@@ -43,18 +38,3 @@ export const blockEditingContentRenderer: BlockContentRendererContribution = con
     render: renderer,
   }
 }
-
-export const plainOutlinerBlockClickBehavior: BlockClickContribution = context =>
-  async (event: MouseEvent) => {
-    if (isInteractiveContentEvent(event)) return
-
-    if (isSelectionClick(event)) return
-
-    event.preventDefault()
-    event.stopPropagation()
-
-    await enterBlockEditMode(context, {
-      x: event.clientX,
-      y: event.clientY,
-    })
-  }

--- a/src/plugins/plain-outliner/test/interactions.test.ts
+++ b/src/plugins/plain-outliner/test/interactions.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { MouseEvent } from 'react'
 import type { Block } from '../../../data/block'
 import type { Repo } from '../../../data/repo'
 import type { BlockRenderer } from '@/types.js'
@@ -8,10 +7,15 @@ import {
   BlockInteractionContext,
 } from '@/extensions/blockInteraction.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
-import {
-  blockEditingContentRenderer,
-  plainOutlinerBlockClickBehavior,
-} from '../interactions.tsx'
+import type { ActionTrigger, BlockPointerDependencies } from '@/shortcuts/types.js'
+import { blockEditingContentRenderer } from '../interactions.tsx'
+import { enterBlockEditModeOnClickAction } from '../clickToEditAction.ts'
+
+const enterEditModeForBlock = vi.hoisted(() => vi.fn())
+vi.mock('@/extensions/blockInteraction.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/extensions/blockInteraction.js')>()),
+  enterEditModeForBlock,
+}))
 
 const PrimaryRenderer: BlockRenderer = () => null
 const SecondaryRenderer: BlockRenderer = () => null
@@ -90,50 +94,45 @@ describe('plain outliner interactions', () => {
     expect(variant?.render).toBe(PrimaryRenderer)
   })
 
-  it.each(interactiveTargets)('leaves %s clicks to the interactive descendant', async (_label, createTarget) => {
+})
+
+describe('plain outliner click-to-edit action', () => {
+  const deps = (): BlockPointerDependencies => ({
+    block: {id: 'block-1'} as Block,
+    uiStateBlock: {id: 'panel'} as Block,
+    targetElement: document.createElement('div'),
+    renderScopeId: 'scope-a',
+  })
+
+  const clickEvent = (target: EventTarget): ActionTrigger => ({
+    target,
+    clientX: 4,
+    clientY: 8,
+  }) as unknown as ActionTrigger
+
+  it('enters edit mode at the click position on a plain click', () => {
+    enterEditModeForBlock.mockClear()
+    const target = document.createElement('span')
+    const d = deps()
+
+    const result = enterBlockEditModeOnClickAction.handler(d, clickEvent(target))
+
+    // Not the not-handled sentinel — the pointer path will preventDefault.
+    expect(result).not.toBe(false)
+    expect(enterEditModeForBlock).toHaveBeenCalledWith(
+      d.block, d.uiStateBlock, 'scope-a', {x: 4, y: 8},
+    )
+  })
+
+  it.each(interactiveTargets)('declines %s clicks so native handling proceeds', (_label, createTarget) => {
+    enterEditModeForBlock.mockClear()
     const interactive = createTarget()
     const child = document.createElement('span')
     interactive.appendChild(child)
 
-    const event = {
-      target: child,
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: false,
-      clientX: 1,
-      clientY: 1,
-    } as unknown as MouseEvent
+    const result = enterBlockEditModeOnClickAction.handler(deps(), clickEvent(child))
 
-    const handler = plainOutlinerBlockClickBehavior(context)
-    if (!handler) throw new Error('Expected plain outliner click handler')
-
-    await handler(event)
-
-    expect(event.preventDefault).not.toHaveBeenCalled()
-    expect(event.stopPropagation).not.toHaveBeenCalled()
-  })
-
-  it('leaves selection clicks to the default selection shell owner', async () => {
-    const target = document.createElement('span')
-    const event = {
-      target,
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: true,
-      clientX: 1,
-      clientY: 1,
-    } as unknown as MouseEvent
-
-    const handler = plainOutlinerBlockClickBehavior(context)
-    if (!handler) throw new Error('Expected plain outliner click handler')
-
-    await handler(event)
-
-    expect(event.preventDefault).not.toHaveBeenCalled()
-    expect(event.stopPropagation).not.toHaveBeenCalled()
+    expect(result).toBe(false)
+    expect(enterEditModeForBlock).not.toHaveBeenCalled()
   })
 })

--- a/src/plugins/plain-outliner/test/interactions.test.ts
+++ b/src/plugins/plain-outliner/test/interactions.test.ts
@@ -20,25 +20,6 @@ vi.mock('@/extensions/blockInteraction.js', async (importOriginal) => ({
 const PrimaryRenderer: BlockRenderer = () => null
 const SecondaryRenderer: BlockRenderer = () => null
 
-const interactiveTargets: Array<[string, () => HTMLElement]> = [
-  ['anchor', () => {
-    const link = document.createElement('a')
-    link.href = 'https://example.com'
-    return link
-  }],
-  ['button', () => document.createElement('button')],
-  ['ARIA button', () => {
-    const button = document.createElement('span')
-    button.setAttribute('role', 'button')
-    return button
-  }],
-  ['controlled video', () => {
-    const video = document.createElement('video')
-    video.controls = true
-    return video
-  }],
-]
-
 const context = {
   block: {id: 'block-1'} as Block,
   repo: {} as Repo,
@@ -111,28 +92,17 @@ describe('plain outliner click-to-edit action', () => {
   }) as unknown as ActionTrigger
 
   it('enters edit mode at the click position on a plain click', () => {
+    // Interactive-target exclusion is the block-pointer context's job
+    // (pointerTargetFilter), so this action assumes a real surface click and
+    // just enters edit mode at the click position.
     enterEditModeForBlock.mockClear()
     const target = document.createElement('span')
     const d = deps()
 
-    const result = enterBlockEditModeOnClickAction.handler(d, clickEvent(target))
+    enterBlockEditModeOnClickAction.handler(d, clickEvent(target))
 
-    // Not the not-handled sentinel — the pointer path will preventDefault.
-    expect(result).not.toBe(false)
     expect(enterEditModeForBlock).toHaveBeenCalledWith(
       d.block, d.uiStateBlock, 'scope-a', {x: 4, y: 8},
     )
-  })
-
-  it.each(interactiveTargets)('declines %s clicks so native handling proceeds', (_label, createTarget) => {
-    enterEditModeForBlock.mockClear()
-    const interactive = createTarget()
-    const child = document.createElement('span')
-    interactive.appendChild(child)
-
-    const result = enterBlockEditModeOnClickAction.handler(deps(), clickEvent(child))
-
-    expect(result).toBe(false)
-    expect(enterEditModeForBlock).not.toHaveBeenCalled()
   })
 })

--- a/src/plugins/srs-rescheduling/index.ts
+++ b/src/plugins/srs-rescheduling/index.ts
@@ -483,15 +483,27 @@ const createScrubRescheduleAction = (
   }
 }
 
+const isSrsBlockTarget = ({block}: BlockShortcutDependencies): boolean => {
+  const data = block.peek()
+  return !!data && getBlockTypes(data).includes(SRS_SM25_TYPE)
+}
+
+const canPasteSrsState = ({block}: BlockShortcutDependencies): boolean => {
+  const entry = getSrsClipboard()
+  return entry !== null && entry.sourceBlockId !== block.id
+}
+
 const srsCutAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
   id: 'srs.cut',
   description: 'SRS: Cut state',
   context: ActionContextTypes.NORMAL_MODE,
   icon: Scissors,
-  isVisible: ({block}) => {
-    const data = block.peek()
-    return !!data && getBlockTypes(data).includes(SRS_SM25_TYPE)
-  },
+  // isVisible filters the menu/palette; canDispatch is the dispatch gate. The
+  // handler stashes whatever block it's given (SRS-ness lives only in these
+  // predicates), so canDispatch must mirror isVisible — otherwise an imperative
+  // dispatch (a stale swipe menu, a run event) could cut a non-SRS block.
+  isVisible: isSrsBlockTarget,
+  canDispatch: isSrsBlockTarget,
   handler: async ({block}: BlockShortcutDependencies) => {
     const data = block.peek() ?? await block.load()
     if (!data) return
@@ -507,10 +519,8 @@ const srsPasteAction: ActionConfig<typeof ActionContextTypes.NORMAL_MODE> = {
   description: 'SRS: Paste state',
   context: ActionContextTypes.NORMAL_MODE,
   icon: ClipboardPaste,
-  isVisible: ({block}) => {
-    const entry = getSrsClipboard()
-    return entry !== null && entry.sourceBlockId !== block.id
-  },
+  isVisible: canPasteSrsState,
+  canDispatch: canPasteSrsState,
   handler: async ({block}: BlockShortcutDependencies) => {
     const entry = getSrsClipboard()
     if (!entry) return

--- a/src/plugins/srs-rescheduling/test/plugin.test.ts
+++ b/src/plugins/srs-rescheduling/test/plugin.test.ts
@@ -268,6 +268,54 @@ describe('srsReschedulingPlugin', () => {
     expect(runtime.contributions(blockContentSurfacePropsFacet)).toHaveLength(1)
   })
 
+  it('gates srs.cut / srs.paste dispatch on canDispatch, not just isVisible', async () => {
+    // The swipe/quick-action path dispatches through canDispatch (the dispatch
+    // gate), so SRS-only actions whose handler trusts the block must refuse a
+    // non-SRS target there — isVisible alone (menu filtering) isn't enough.
+    let txSeq = 0
+    const repo = new Repo({
+      db: sharedDb.db,
+      cache: new BlockCache(),
+      user: {id: 'user-1'},
+      newTxSeq: () => ++txSeq,
+      startSyncObserver: false,
+    })
+    const runtime = resolveFacetRuntimeSync([
+      kernelDataExtension,
+      dailyNotesDataExtension,
+      srsReschedulingPlugin,
+    ])
+    repo.setFacetRuntime(runtime)
+
+    const snapshot = repo.snapshotTypeRegistries()
+    await repo.tx(async tx => {
+      await tx.create({id: 'srs-block', workspaceId: 'ws-1', parentId: null, orderKey: 'a0', content: 'SRS'})
+      await repo.addTypeInTx(tx, 'srs-block', SRS_SM25_TYPE, {}, snapshot)
+      await tx.create({id: 'plain-block', workspaceId: 'ws-1', parentId: null, orderKey: 'a1', content: 'Plain'})
+    }, {scope: ChangeScope.BlockDefault, description: 'seed cut/paste blocks'})
+
+    const actions = getEffectiveActions(runtime)
+    const cut = actions.find(it => it.id === 'srs.cut')!
+    const paste = actions.find(it => it.id === 'srs.paste')!
+
+    const srsBlock = repo.block('srs-block')
+    const plainBlock = repo.block('plain-block')
+    await srsBlock.load()
+    await plainBlock.load()
+
+    // cut: only an SRS block is a valid dispatch target.
+    expect(cut.canDispatch?.({block: srsBlock, uiStateBlock: srsBlock})).toBe(true)
+    expect(cut.canDispatch?.({block: plainBlock, uiStateBlock: plainBlock})).toBe(false)
+
+    // paste: only with something on the clipboard, and not onto its source.
+    clearSrsClipboard()
+    expect(paste.canDispatch?.({block: srsBlock, uiStateBlock: srsBlock})).toBe(false)
+    setSrsClipboard({sourceBlockId: 'srs-block', sourceWorkspaceId: 'ws-1'})
+    expect(paste.canDispatch?.({block: plainBlock, uiStateBlock: plainBlock})).toBe(true)
+    expect(paste.canDispatch?.({block: srsBlock, uiStateBlock: srsBlock})).toBe(false)
+    clearSrsClipboard()
+  })
+
   it('decorates the swipe-right block action to archive SRS blocks', async () => {
     let txSeq = 0
     const repo = new Repo({

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -6,6 +6,7 @@ import { useUIStateBlock } from '@/data/globalState'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { usePropertyValue } from '@/hooks/block.js'
 import { getEffectiveActions } from '@/shortcuts/effectiveActions.js'
+import { dispatchActionWithDeps } from '@/shortcuts/runAction.js'
 import type { ActionConfig, ActionIcon } from '@/shortcuts/types.js'
 import { topLevelBlockIdProp } from '@/data/properties.js'
 import {
@@ -343,23 +344,18 @@ export const SwipeActionMenu = () => {
     renderScopeId: string | undefined,
     trigger: CustomEvent,
   ): boolean => {
-    const action = allActions.find(a => a.id === actionId)
-    if (!action) return false
-
     const block = repo.block(blockId)
-    // Swipe runs actions imperatively (outside a block's React context),
-    // so scopeRootId isn't injected by useShortcutSurfaceActivations.
-    // The menu is panel-scoped and operates on the main outline, so the
-    // panel's top-level block is the scope root — the same value the
-    // structural handlers need (delete/indent/move).
+    // Swipe runs actions imperatively (outside a block's React context), so
+    // scopeRootId isn't injected by useShortcutSurfaceActivations. The menu is
+    // panel-scoped and operates on the main outline, so the panel's top-level
+    // block is the scope root — the same value the structural handlers need
+    // (delete/indent/move). The gesture supplies these deps through the unified
+    // dispatch path (resolveDeps validation + canDispatch gate + error logging)
+    // rather than looking the action up and invoking its handler directly. The
+    // returned boolean tells the gesture whether to preventDefault / fall back.
     const deps = {block, uiStateBlock, scopeRootId: topLevelBlockId, ...(renderScopeId ? {renderScopeId} : {})}
-    if (action.isVisible && !action.isVisible(deps)) return false
-
-    void Promise.resolve(action.handler(deps, trigger)).catch(error => {
-      console.error(`[swipe-quick-actions] Action "${actionId}" failed`, error)
-    })
-    return true
-  }, [allActions, repo, uiStateBlock, topLevelBlockId])
+    return dispatchActionWithDeps(actionId, deps, trigger)
+  }, [repo, uiStateBlock, topLevelBlockId])
   const actionItems = runtime.read(quickActionItemsFacet)
   // Filter via the referenced action's `isVisible` (the swipe surface is
   // presentational — semantic availability lives on the action). The

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -350,9 +350,13 @@ export const SwipeActionMenu = () => {
     // panel-scoped and operates on the main outline, so the panel's top-level
     // block is the scope root — the same value the structural handlers need
     // (delete/indent/move) — and it's a focal surface, so scopeRootForcesOpen is
-    // true. We supply scopeRootForcesOpen explicitly: resolveDeps merges supplied
-    // deps over the active context's, so omitting it could leak a *different*
-    // focused block's value into a swipe-referenced navigation action.
+    // true. renderScopeId comes from the swipe event (undefined for the normal
+    // outline, set for an embedded/backlink instance).
+    //
+    // These deps are the COMPLETE set for the swiped action: resolveDeps treats
+    // supplied deps as standalone (it does not merge the active context's deps
+    // underneath), so an omitted field resolves to undefined rather than
+    // inheriting a coincidentally-focused instance's value.
     //
     // The gesture supplies these deps through the unified dispatch path
     // (resolveDeps validation + canDispatch gate + error logging) rather than
@@ -363,7 +367,7 @@ export const SwipeActionMenu = () => {
       uiStateBlock,
       scopeRootId: topLevelBlockId,
       scopeRootForcesOpen: true,
-      ...(renderScopeId ? {renderScopeId} : {}),
+      renderScopeId,
     }
     return dispatchActionWithDeps(actionId, deps, trigger)
   }, [repo, uiStateBlock, topLevelBlockId])

--- a/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
+++ b/src/plugins/swipe-quick-actions/SwipeActionMenu.tsx
@@ -349,11 +349,22 @@ export const SwipeActionMenu = () => {
     // scopeRootId isn't injected by useShortcutSurfaceActivations. The menu is
     // panel-scoped and operates on the main outline, so the panel's top-level
     // block is the scope root — the same value the structural handlers need
-    // (delete/indent/move). The gesture supplies these deps through the unified
-    // dispatch path (resolveDeps validation + canDispatch gate + error logging)
-    // rather than looking the action up and invoking its handler directly. The
-    // returned boolean tells the gesture whether to preventDefault / fall back.
-    const deps = {block, uiStateBlock, scopeRootId: topLevelBlockId, ...(renderScopeId ? {renderScopeId} : {})}
+    // (delete/indent/move) — and it's a focal surface, so scopeRootForcesOpen is
+    // true. We supply scopeRootForcesOpen explicitly: resolveDeps merges supplied
+    // deps over the active context's, so omitting it could leak a *different*
+    // focused block's value into a swipe-referenced navigation action.
+    //
+    // The gesture supplies these deps through the unified dispatch path
+    // (resolveDeps validation + canDispatch gate + error logging) rather than
+    // invoking the handler directly. The returned boolean tells the gesture
+    // whether to preventDefault / fall back.
+    const deps = {
+      block,
+      uiStateBlock,
+      scopeRootId: topLevelBlockId,
+      scopeRootForcesOpen: true,
+      ...(renderScopeId ? {renderScopeId} : {}),
+    }
     return dispatchActionWithDeps(actionId, deps, trigger)
   }, [repo, uiStateBlock, topLevelBlockId])
   const actionItems = runtime.read(quickActionItemsFacet)
@@ -595,12 +606,12 @@ export const SwipeActionMenu = () => {
   const block = repo.block(renderedBlockId)
   if (!block.peek()) return inlineAnchor
 
-  /** Dispatch the resolved action's handler with our block-level deps.
-   *  We call the handler directly rather than going through
-   *  `useRunAction` because the dispatcher requires the action's context
-   *  to be active (e.g. NORMAL_MODE), and the swipe gesture is itself
-   *  the activation. The handler is the same one the keyboard binding
-   *  invokes, so semantics (focus restoration, etc.) stay in lockstep. */
+  /** Dispatch the resolved action with our block-level deps via
+   *  `runBlockAction` → `dispatchActionWithDeps`. That routes through the same
+   *  `resolve` + `canDispatch` + run-until-handled path the keyboard/pointer
+   *  coordinators use, with the deps SUPPLIED (the swipe gesture is itself the
+   *  activation, so the action's context needn't be keyboard-active). Semantics
+   *  stay in lockstep with the keyboard binding's handler. */
   const handleRun = (resolved: ResolvedQuickAction): void => {
     const {item, action} = resolved
     if (!action) {

--- a/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
+++ b/src/plugins/swipe-quick-actions/test/SwipeActionMenu.test.tsx
@@ -7,9 +7,12 @@ import { BlockCache } from '@/data/blockCache'
 import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
 import type { Block } from '@/data/block'
-import { actionTransformsFacet, actionsFacet } from '@/extensions/core'
-import { resolveFacetRuntimeSync, type FacetRuntime } from '@/extensions/facet'
+import { actionContextsFacet, actionTransformsFacet, actionsFacet } from '@/extensions/core'
+import { resolveFacetRuntimeSync, type AppExtension, type FacetRuntime } from '@/extensions/facet'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext'
+import { ActiveContextsProvider } from '@/shortcuts/ActiveContexts'
+import { HotkeyReconciler } from '@/shortcuts/HotkeyReconciler'
+import { defaultActionContextConfigs } from '@/shortcuts/defaultContexts'
 import { type ActionConfig, ActionContextTypes, type BlockShortcutDependencies } from '@/shortcuts/types'
 import { topLevelBlockIdProp } from '@/data/properties'
 import { quickActionItemsFacet, SWIPE_RIGHT_BLOCK_ACTION_ID } from '../actions'
@@ -71,6 +74,16 @@ const runEvent = (
     detail: renderScopeId ? {blockId, renderScopeId, actionId} : {blockId, actionId},
   })
 
+// The swipe menu dispatches actions through the unified by-id path, which is a
+// no-op until <HotkeyReconciler/> installs its dispatcher — so every runtime
+// here registers the default action contexts (for deps validation) and the
+// render mounts the coordinator inside an ActiveContextsProvider.
+const buildRuntime = (contributions: AppExtension): FacetRuntime =>
+  resolveFacetRuntimeSync([
+    ...defaultActionContextConfigs.map(c => actionContextsFacet.of(c)),
+    contributions,
+  ])
+
 describe('SwipeActionMenu', () => {
   let sharedDb: TestDb
   let h: TestDb
@@ -93,7 +106,7 @@ describe('SwipeActionMenu', () => {
       startSyncObserver: false,
     })
     repo.setActiveWorkspaceId(WS)
-    runtime = resolveFacetRuntimeSync([
+    runtime = buildRuntime([
       actionsFacet.of({
         id: 'copy_block',
         description: 'Copy block',
@@ -143,10 +156,13 @@ describe('SwipeActionMenu', () => {
   const renderMenu = () =>
     render(
       <AppRuntimeContextProvider value={runtime}>
-        <div className="panel">
-          <div data-block-id="block-1">Block</div>
-          <SwipeActionMenu/>
-        </div>
+        <ActiveContextsProvider>
+          <HotkeyReconciler/>
+          <div className="panel">
+            <div data-block-id="block-1">Block</div>
+            <SwipeActionMenu/>
+          </div>
+        </ActiveContextsProvider>
       </AppRuntimeContextProvider>,
     )
 
@@ -265,7 +281,7 @@ describe('SwipeActionMenu', () => {
       isVisible: ({block}) => block.id !== 'block-1',
       handler: vi.fn(),
     }
-    runtime = resolveFacetRuntimeSync([
+    runtime = buildRuntime([
       actionsFacet.of(alwaysAction, {source: 'test'}),
       actionsFacet.of(gatedAction, {source: 'test'}),
       quickActionItemsFacet.of({actionId: 'always', label: 'Always'}, {source: 'test'}),
@@ -286,7 +302,7 @@ describe('SwipeActionMenu', () => {
       expect(deps.block.id).toBe('block-1')
     })
     const isVisible = vi.fn((deps: BlockShortcutDependencies) => deps.block.id === 'block-1')
-    runtime = resolveFacetRuntimeSync([
+    runtime = buildRuntime([
       actionsFacet.of({
         id: 'scoped_action',
         description: 'Scoped action',
@@ -298,11 +314,14 @@ describe('SwipeActionMenu', () => {
     ])
     render(
       <AppRuntimeContextProvider value={runtime}>
-        <div className="panel">
-          <div data-block-id="block-1" data-render-scope-id="scope-a">Outline</div>
-          <div data-block-id="block-1" data-render-scope-id="scope-b">Embed</div>
-          <SwipeActionMenu/>
-        </div>
+        <ActiveContextsProvider>
+          <HotkeyReconciler/>
+          <div className="panel">
+            <div data-block-id="block-1" data-render-scope-id="scope-a">Outline</div>
+            <div data-block-id="block-1" data-render-scope-id="scope-b">Embed</div>
+            <SwipeActionMenu/>
+          </div>
+        </ActiveContextsProvider>
       </AppRuntimeContextProvider>,
     )
 
@@ -330,7 +349,7 @@ describe('SwipeActionMenu', () => {
         calls.push(`base:${block.id}:${renderScopeId ?? ''}`)
       },
     }
-    runtime = resolveFacetRuntimeSync([
+    runtime = buildRuntime([
       actionsFacet.of(baseAction, {source: 'test'}),
       actionTransformsFacet.of({
         actionId: SWIPE_RIGHT_BLOCK_ACTION_ID,

--- a/src/plugins/vim-normal-mode/index.ts
+++ b/src/plugins/vim-normal-mode/index.ts
@@ -1,21 +1,20 @@
 import {
-  blockClickHandlersFacet,
   blockContentSurfacePropsFacet,
   shortcutSurfaceActivationsFacet,
 } from '@/extensions/blockInteraction.js'
+import { actionTransformsFacet } from '@/extensions/core.js'
 import { AppExtension } from '@/extensions/facet.js'
 import { systemToggle } from '@/extensions/togglable.js'
 import { Repo } from '../../data/repo'
 import { vimNormalModeActionsExtension } from './actions.ts'
 import {
-  vimBlockClickBehavior,
+  vimClickToFocusTransform,
   vimContentSurfaceBehavior,
   vimNormalModeActivation,
 } from './interactions.ts'
 
 export const vimNormalModeInteractionExtension: AppExtension = [
-  blockClickHandlersFacet.of(vimBlockClickBehavior, {
-    precedence: 100,
+  actionTransformsFacet.of(vimClickToFocusTransform, {
     source: 'vim-normal-mode',
   }),
   blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior, {

--- a/src/plugins/vim-normal-mode/interactions.ts
+++ b/src/plugins/vim-normal-mode/interactions.ts
@@ -1,4 +1,4 @@
-import type { MouseEvent, MouseEvent as ReactMouseEvent, TouchEvent } from 'react'
+import type { MouseEvent, TouchEvent } from 'react'
 import {
   BlockContentSurfaceContribution,
   enterBlockEditMode,
@@ -9,7 +9,6 @@ import {
 import {
   ActionContextTypes,
   type ActionTransform,
-  type ActionTrigger,
   type BlockPointerDependencies,
 } from '@/shortcuts/types.js'
 import { isEditingProp, isFocusedBlock } from '@/data/properties.js'
@@ -23,17 +22,16 @@ import { Block } from '../../data/block'
  * Decorates the plain-outliner click-to-edit pointer action by replacing its
  * handler, the same Replace semantics vim used to get by winning the
  * `blockClickHandlersFacet` last-contribution race — now expressed through the
- * one transform mechanism. Declines on interactive content so links/buttons
- * fall through to native handling.
+ * one transform mechanism. Interactive descendants are excluded upstream by the
+ * `block-pointer` context's `pointerTargetFilter`, so the handler doesn't
+ * re-check them.
  */
 export const vimClickToFocusTransform: ActionTransform = {
   actionId: ENTER_BLOCK_EDIT_MODE_ACTION_ID,
   context: ActionContextTypes.BLOCK_POINTER,
   apply: action => ({
     ...action,
-    handler: (deps, trigger: ActionTrigger) => {
-      const event = trigger as ReactMouseEvent<HTMLElement>
-      if (isInteractiveContentEvent(event)) return false
+    handler: (deps) => {
       const {block, uiStateBlock, renderScopeId} = deps as BlockPointerDependencies
       void focusBlockWithoutEditing(block, uiStateBlock, renderScopeId)
     },

--- a/src/plugins/vim-normal-mode/interactions.ts
+++ b/src/plugins/vim-normal-mode/interactions.ts
@@ -25,6 +25,12 @@ import { Block } from '../../data/block'
  * one transform mechanism. Interactive descendants are excluded upstream by the
  * `block-pointer` context's `pointerTargetFilter`, so the handler doesn't
  * re-check them.
+ *
+ * Coupling note: this targets plain-outliner's action id, so single-click-focus
+ * only applies when plain-outliner is enabled (it provides the click-to-edit
+ * action this replaces). That's the normal config — vim normal mode edits the
+ * text blocks plain-outliner renders — but disabling plain-outliner while vim
+ * stays on would drop click-to-focus rather than fall back to it.
  */
 export const vimClickToFocusTransform: ActionTransform = {
   actionId: ENTER_BLOCK_EDIT_MODE_ACTION_ID,

--- a/src/plugins/vim-normal-mode/interactions.ts
+++ b/src/plugins/vim-normal-mode/interactions.ts
@@ -1,22 +1,44 @@
-import type { MouseEvent, TouchEvent } from 'react'
+import type { MouseEvent, MouseEvent as ReactMouseEvent, TouchEvent } from 'react'
 import {
-  BlockClickContribution,
   BlockContentSurfaceContribution,
   enterBlockEditMode,
-  handleBlockSelectionClick,
+  focusBlockWithoutEditing,
   isInteractiveContentEvent,
-  isSelectionClick,
   ShortcutActivationContribution,
 } from '@/extensions/blockInteraction.js'
-import { ActionContextTypes } from '@/shortcuts/types.js'
+import {
+  ActionContextTypes,
+  type ActionTransform,
+  type ActionTrigger,
+  type BlockPointerDependencies,
+} from '@/shortcuts/types.js'
 import { isEditingProp, isFocusedBlock } from '@/data/properties.js'
+import { ENTER_BLOCK_EDIT_MODE_ACTION_ID } from '@/plugins/plain-outliner/clickToEditAction.js'
 import { Block } from '../../data/block'
 
-export const vimBlockClickBehavior: BlockClickContribution = context =>
-  event => {
-    if (isSelectionClick(event)) return
-    void handleBlockSelectionClick(context, event)
-  }
+/**
+ * Vim normal mode: a single click focuses the block instead of entering edit
+ * mode (double-click / tap still edits — see `vimContentSurfaceBehavior`).
+ *
+ * Decorates the plain-outliner click-to-edit pointer action by replacing its
+ * handler, the same Replace semantics vim used to get by winning the
+ * `blockClickHandlersFacet` last-contribution race — now expressed through the
+ * one transform mechanism. Declines on interactive content so links/buttons
+ * fall through to native handling.
+ */
+export const vimClickToFocusTransform: ActionTransform = {
+  actionId: ENTER_BLOCK_EDIT_MODE_ACTION_ID,
+  context: ActionContextTypes.BLOCK_POINTER,
+  apply: action => ({
+    ...action,
+    handler: (deps, trigger: ActionTrigger) => {
+      const event = trigger as ReactMouseEvent<HTMLElement>
+      if (isInteractiveContentEvent(event)) return false
+      const {block, uiStateBlock, renderScopeId} = deps as BlockPointerDependencies
+      void focusBlockWithoutEditing(block, uiStateBlock, renderScopeId)
+    },
+  }),
+}
 
 type TouchStart = { x: number; y: number; time: number }
 

--- a/src/plugins/vim-normal-mode/test/interactions.test.ts
+++ b/src/plugins/vim-normal-mode/test/interactions.test.ts
@@ -89,30 +89,15 @@ describe('vim normal mode interactions', () => {
       targetElement: document.createElement('div'),
       renderScopeId: 'scope-a',
     }
-    const clickEvent = (target: EventTarget): ActionTrigger =>
-      ({target}) as unknown as ActionTrigger
 
     it('focuses the clicked block without entering edit mode', () => {
+      // Interactive-target exclusion is the block-pointer context's job; the
+      // transform just replaces the edit handler with focus-without-editing.
       focusBlockWithoutEditing.mockClear()
-      const result = focusHandler(deps, clickEvent(document.createElement('span')))
+      focusHandler(deps, {} as ActionTrigger)
 
-      // Handled (not the not-handled sentinel) — the edit action's handler is
-      // replaced, so it never runs; the block just focuses.
-      expect(result).not.toBe(false)
       expect(editAction.handler).not.toHaveBeenCalled()
       expect(focusBlockWithoutEditing).toHaveBeenCalledWith(deps.block, deps.uiStateBlock, 'scope-a')
-    })
-
-    it.each(interactiveTargets)('declines %s clicks so native handling proceeds', (_label, createTarget) => {
-      focusBlockWithoutEditing.mockClear()
-      const interactive = createTarget()
-      const child = document.createElement('span')
-      interactive.appendChild(child)
-
-      const result = focusHandler(deps, clickEvent(child))
-
-      expect(result).toBe(false)
-      expect(focusBlockWithoutEditing).not.toHaveBeenCalled()
     })
   })
 

--- a/src/plugins/vim-normal-mode/test/interactions.test.ts
+++ b/src/plugins/vim-normal-mode/test/interactions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { MouseEvent, TouchEvent } from 'react'
+import type { TouchEvent } from 'react'
 import type { Block } from '../../../data/block'
 import type { Repo } from '../../../data/repo'
 import {
@@ -8,12 +8,24 @@ import {
   shortcutSurfaceActivationsFacet,
 } from '@/extensions/blockInteraction.js'
 import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
-import { ActionContextTypes } from '@/shortcuts/types.js'
 import {
-  vimBlockClickBehavior,
+  ActionContextTypes,
+  type ActionConfig,
+  type ActionTrigger,
+  type BlockPointerDependencies,
+} from '@/shortcuts/types.js'
+import { ENTER_BLOCK_EDIT_MODE_ACTION_ID } from '@/plugins/plain-outliner/clickToEditAction.js'
+import {
+  vimClickToFocusTransform,
   vimContentSurfaceBehavior,
   vimNormalModeActivation,
 } from '../interactions.ts'
+
+const focusBlockWithoutEditing = vi.hoisted(() => vi.fn())
+vi.mock('@/extensions/blockInteraction.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/extensions/blockInteraction.js')>()),
+  focusBlockWithoutEditing,
+}))
 
 const interactiveTargets: Array<[string, () => HTMLElement]> = [
   ['anchor', () => {
@@ -60,44 +72,48 @@ describe('vim normal mode interactions', () => {
     expect(props.onTouchEnd).toBeDefined()
   })
 
-  it.each(interactiveTargets)('leaves %s clicks to the interactive descendant', async (_label, createTarget) => {
-    const interactive = createTarget()
-    const child = document.createElement('span')
-    interactive.appendChild(child)
+  describe('click-to-focus transform (single click focuses, does not edit)', () => {
+    const editAction: ActionConfig = {
+      id: ENTER_BLOCK_EDIT_MODE_ACTION_ID,
+      description: 'Enter edit mode on click',
+      context: ActionContextTypes.BLOCK_POINTER,
+      handler: vi.fn(),
+    }
+    const transformed = vimClickToFocusTransform.apply(editAction)
+    if (!transformed) throw new Error('expected vim transform to return a decorated action')
+    const focusHandler = transformed.handler
 
-    const event = {
-      target: child,
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-    } as unknown as MouseEvent
+    const deps: BlockPointerDependencies = {
+      block: {id: 'block-1'} as Block,
+      uiStateBlock: {id: 'panel'} as Block,
+      targetElement: document.createElement('div'),
+      renderScopeId: 'scope-a',
+    }
+    const clickEvent = (target: EventTarget): ActionTrigger =>
+      ({target}) as unknown as ActionTrigger
 
-    const handler = vimBlockClickBehavior(context)
-    if (!handler) throw new Error('Expected Vim block click handler')
+    it('focuses the clicked block without entering edit mode', () => {
+      focusBlockWithoutEditing.mockClear()
+      const result = focusHandler(deps, clickEvent(document.createElement('span')))
 
-    await handler(event)
+      // Handled (not the not-handled sentinel) — the edit action's handler is
+      // replaced, so it never runs; the block just focuses.
+      expect(result).not.toBe(false)
+      expect(editAction.handler).not.toHaveBeenCalled()
+      expect(focusBlockWithoutEditing).toHaveBeenCalledWith(deps.block, deps.uiStateBlock, 'scope-a')
+    })
 
-    expect(event.preventDefault).not.toHaveBeenCalled()
-    expect(event.stopPropagation).not.toHaveBeenCalled()
-  })
+    it.each(interactiveTargets)('declines %s clicks so native handling proceeds', (_label, createTarget) => {
+      focusBlockWithoutEditing.mockClear()
+      const interactive = createTarget()
+      const child = document.createElement('span')
+      interactive.appendChild(child)
 
-  it('leaves selection clicks to the default selection shell owner', async () => {
-    const target = document.createElement('span')
-    const event = {
-      target,
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: true,
-    } as unknown as MouseEvent
+      const result = focusHandler(deps, clickEvent(child))
 
-    const handler = vimBlockClickBehavior(context)
-    if (!handler) throw new Error('Expected Vim block click handler')
-
-    await handler(event)
-
-    expect(event.preventDefault).not.toHaveBeenCalled()
-    expect(event.stopPropagation).not.toHaveBeenCalled()
+      expect(result).toBe(false)
+      expect(focusBlockWithoutEditing).not.toHaveBeenCalled()
+    })
   })
 
   it.each(interactiveTargets)('does not turn %s taps into edit-mode taps', (_label, createTarget) => {

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -24,6 +24,7 @@ import { computeInstallableContexts, resolve, resolveDeps } from './resolve.ts'
 import {
   matchesMouseEvent,
   pointerBindingDescriptor,
+  type PointerBindingSpec,
   type PointerPhase,
 } from './canonicalizeChord.ts'
 import {
@@ -238,11 +239,21 @@ export function HotkeyReconciler(): null {
       const matched = getEffectiveActions(runtime).filter(action => {
         const spec = action.pointerBinding
         if (!spec) return false
-        const descriptor = pointerBindingDescriptor(spec)
-        if (descriptor.phase !== phase) return false
-        if (!matchesMouseEvent(descriptor, eventLike)) return false
-        if (descriptor.role && !pointerRoleMatches(supplied.targetElement, descriptor.role)) return false
-        return true
+        // Context-level pointer gate: a context can declare its gestures don't
+        // apply to this target (e.g. block-pointer excludes interactive
+        // descendants), so none of its actions become candidates here.
+        const contextFilter = contextConfigsByType.get(action.context)?.pointerTargetFilter
+        if (contextFilter && !contextFilter(event)) return false
+        // A binding may list several pointer chords (ctrl-click OR meta-click);
+        // the action matches if any of them does.
+        const specs: readonly PointerBindingSpec[] = Array.isArray(spec) ? spec : [spec]
+        return specs.some(candidate => {
+          const descriptor = pointerBindingDescriptor(candidate)
+          if (descriptor.phase !== phase) return false
+          if (!matchesMouseEvent(descriptor, eventLike)) return false
+          if (descriptor.role && !pointerRoleMatches(supplied.targetElement, descriptor.role)) return false
+          return true
+        })
       })
       if (matched.length === 0) return false
 

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -12,7 +12,7 @@ import {
   useActiveContextsState,
   ActiveContextsMap,
 } from '@/shortcuts/ActiveContexts.js'
-import { setRunActionDispatcher } from '@/shortcuts/runAction.js'
+import { setRunActionDispatcher, setActionWithDepsDispatcher } from '@/shortcuts/runAction.js'
 import { setPointerActionDispatcher } from '@/shortcuts/pointerAction.js'
 import {
   actionRuntimeKey,
@@ -189,6 +189,32 @@ export function HotkeyReconciler(): null {
       return result === false ? undefined : result
     })
     return () => setRunActionDispatcher(null)
+  }, [runtime])
+
+  // Install the supplied-deps by-id dispatcher. Same resolve + run-until-handled
+  // path as keyboard/pointer, but candidates are matched by action id and deps
+  // are SUPPLIED by the caller (the swipe gesture / quick-action menu), so the
+  // action's context need not be keyboard-active. The caller owns native
+  // default-handling (swipe preventDefaults off the boolean return), so no event
+  // options are applied here.
+  useEffect(() => {
+    setActionWithDepsDispatcher((actionId, supplied, trigger) => {
+      const active = activeRef.current
+      const contextConfigsByType = contextConfigsByTypeRef.current
+      const ordered = resolve(
+        getEffectiveActions(runtime),
+        {active, contextConfigsByType},
+        {kind: 'supplied', actionId},
+      )
+      return runOrderedCandidates(
+        ordered,
+        trigger,
+        {active, contextConfigsByType, dispatch: dispatchRef.current},
+        supplied,
+        () => undefined,
+      )
+    })
+    return () => setActionWithDepsDispatcher(null)
   }, [runtime])
 
   // Install the pointer-action dispatcher. Mirrors the keyboard coordinator's

--- a/src/shortcuts/defaultContexts.ts
+++ b/src/shortcuts/defaultContexts.ts
@@ -8,6 +8,7 @@ import {
   MultiSelectModeDependencies,
   PropertyEditingDependencies,
 } from '@/shortcuts/types.js'
+import { isInteractiveContentEvent } from '@/extensions/blockInteraction.js'
 import { Block } from '../data/block'
 import { EditorView } from '@codemirror/view'
 
@@ -76,6 +77,11 @@ export const defaultActionContextConfigs: readonly ActionContextConfig[] = [
     type: ActionContextTypes.BLOCK_POINTER,
     displayName: 'Block Pointer Gesture',
     keyboardBindable: false,
+    // Clicks landing on interactive descendants (links, buttons, …) keep their
+    // native behavior — block gestures never apply there. Declaring it once on
+    // the context means individual pointer actions (select/toggle/edit) don't
+    // each re-check, and a Shift-click on a link can't be claimed as selection.
+    pointerTargetFilter: event => !isInteractiveContentEvent(event),
     validateDependencies: isBlockPointerDependencies,
   },
 ]

--- a/src/shortcuts/resolve.test.ts
+++ b/src/shortcuts/resolve.test.ts
@@ -3,6 +3,7 @@ import {
   compareContexts,
   computeInstallableContexts,
   resolve,
+  resolveDeps,
   type ResolutionContext,
 } from './resolve.ts'
 import {
@@ -199,6 +200,41 @@ describe('resolve by supplied deps (context need not be active)', () => {
     ]
     const ordered = resolve(all, ctx, {kind: 'supplied', actionId: 'copy_block'})
     expect(ordered.map(a => a.id)).toEqual(['copy_block'])
+  })
+})
+
+describe('resolveDeps', () => {
+  const NM = ActionContextTypes.NORMAL_MODE
+  const configs = new Map([[NM, config(NM)]])
+
+  it('returns the active deps untouched when nothing is supplied', () => {
+    const activeDeps = {renderScopeId: 'scope-a'} as unknown as BaseShortcutDependencies
+    const active = new Map([[NM, activeDeps]]) as ActiveContextsMap
+    expect(resolveDeps(action('x', NM), active, configs)).toBe(activeDeps)
+  })
+
+  it('uses supplied deps standalone — does NOT inherit fields from an active context of the same type', () => {
+    // A focused embed has NORMAL_MODE active carrying its own renderScopeId. A
+    // swipe on the main outline supplies deps WITHOUT a renderScopeId. The
+    // supplied set must win wholesale: the embed's scope must not leak in, or
+    // the swiped action would focus/open as if from that unrelated instance.
+    const active = new Map([
+      [NM, {renderScopeId: 'embed-scope', scopeRootForcesOpen: false} as unknown as BaseShortcutDependencies],
+    ]) as ActiveContextsMap
+    const supplied = {block: {id: 'b'}, uiStateBlock: {id: 'p'}} as unknown as BaseShortcutDependencies
+    const resolved = resolveDeps(action('block.swipe-right', NM), active, configs, supplied)
+    expect(resolved).toBe(supplied)
+    expect(resolved && 'renderScopeId' in resolved).toBe(false)
+  })
+
+  it('returns null when supplied deps fail the context validator', () => {
+    const strict = new Map([[NM, {
+      ...config(NM),
+      validateDependencies: (d: unknown): d is BaseShortcutDependencies =>
+        typeof d === 'object' && d !== null && 'block' in d,
+    }]])
+    const active = new Map() as ActiveContextsMap
+    expect(resolveDeps(action('x', NM), active, strict, {} as BaseShortcutDependencies)).toBeNull()
   })
 })
 

--- a/src/shortcuts/resolve.test.ts
+++ b/src/shortcuts/resolve.test.ts
@@ -171,6 +171,37 @@ describe('resolve precedence', () => {
   })
 })
 
+describe('resolve by supplied deps (context need not be active)', () => {
+  it('matches by id even when the action\'s context is not active', () => {
+    // The swipe gesture holds the clicked block's deps, but that block's
+    // context (normal-mode) isn't keyboard-active. {kind:'action'} drops it
+    // for exactly that reason; {kind:'supplied'} matches on id alone and lets
+    // resolveDeps validate the supplied deps downstream.
+    const ctx = ctxOf([], [config(ActionContextTypes.NORMAL_MODE)])
+    const all = [action('block.swipe-right', ActionContextTypes.NORMAL_MODE)]
+    const byAction = resolve(all, ctx, {kind: 'action', actionId: 'block.swipe-right'})
+    const bySupplied = resolve(all, ctx, {kind: 'supplied', actionId: 'block.swipe-right'})
+    expect(byAction).toEqual([]) // inactive context → not found
+    expect(bySupplied.map(a => a.id)).toEqual(['block.swipe-right'])
+  })
+
+  it('filters to the matching id and is not suppressed by an active modal', () => {
+    // normal-mode is active but shadowed by the 'multi' modal for the keyboard.
+    // Supplied dispatch is not a keyboard-install concern, so the id still
+    // resolves (mirrors {kind:'action'}'s shadowing exemption).
+    const ctx = ctxOf(
+      [ActionContextTypes.NORMAL_MODE, 'multi'],
+      [config(ActionContextTypes.NORMAL_MODE), config('multi', {modal: true})],
+    )
+    const all = [
+      action('copy_block', ActionContextTypes.NORMAL_MODE),
+      action('delete_block', ActionContextTypes.NORMAL_MODE),
+    ]
+    const ordered = resolve(all, ctx, {kind: 'supplied', actionId: 'copy_block'})
+    expect(ordered.map(a => a.id)).toEqual(['copy_block'])
+  })
+})
+
 describe('compareContexts', () => {
   it('is a stable comparator (antisymmetric on tier)', () => {
     const ctx = ctxOf(

--- a/src/shortcuts/resolve.ts
+++ b/src/shortcuts/resolve.ts
@@ -186,12 +186,26 @@ export const resolve = (
  * active context.
  *
  * `supplied` lets callers hand in deps the active map doesn't hold — a pointer
- * gesture supplying the CLICKED block's deps (its context isn't active), or
- * swipe's `runBlockAction` passing `{block, uiStateBlock}` instead of forking
- * the dispatcher. When deps are supplied the context need not be active: the
- * merged deps are validated at this one boundary and used on their own if there
- * is no active base. Validation runs only when deps are supplied — active-map
- * deps were already validated at activation, so re-validating is redundant.
+ * gesture supplying the CLICKED block's deps, or swipe's `runBlockAction`
+ * supplying the swiped block's deps. When deps are supplied they STAND ALONE:
+ * the gesture itself is the activation, so the supplied object is the complete
+ * dependency set and the active context's deps are NOT merged underneath.
+ *
+ * Standalone (rather than `{...base, ...supplied}`) is deliberate and the safer
+ * contract. A merge lets any field a caller OMITS silently inherit an unrelated
+ * active instance's value — e.g. a focused embed's `renderScopeId` /
+ * `scopeRootForcesOpen` leaking into a swipe action and making it focus/open as
+ * if from that embed. No call site can defend against that without exhaustively
+ * restating every field on every dispatch; making supplied deps standalone
+ * retires the whole class at the boundary instead. This is a behaviour change
+ * only when `action.context` is coincidentally active (the leak case): pointer
+ * contexts are never activated, and swipe already supplies a complete set, so
+ * both keep resolving the same deps they did before.
+ *
+ * Validation runs only when deps are supplied — active-map deps were already
+ * validated at activation, so re-validating is redundant. A supplied set that's
+ * incomplete now fails validation (→ null → skip) rather than borrowing missing
+ * fields from an unrelated active instance, which is the more correct failure.
  */
 export const resolveDeps = (
   action: ActionConfig,
@@ -199,10 +213,8 @@ export const resolveDeps = (
   contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>,
   supplied?: Partial<BaseShortcutDependencies>,
 ): BaseShortcutDependencies | null => {
-  const base = active.get(action.context)
-  if (!supplied) return base ?? null
-  const merged = (base ? {...base, ...supplied} : supplied) as BaseShortcutDependencies
+  if (!supplied) return active.get(action.context) ?? null
   const config = contextConfigsByType.get(action.context)
-  if (config && !config.validateDependencies(merged)) return null
-  return merged
+  if (config && !config.validateDependencies(supplied)) return null
+  return supplied as BaseShortcutDependencies
 }

--- a/src/shortcuts/resolve.ts
+++ b/src/shortcuts/resolve.ts
@@ -28,15 +28,19 @@ import type { ActiveContextsMap } from './ActiveContexts.tsx'
  * What's being resolved. The kind selects the install-filter policy:
  *  - `'action'` — imperative lookup by id (runActionById / useRunAction).
  *    Modal shadowing is NOT applied; an action is found in any active context.
+ *    The context MUST be active (deps come from the active map).
+ *  - `'supplied'` — imperative lookup by id where the CALLER supplies the deps
+ *    (swipe gesture / quick-action menu). Like `'action'` but the context need
+ *    NOT be active — the supplied deps are the activation, validated in
+ *    `resolveDeps`. Modal shadowing is not applied.
  *  - `'keyboard'` — the coordinator's already-matched candidate set for a
  *    chord. Modal shadowing IS applied (the keyboard gather filter).
- * Phase 3 will extend the keyboard arm with a normalized pointer/touch
- * descriptor when a caller actually constructs one (see `ChordDescriptor`,
- * whose `kind` field stays open for that); resolve doesn't need the chord
- * itself, only the policy + the candidate set.
+ *  - `'pointer'` — pointer-bound candidates already matched on their binding
+ *    descriptor and dispatched with supplied deps (see the filter note below).
  */
 export type Trigger =
   | { kind: 'action'; actionId: string }
+  | { kind: 'supplied'; actionId: string }
   | { kind: 'keyboard' }
   | { kind: 'pointer' }
 
@@ -141,6 +145,13 @@ export const resolve = (
       case 'action':
         // Imperative lookup: any active context, matching id.
         return ctx.active.has(action.context) && action.id === trigger.actionId
+      case 'supplied':
+        // Imperative by-id dispatch with caller-supplied deps. The context
+        // need NOT be active — the caller (swipe gesture, quick-action menu)
+        // holds the deps and the gesture itself is the activation. resolveDeps
+        // validates the supplied deps at the dispatch boundary. Modal shadowing
+        // is a keyboard-install concern and does not apply here.
+        return action.id === trigger.actionId
       case 'keyboard':
         // Already-matched chord candidates, gated by modal shadowing.
         return ctx.active.has(action.context) && installable!.has(action.context)

--- a/src/shortcuts/runAction.ts
+++ b/src/shortcuts/runAction.ts
@@ -34,6 +34,14 @@ export function setRunActionDispatcher(next: RunActionByIdFn | null): void {
  * evaluated code in useAgentRuntimeBridge or one-off imperative callsites).
  *
  * Throws if called before the app mounts <HotkeyReconciler/>.
+ *
+ * NOTE: unlike the keyboard / pointer / supplied-deps dispatch paths, this does
+ * NOT consult `canDispatch` — it resolves the active action by id and invokes
+ * the handler. Callers own the precondition: an action whose handler trusts its
+ * deps (e.g. an SRS-only action) must either be unreachable here when
+ * inapplicable (the command palette filters by `isVisible`) or guard inside its
+ * handler. `dispatchActionWithDeps` below DOES gate on `canDispatch`. Unifying
+ * these gates is tracked with the broader dispatch-lifecycle work.
  */
 export const runActionById: RunActionByIdFn = (actionId, trigger) => {
   if (!dispatcher) {

--- a/src/shortcuts/runAction.ts
+++ b/src/shortcuts/runAction.ts
@@ -9,6 +9,7 @@ import {
   ActionTrigger,
   type ActionContextConfig,
   type ActionContextType,
+  type BaseShortcutDependencies,
 } from '@/shortcuts/types.js'
 import { getActiveActionById, getEffectiveActions } from './effectiveActions.ts'
 import { resolveDeps } from './resolve.ts'
@@ -42,6 +43,38 @@ export const runActionById: RunActionByIdFn = (actionId, trigger) => {
   }
   return dispatcher(actionId, trigger)
 }
+
+export type DispatchActionWithDepsFn = (
+  actionId: string,
+  deps: Partial<BaseShortcutDependencies>,
+  trigger: ActionTrigger,
+) => boolean
+
+let withDepsDispatcher: DispatchActionWithDepsFn | null = null
+
+/**
+ * Installed by <HotkeyReconciler/> on mount; torn down on unmount so stray
+ * callers fail soft (no dispatch) rather than against a stale runtime.
+ */
+export function setActionWithDepsDispatcher(next: DispatchActionWithDepsFn | null): void {
+  withDepsDispatcher = next
+}
+
+/**
+ * Run a known action by id with caller-SUPPLIED deps, through the same
+ * `resolve` + run-until-handled path the keyboard and pointer coordinators
+ * use. Unlike `runActionById`, the action's context need NOT be keyboard-active
+ * — the caller (the swipe gesture, a quick-action menu button) holds the deps,
+ * and the gesture is itself the activation. The supplied deps are validated at
+ * the dispatch boundary (`resolveDeps`); a declining `canDispatch` or a synchronous
+ * `false` return falls through like any other candidate.
+ *
+ * Returns true when a candidate handled (or threw), false when none matched or
+ * every candidate declined — so the caller can fall back to a default. No-op
+ * returning false before the coordinator mounts.
+ */
+export const dispatchActionWithDeps: DispatchActionWithDepsFn = (actionId, deps, trigger) =>
+  withDepsDispatcher ? withDepsDispatcher(actionId, deps, trigger) : false
 
 /**
  * Hook variant for React callers. Re-computes on runtime/activeContexts changes

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -63,10 +63,22 @@ const blockPointerContextConfig: ActionContextConfig = {
     typeof deps === 'object' && deps !== null,
 }
 
+const FILTERED_POINTER_CONTEXT = 'filtered-pointer' as ActionContextType
+const filteredPointerContextConfig: ActionContextConfig = {
+  type: FILTERED_POINTER_CONTEXT,
+  displayName: 'Filtered Pointer',
+  // Reject events whose target is an anchor — stands in for block-pointer's
+  // "exclude interactive descendants" pointerTargetFilter.
+  pointerTargetFilter: event => (event.target as HTMLElement | null)?.tagName !== 'A',
+  validateDependencies: (deps): deps is BaseShortcutDependencies =>
+    typeof deps === 'object' && deps !== null,
+}
+
 const pointerEvent = (
   overrides: Partial<{
     type: string; button: number; detail: number
     shiftKey: boolean; altKey: boolean; ctrlKey: boolean; metaKey: boolean
+    target: EventTarget
   }> = {},
 ): ReactMouseEvent<HTMLElement> => ({
   type: 'click',
@@ -738,6 +750,65 @@ describe('HotkeyReconciler', () => {
 
       expect(handled).toBe(false)
       expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('does not dispatch when the context pointerTargetFilter rejects the target', () => {
+      const handler = vi.fn()
+      const action = {
+        id: 'pointer.filtered',
+        description: 'filtered pointer action',
+        context: FILTERED_POINTER_CONTEXT,
+        pointerBinding: {kind: 'mouse', mods: ['Shift'], phase: 'click'},
+        handler,
+      } as ActionConfig
+
+      render(<Harness actions={[action]} contexts={[filteredPointerContextConfig]}/>)
+
+      // Target is an anchor → the context filter rejects it → no candidate.
+      let handled = true
+      act(() => {
+        handled = dispatchPointerAction(
+          pointerEvent({shiftKey: true, target: document.createElement('a')}),
+          {marker: 'x'} as never,
+        )
+      })
+      expect(handled).toBe(false)
+      expect(handler).not.toHaveBeenCalled()
+
+      // A non-anchor target passes the filter.
+      act(() => {
+        dispatchPointerAction(
+          pointerEvent({shiftKey: true, target: document.createElement('span')}),
+          {marker: 'x'} as never,
+        )
+      })
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('matches when any of several pointer bindings matches (ctrl-OR-meta style)', () => {
+      const handler = vi.fn()
+      const action = {
+        id: 'pointer.multi',
+        description: 'multi-binding pointer action',
+        context: BLOCK_POINTER_CONTEXT,
+        pointerBinding: [
+          {kind: 'mouse', mods: ['Shift'], phase: 'click'},
+          {kind: 'mouse', mods: ['Alt'], phase: 'click'},
+        ],
+        handler,
+      } as ActionConfig
+
+      render(<Harness actions={[action]} contexts={[blockPointerContextConfig]}/>)
+
+      act(() => { dispatchPointerAction(pointerEvent({shiftKey: true}), {marker: 'x'} as never) })
+      act(() => { dispatchPointerAction(pointerEvent({altKey: true}), {marker: 'x'} as never) })
+      expect(handler).toHaveBeenCalledTimes(2)
+
+      // A plain click matches neither binding.
+      let handled = true
+      act(() => { handled = dispatchPointerAction(pointerEvent({}), {marker: 'x'} as never) })
+      expect(handled).toBe(false)
+      expect(handler).toHaveBeenCalledTimes(2)
     })
 
     it('falls through to the next pointer candidate when the first declines', () => {

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -3,6 +3,7 @@ import { act, render, cleanup } from '@testing-library/react'
 import type { MouseEvent as ReactMouseEvent } from 'react'
 import { HotkeyReconciler } from '@/shortcuts/HotkeyReconciler.js'
 import { dispatchPointerAction } from '@/shortcuts/pointerAction.js'
+import { dispatchActionWithDeps } from '@/shortcuts/runAction.js'
 import {
   ActiveContextsProvider,
   useActiveContextsState,
@@ -753,6 +754,60 @@ describe('HotkeyReconciler', () => {
 
       expect(declined).toHaveBeenCalledTimes(1)
       expect(fallback).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('supplied-deps action dispatch', () => {
+    const byIdAction = (
+      overrides: Partial<ActionConfig> & Pick<ActionConfig, 'id' | 'handler'>,
+    ): ActionConfig => ({
+      description: 'test supplied action',
+      context: TEST_CONTEXT,
+      ...overrides,
+    } as ActionConfig)
+
+    it('runs an action by id with supplied deps when its context is not active', () => {
+      const handler = vi.fn()
+      const action = byIdAction({id: 'block.swipe-right', handler})
+
+      // TEST_CONTEXT is never activated (no Activator) — the deps are supplied.
+      render(<Harness actions={[action]} contexts={[testContextConfig]}/>)
+
+      const supplied = {marker: 'swiped'} as unknown as BaseShortcutDependencies
+      let handled = false
+      act(() => {
+        handled = dispatchActionWithDeps('block.swipe-right', supplied, new CustomEvent('swipe'))
+      })
+
+      expect(handled).toBe(true)
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler.mock.calls[0]?.[0]).toBe(supplied)
+    })
+
+    it('returns false when no action matches the id', () => {
+      render(<Harness actions={[]} contexts={[testContextConfig]}/>)
+
+      let handled = true
+      act(() => {
+        handled = dispatchActionWithDeps('nope', {marker: 'x'} as never, new CustomEvent('swipe'))
+      })
+
+      expect(handled).toBe(false)
+    })
+
+    it('falls through (not handled) when canDispatch declines', () => {
+      const handler = vi.fn()
+      const action = byIdAction({id: 'gated', handler, canDispatch: () => false})
+
+      render(<Harness actions={[action]} contexts={[testContextConfig]}/>)
+
+      let handled = true
+      act(() => {
+        handled = dispatchActionWithDeps('gated', {marker: 'x'} as never, new CustomEvent('swipe'))
+      })
+
+      expect(handled).toBe(false)
+      expect(handler).not.toHaveBeenCalled()
     })
   })
 

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -69,6 +69,16 @@ export interface ActionContextConfig<T extends ActionContextType = ActionContext
    */
   keyboardBindable?: boolean;
   /**
+   * Optional gate for POINTER dispatch: when present and it returns false for a
+   * pointer event, none of this context's actions are considered candidates for
+   * that event. Lets a context declare "my gestures don't apply here" once,
+   * centrally, instead of every action/handler re-checking — e.g. `block-pointer`
+   * excludes clicks landing on interactive descendants (links, buttons) so they
+   * keep their native behavior. Keys off the actual event target. Only consulted
+   * on the pointer path; ignored for keyboard.
+   */
+  pointerTargetFilter?: (event: ReactMouseEvent<HTMLElement>) => boolean;
+  /**
    * Type guard function to validate the dependencies provided when activating the context.
    */
   validateDependencies: DependencyValidator<T>;
@@ -231,8 +241,10 @@ export interface Action<T extends ActionContextType = ActionContextType> {
   defaultBinding?: ShortcutBindingDefaults; // Optional default keyboard binding
   /** Optional pointer (mouse) binding — dispatched through the same coordinator
    *  + `resolve` path as keyboard, but matched against a pointer event and
-   *  supplied the clicked block's deps. See {@link PointerBindingSpec}. */
-  pointerBinding?: PointerBindingSpec;
+   *  supplied the clicked block's deps. A list binds the action to several
+   *  pointer chords (e.g. ctrl-click OR meta-click both toggle selection), since
+   *  modifier matching is exact-set. See {@link PointerBindingSpec}. */
+  pointerBinding?: PointerBindingSpec | readonly PointerBindingSpec[];
   /** Optional icon for surfaces that render actions visually (toolbars,
    *  swipe menus, eventual command-palette icon column). Surfaces that
    *  don't render icons just ignore the field. */


### PR DESCRIPTION
Follow-up to #123 — the deferred Phase 3 items that are genuinely *action-dispatch* unification (as opposed to render-composition). Two clean collapses, each TDD, each `yarn run check`-green.

## 1. Swipe `runBlockAction` fork → unified dispatch (`466cec6`)

Swipe looked actions up by id, built deps, applied its own `isVisible` gate, and called the handler directly — a parallel dispatch path the action-system unification meant to retire.

- New `{kind:'supplied'}` arm in `resolve` + a `dispatchActionWithDeps` imperative entry point: match by id, run through the **same** `resolve` + run-until-handled loop the keyboard/pointer coordinators use, with caller-supplied deps. Unlike `runActionById`, the action's context need not be keyboard-active — the gesture *is* the activation, and the supplied deps are validated at the `resolveDeps` boundary.
- Swipe now gates on `canDispatch` (the dispatch gate) rather than `isVisible` (the presentational gate the menu already applies at render time).

## 2. Click-to-edit → pointer-bound action (`677774b`)

`blockClickHandlersFacet` was the one genuine "silent Replace" footgun: vim's click-to-focus won over plain-outliner's click-to-edit via highest-precedence-last-wins.

- plain-outliner registers `block.enter-edit-mode`, a pointer-bound action (plain click, exact-modifier match) in the `block-pointer` context. It **declines** on interactive content so links/buttons fall through to native handling — the "this isn't my gesture" contract from the plan.
- vim decorates that action with an `ActionTransform` replacing the handler to focus-without-editing — the same Replace semantics, now through the one transform mechanism rather than facet precedence.
- the block shell routes plain clicks through the pointer dispatch alongside selection gestures.

Exact-modifier matching means each gesture maps to exactly one action: plain click → edit/focus, shift-click → extend selection, ctrl/meta → structural selection fallback.

## Scope notes

The other two items listed under Phase 3 were deliberately **left out** — they're not action-dispatch and the repo's own docs say so:

- **`blockContentSurfacePropsFacet` / `blockContentDecoratorsFacet`** — render-composition facets. `docs/renderer-resolution.md` explicitly states these "already cleanly stack and aren't part of the dispatch problem… this redesign keeps them untouched," and `docs/type-system.md` relies on their current shape.
- **`blockGestureConflictsFacet`** — touch-gesture *arbitration*, not dispatch. Migrating it would mean a touch descriptor kind + non-passive listener infra + gesture-arbitration-via-resolve — a real redesign, out of scope for a clean collapse. (Relatedly, see #124 for the pointer/context-lifecycle integration.)

## Verification

`yarn run check` — 281 files, 3049 tests pass, 0 lint errors.

New/updated tests: `resolve.test.ts` (`{kind:'supplied'}` arm), `HotkeyReconciler.test.tsx` (`dispatchActionWithDeps`), `SwipeActionMenu.test.tsx` (now mounts the coordinator so the unified path is exercised end-to-end), `plain-outliner`/`vim` interaction tests (edit action + focus transform, incl. the interactive-content decline), `defaultEditorInteractions.test.ts` (plain-click pointer routing + fallback).

https://claude.ai/code/session_019rpY1TcxUbQd7fZeRax2SA

---
_Generated by [Claude Code](https://claude.ai/code/session_019rpY1TcxUbQd7fZeRax2SA)_