### PR TITLE
feat(input): migrate double-click and tap edit onto pointer actions

### DIFF
--- a/src/extensions/blockInteraction.ts
+++ b/src/extensions/blockInteraction.ts
@@ -25,7 +25,8 @@ import {
   type VariantContribution,
   type VariantResolver,
 } from '@/extensions/variantFacet.js'
-import type { ActionContextActivation } from '@/shortcuts/types.js'
+import type { ActionContextActivation, BlockPointerDependencies } from '@/shortcuts/types.js'
+import type { PointerGestureEvent } from '@/shortcuts/pointerAction.js'
 import type { BlockContextType, BlockRenderer } from '@/types.js'
 
 export interface BlockContentRendererSlot {
@@ -512,3 +513,30 @@ export const focusBlockWithoutEditing = async (
 
 export const isSelectionClick = (event: MouseEvent) =>
   event.ctrlKey || event.metaKey || event.shiftKey
+
+/**
+ * Build the deps a pointer-dispatched block gesture needs from a block's
+ * resolve context plus the live event — the clicked/tapped block, the surface
+ * boundary, and the DOM node the event targeted. `currentTarget` is read
+ * synchronously here (the caller is still inside the React handler) because
+ * React nulls it once the handler returns, and pointer actions (the spatial
+ * selection walker) need the bound element to locate the gesture among visible
+ * blocks. Shared by the block shell's click path and the content surface's
+ * double-click/tap path so the supplied-deps shape stays in one place.
+ */
+export const blockPointerDepsFrom = (
+  context: BlockResolveContext,
+  event: PointerGestureEvent,
+): BlockPointerDependencies => {
+  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
+    ? context.blockContext.renderScopeId
+    : undefined
+  return {
+    block: context.block,
+    uiStateBlock: context.uiStateBlock,
+    scopeRootId: context.scopeRootId,
+    scopeRootForcesOpen: !context.blockContext?.isNestedSurface,
+    targetElement: event.currentTarget,
+    ...(renderScopeId ? {renderScopeId} : {}),
+  }
+}

--- a/src/extensions/defaultEditorInteractions.ts
+++ b/src/extensions/defaultEditorInteractions.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { MouseEvent } from 'react'
 import {
+  blockPointerDepsFrom,
   blockShellDecoratorsFacet,
   isInteractiveContentEvent,
   isSelectionClick,
@@ -14,7 +15,7 @@ import {
 import { editorAutocompleteExtension } from '@/extensions/editorAutocomplete.js'
 import { AppExtension } from '@/extensions/facet.js'
 import { actionsFacet } from '@/extensions/core.js'
-import { ActionContextTypes, type BlockPointerDependencies } from '@/shortcuts/types.js'
+import { ActionContextTypes } from '@/shortcuts/types.js'
 import { dispatchPointerAction } from '@/shortcuts/pointerAction.js'
 import {
   extendBlockSelectionAction,
@@ -42,28 +43,6 @@ export const codeMirrorEditModeActivation: ShortcutActivationContribution = cont
 const isBlockSelectionGesture = (event: MouseEvent<HTMLElement>): boolean =>
   isSelectionClick(event) && !isInteractiveContentEvent(event)
 
-/**
- * Build the deps a pointer-dispatched block gesture needs from a block's
- * resolve context plus the live event. `currentTarget` — the block shell the
- * spatial walker tags — is captured synchronously before React nulls it.
- */
-const suppliedPointerDeps = (
-  resolveContext: BlockResolveContext,
-  event: MouseEvent<HTMLElement>,
-): BlockPointerDependencies => {
-  const renderScopeId = typeof resolveContext.blockContext?.renderScopeId === 'string'
-    ? resolveContext.blockContext.renderScopeId
-    : undefined
-  return {
-    block: resolveContext.block,
-    uiStateBlock: resolveContext.uiStateBlock,
-    scopeRootId: resolveContext.scopeRootId,
-    scopeRootForcesOpen: !resolveContext.blockContext?.isNestedSurface,
-    targetElement: event.currentTarget,
-    ...(renderScopeId ? {renderScopeId} : {}),
-  }
-}
-
 export const createBlockSelectionShellState = (
   resolveContext: BlockResolveContext,
   state: BlockShellState,
@@ -86,7 +65,7 @@ export const createBlockSelectionShellState = (
       // block-pointer context's pointerTargetFilter keeps interactive descendants
       // native (no candidate matches). Fall back to any residual facet click
       // handler only when nothing claims the gesture.
-      if (!dispatchPointerAction(event, suppliedPointerDeps(resolveContext, event))) {
+      if (!dispatchPointerAction(event, blockPointerDepsFrom(resolveContext, event))) {
         state.shellProps.onClick?.(event)
       }
     },

--- a/src/extensions/defaultEditorInteractions.ts
+++ b/src/extensions/defaultEditorInteractions.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react'
-import type { MouseEvent } from 'react'
+import type { MouseEvent, TouchEvent } from 'react'
 import {
+  blockContentSurfacePropsFacet,
   blockPointerDepsFrom,
   blockShellDecoratorsFacet,
   isInteractiveContentEvent,
   isSelectionClick,
+  type BlockContentSurfaceContribution,
   type BlockResolveContext,
   type BlockShellDecoratorContribution,
   type BlockShellDecoratorProps,
@@ -16,7 +18,7 @@ import { editorAutocompleteExtension } from '@/extensions/editorAutocomplete.js'
 import { AppExtension } from '@/extensions/facet.js'
 import { actionsFacet } from '@/extensions/core.js'
 import { ActionContextTypes } from '@/shortcuts/types.js'
-import { dispatchPointerAction } from '@/shortcuts/pointerAction.js'
+import { dispatchPointerAction, type PointerGestureEvent } from '@/shortcuts/pointerAction.js'
 import {
   extendBlockSelectionAction,
   toggleBlockSelectionAction,
@@ -89,6 +91,78 @@ export function BlockSelectionShellDecorator({
 export const blockSelectionShellDecorator: BlockShellDecoratorContribution = () =>
   BlockSelectionShellDecorator
 
+type ContentTouchStart = { x: number; y: number; time: number }
+
+// Per-block touch origin, kept between touchstart and touchend so a tap can be
+// told apart from a drag/scroll. Module-level because the surface contribution
+// is re-derived per render; keyed by block id, cleared on every touchend.
+const contentTouchStarts = new Map<string, ContentTouchStart>()
+
+const TAP_MOVE_PX = 10
+const TAP_MAX_MS = 300
+
+const isTap = (start: ContentTouchStart, end: ContentTouchStart): boolean =>
+  Math.abs(end.x - start.x) <= TAP_MOVE_PX &&
+  Math.abs(end.y - start.y) <= TAP_MOVE_PX &&
+  (end.time - start.time) <= TAP_MAX_MS
+
+/**
+ * Core pointer-gesture recognition on a block's CONTENT surface: routes a
+ * pointerdown-phase mouse gesture and a touch tap through the same pointer
+ * dispatch the shell uses for clicks, with the block's deps supplied. The
+ * surface only RECOGNISES and routes; what a gesture DOES is a bound
+ * `block-pointer` action (e.g. vim's double-click/tap-to-edit), so an unbound
+ * gesture is a no-op.
+ *
+ * Lives on the content surface, not the shell, so it never fires for the
+ * bullet, controls, or properties chrome — only the block's own content — and
+ * the context's `pointerTargetFilter` keeps it off interactive descendants and
+ * the CodeMirror editor while editing (where a double-click should select a
+ * word natively).
+ *
+ * Each branch recognises a discrete gesture, then routes it. A multi-click
+ * (`detail >= 2`) is the mouse gesture worth routing at the pointerdown phase —
+ * the action's binding picks the exact count (`detail: 2` for double-click),
+ * and binding at pointerdown (not `click`) lets the dispatch's preventDefault
+ * beat native word-selection. A single press isn't a gesture, so it's left for
+ * the shell's click. Touch has no single "tap" event, so the tap is recognised
+ * here (movement/duration thresholds) before routing.
+ */
+export const blockContentPointerGestures: BlockContentSurfaceContribution = context => {
+  const dispatchGesture = (event: PointerGestureEvent): void => {
+    dispatchPointerAction(event, blockPointerDepsFrom(context, event))
+  }
+
+  return {
+    onMouseDownCapture: (event: MouseEvent<HTMLDivElement>) => {
+      // A shell-level selection gesture already preventDefaulted (capture runs
+      // shell → content), so skip it here rather than double-routing.
+      if (event.defaultPrevented) return
+      // Only multi-clicks are pointerdown gestures; a single press is the
+      // shell's click to resolve, not a gesture to route.
+      if (event.detail < 2) return
+      dispatchGesture(event)
+    },
+    onTouchStart: (event: TouchEvent<HTMLDivElement>) => {
+      const touch = event.touches[0]
+      if (!touch) return
+      contentTouchStarts.set(context.block.id, {
+        x: touch.clientX,
+        y: touch.clientY,
+        time: Date.now(),
+      })
+    },
+    onTouchEnd: (event: TouchEvent<HTMLDivElement>) => {
+      const start = contentTouchStarts.get(context.block.id)
+      contentTouchStarts.delete(context.block.id)
+      const touch = event.changedTouches[0]
+      if (!start || !touch) return
+      if (!isTap(start, {x: touch.clientX, y: touch.clientY, time: Date.now()})) return
+      dispatchGesture(event)
+    },
+  }
+}
+
 export const defaultEditorInteractionExtension: AppExtension = systemToggle({
   id: 'system:default-editor-interactions',
   name: 'Default editor interactions',
@@ -99,6 +173,11 @@ export const defaultEditorInteractionExtension: AppExtension = systemToggle({
   blockShellDecoratorsFacet.of(blockFocusShellDecorator, {
     precedence: 1000,
     source: 'default-block-focus',
+  }),
+  // Content-surface pointer gestures the shell click can't see — pointerdown
+  // (double-click) and touch tap — dispatched through the same pointer path.
+  blockContentSurfacePropsFacet.of(blockContentPointerGestures, {
+    source: 'default-content-gestures',
   }),
   shortcutSurfaceActivationsFacet.of(codeMirrorEditModeActivation, {
     source: 'codemirror-edit-mode',

--- a/src/extensions/test/defaultEditorInteractions.test.ts
+++ b/src/extensions/test/defaultEditorInteractions.test.ts
@@ -1,12 +1,15 @@
-import type { MouseEvent, RefObject } from 'react'
+import type { MouseEvent, RefObject, TouchEvent } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Block } from '@/data/block'
 import type { Repo } from '@/data/repo'
 import type {
+  BlockContentSurfaceProps,
   BlockInteractionContext,
+  BlockResolveContext,
   BlockShellState,
 } from '@/extensions/blockInteraction'
 import {
+  blockContentPointerGestures,
   createBlockSelectionShellState,
 } from '@/extensions/defaultEditorInteractions'
 import { dispatchPointerAction } from '@/shortcuts/pointerAction'
@@ -178,5 +181,74 @@ describe('default editor interactions', () => {
 
     expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
     expect(pluginClick).toHaveBeenCalledWith(event)
+  })
+})
+
+describe('blockContentPointerGestures (content-surface pointer gestures)', () => {
+  beforeEach(() => {
+    mockDispatchPointerAction.mockClear()
+    mockDispatchPointerAction.mockReturnValue(true)
+  })
+
+  const mouseDown = (overrides: Partial<MouseEvent<HTMLDivElement>> = {}): MouseEvent<HTMLDivElement> => ({
+    type: 'mousedown',
+    detail: 2,
+    defaultPrevented: false,
+    currentTarget: document.createElement('div'),
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...overrides,
+  }) as unknown as MouseEvent<HTMLDivElement>
+
+  const touchAt = (x: number, y: number): TouchEvent<HTMLDivElement> => ({
+    currentTarget: document.createElement('div'),
+    touches: [{clientX: x, clientY: y}],
+    changedTouches: [{clientX: x, clientY: y}],
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }) as unknown as TouchEvent<HTMLDivElement>
+
+  const props = () =>
+    blockContentPointerGestures(context as BlockResolveContext) as BlockContentSurfaceProps
+
+  it('routes a content mousedown through the pointer dispatcher with the block supplied', () => {
+    const event = mouseDown({detail: 2})
+    props().onMouseDownCapture?.(event)
+
+    expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
+    const [dispatchedEvent, supplied] = mockDispatchPointerAction.mock.calls[0]!
+    expect(dispatchedEvent).toBe(event)
+    expect(supplied).toMatchObject({
+      block: context.block,
+      uiStateBlock: context.uiStateBlock,
+      targetElement: event.currentTarget,
+    })
+  })
+
+  it('skips a mousedown a shell selection gesture already preventDefaulted', () => {
+    props().onMouseDownCapture?.(mouseDown({defaultPrevented: true}))
+    expect(mockDispatchPointerAction).not.toHaveBeenCalled()
+  })
+
+  it('ignores a single press (only a multi-click is a pointerdown gesture)', () => {
+    props().onMouseDownCapture?.(mouseDown({detail: 1}))
+    expect(mockDispatchPointerAction).not.toHaveBeenCalled()
+  })
+
+  it('routes a tap when touchstart→touchend stays within the tap thresholds', () => {
+    const surface = props()
+    surface.onTouchStart?.(touchAt(5, 5))
+    const end = touchAt(6, 6)
+    surface.onTouchEnd?.(end)
+
+    expect(mockDispatchPointerAction).toHaveBeenCalledTimes(1)
+    expect(mockDispatchPointerAction.mock.calls[0]![0]).toBe(end)
+  })
+
+  it('ignores a touch that moves beyond the tap threshold (a drag, not a tap)', () => {
+    const surface = props()
+    surface.onTouchStart?.(touchAt(5, 5))
+    surface.onTouchEnd?.(touchAt(80, 80))
+    expect(mockDispatchPointerAction).not.toHaveBeenCalled()
   })
 })

--- a/src/plugins/grouped-backlinks/GroupHeaderActionButton.tsx
+++ b/src/plugins/grouped-backlinks/GroupHeaderActionButton.tsx
@@ -3,6 +3,7 @@ import type { Block } from '@/data/block'
 import { Button } from '@/components/ui/button.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { useUIStateBlock } from '@/data/globalState.js'
+import { dispatchActionWithDeps } from '@/shortcuts/runAction.js'
 import { getEffectiveActions } from '@/shortcuts/effectiveActions.js'
 import {
   ActionContextTypes,
@@ -75,9 +76,13 @@ export const GroupHeaderActionButton = ({
     const trigger = new CustomEvent(`group-header:${actionId}`, {
       detail: triggerDetail,
     })
-    void Promise.resolve(action.handler(deps, trigger)).catch(error => {
-      console.error(`[group-header] Action ${actionId} failed`, error)
-    })
+    // Route through the supplied-deps dispatch (resolveDeps validation +
+    // canDispatch gate + error logging) rather than invoking the handler
+    // directly. The button only renders once `isVisible` passed and the
+    // synthesized MULTI_SELECT_MODE deps validate, so the action resolves; the
+    // returned boolean is unused — an unclaimed click is a no-op, there's no
+    // fallback to fall through to.
+    dispatchActionWithDeps(actionId, deps, trigger)
   }
 
   return (

--- a/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
+++ b/src/plugins/mobile-bottom-nav/MobileBottomNav.tsx
@@ -2,6 +2,7 @@ import { useIsMobile } from '@/utils/react.js'
 import { useAppRuntime } from '@/extensions/runtimeContext.js'
 import { useActiveContextsState, type ActiveContextsMap } from '@/shortcuts/ActiveContexts.js'
 import { actionRuntimeKey, getEffectiveActions } from '@/shortcuts/effectiveActions.js'
+import { dispatchActionWithDeps } from '@/shortcuts/runAction.js'
 import { ActionContextTypes, type ActionConfig } from '@/shortcuts/types.js'
 import { mobileBottomNavItemsFacet } from './facet.ts'
 import { MobileBottomNavButton } from './Button.tsx'
@@ -18,8 +19,15 @@ function MobileBottomNavActionButton({
   const handleClick = () => {
     const deps = activeContexts.get(action.context)
     if (!deps) return
-    void action.handler(
-      deps as never,
+    // Route through the supplied-deps dispatch (resolveDeps validation +
+    // canDispatch gate + error logging) rather than invoking the handler
+    // directly. The button is disabled unless its context is active, so `deps`
+    // is the active context's set; handing it in as supplied keeps the dispatch
+    // path uniform without requiring the resolver to treat the context as
+    // keyboard-active.
+    dispatchActionWithDeps(
+      action.id,
+      deps,
       new CustomEvent('mobile-bottom-nav-action', {detail: {actionId: action.id}}),
     )
   }

--- a/src/plugins/vim-normal-mode/index.ts
+++ b/src/plugins/vim-normal-mode/index.ts
@@ -2,12 +2,13 @@ import {
   blockContentSurfacePropsFacet,
   shortcutSurfaceActivationsFacet,
 } from '@/extensions/blockInteraction.js'
-import { actionTransformsFacet } from '@/extensions/core.js'
+import { actionsFacet, actionTransformsFacet } from '@/extensions/core.js'
 import { AppExtension } from '@/extensions/facet.js'
 import { systemToggle } from '@/extensions/togglable.js'
 import { Repo } from '../../data/repo'
 import { vimNormalModeActionsExtension } from './actions.ts'
 import {
+  enterBlockEditModeOnGestureAction,
   vimClickToFocusTransform,
   vimContentSurfaceBehavior,
   vimNormalModeActivation,
@@ -15,6 +16,9 @@ import {
 
 export const vimNormalModeInteractionExtension: AppExtension = [
   actionTransformsFacet.of(vimClickToFocusTransform, {
+    source: 'vim-normal-mode',
+  }),
+  actionsFacet.of(enterBlockEditModeOnGestureAction, {
     source: 'vim-normal-mode',
   }),
   blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior, {

--- a/src/plugins/vim-normal-mode/index.ts
+++ b/src/plugins/vim-normal-mode/index.ts
@@ -1,5 +1,4 @@
 import {
-  blockContentSurfacePropsFacet,
   shortcutSurfaceActivationsFacet,
 } from '@/extensions/blockInteraction.js'
 import { actionsFacet, actionTransformsFacet } from '@/extensions/core.js'
@@ -10,7 +9,6 @@ import { vimNormalModeActionsExtension } from './actions.ts'
 import {
   enterBlockEditModeOnGestureAction,
   vimClickToFocusTransform,
-  vimContentSurfaceBehavior,
   vimNormalModeActivation,
 } from './interactions.ts'
 
@@ -19,10 +17,6 @@ export const vimNormalModeInteractionExtension: AppExtension = [
     source: 'vim-normal-mode',
   }),
   actionsFacet.of(enterBlockEditModeOnGestureAction, {
-    source: 'vim-normal-mode',
-  }),
-  blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior, {
-    precedence: 100,
     source: 'vim-normal-mode',
   }),
   shortcutSurfaceActivationsFacet.of(vimNormalModeActivation, {

--- a/src/plugins/vim-normal-mode/interactions.ts
+++ b/src/plugins/vim-normal-mode/interactions.ts
@@ -1,14 +1,21 @@
 import type { MouseEvent, TouchEvent } from 'react'
 import {
   BlockContentSurfaceContribution,
-  enterBlockEditMode,
+  enterEditModeForBlock,
   focusBlockWithoutEditing,
-  isInteractiveContentEvent,
   ShortcutActivationContribution,
+  type BlockResolveContext,
+  type EditorActivationSelection,
 } from '@/extensions/blockInteraction.js'
 import {
+  dispatchPointerAction,
+  type PointerGestureEvent,
+} from '@/shortcuts/pointerAction.js'
+import {
   ActionContextTypes,
+  type ActionConfig,
   type ActionTransform,
+  type ActionTrigger,
   type BlockPointerDependencies,
 } from '@/shortcuts/types.js'
 import { isEditingProp, isFocusedBlock } from '@/data/properties.js'
@@ -17,7 +24,7 @@ import { Block } from '../../data/block'
 
 /**
  * Vim normal mode: a single click focuses the block instead of entering edit
- * mode (double-click / tap still edits — see `vimContentSurfaceBehavior`).
+ * mode (double-click / tap still edits — see `enterBlockEditModeOnGestureAction`).
  *
  * Decorates the plain-outliner click-to-edit pointer action by replacing its
  * handler, the same Replace semantics vim used to get by winning the
@@ -44,6 +51,56 @@ export const vimClickToFocusTransform: ActionTransform = {
   }),
 }
 
+export const ENTER_BLOCK_EDIT_MODE_GESTURE_ACTION_ID = 'vim.block.enter-edit-mode-gesture'
+
+/** Cursor position for the entered editor, taken from whichever gesture fired:
+ *  a tap's changed touch, or a mouse event's client coordinates. Other trigger
+ *  shapes (keyboard, custom) carry no position, so editing starts at the
+ *  default caret. */
+const pointerSelectionFromTrigger = (
+  trigger: ActionTrigger,
+): EditorActivationSelection | undefined => {
+  if ('changedTouches' in trigger) {
+    const touch = trigger.changedTouches[0]
+    return touch ? {x: touch.clientX, y: touch.clientY} : undefined
+  }
+  if ('clientX' in trigger) return {x: trigger.clientX, y: trigger.clientY}
+  return undefined
+}
+
+/**
+ * Vim normal mode: a double-click (mouse) or tap (touch) enters edit mode — the
+ * counterpart to `vimClickToFocusTransform`, which makes a single click focus
+ * rather than edit. A pointer-bound `block-pointer` action, so it dispatches
+ * through the same `resolve` + coordinator path as click-to-edit and selection,
+ * with the clicked/tapped block's deps SUPPLIED. The context's
+ * `pointerTargetFilter` keeps it off interactive descendants and the CodeMirror
+ * editor (once editing, the surface is contenteditable → filtered → native
+ * double-click word-select stands).
+ *
+ * Double-click binds at `pointerdown` to beat the browser's native
+ * text-selection, which the `click` phase is too late to suppress; the tap
+ * binds at the touch `tap` phase, dispatched from the content surface's
+ * touchend once it has recognised the gesture.
+ */
+export const enterBlockEditModeOnGestureAction: ActionConfig<typeof ActionContextTypes.BLOCK_POINTER> = {
+  id: ENTER_BLOCK_EDIT_MODE_GESTURE_ACTION_ID,
+  description: 'Enter edit mode on double-click or tap',
+  context: ActionContextTypes.BLOCK_POINTER,
+  pointerBinding: [
+    {kind: 'mouse', detail: 2, phase: 'pointerdown'},
+    {kind: 'touch', phase: 'tap'},
+  ],
+  handler: ({block, uiStateBlock, renderScopeId}, trigger) => {
+    void enterEditModeForBlock(
+      block,
+      uiStateBlock,
+      renderScopeId,
+      pointerSelectionFromTrigger(trigger),
+    )
+  },
+}
+
 type TouchStart = { x: number; y: number; time: number }
 
 const touchStartByBlockId = new Map<string, TouchStart>()
@@ -55,29 +112,64 @@ const isBlockInEditMode = (uiStateBlock: Block, blockId: string, renderScopeId?:
   isFocusedBlock(uiStateBlock, blockId, renderScopeId) &&
   Boolean(uiStateBlock.peekProperty(isEditingProp))
 
+/**
+ * Build the deps a pointer-dispatched gesture needs from the block's resolve
+ * context plus the live event. `currentTarget` (the content surface) is read
+ * synchronously before React nulls it. Mirrors the shell's `suppliedPointerDeps`
+ * but sourced from the content-surface contribution's context.
+ */
+const suppliedGestureDeps = (
+  context: BlockResolveContext,
+  event: PointerGestureEvent,
+): BlockPointerDependencies => {
+  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
+    ? context.blockContext.renderScopeId
+    : undefined
+  return {
+    block: context.block,
+    uiStateBlock: context.uiStateBlock,
+    scopeRootId: context.scopeRootId,
+    scopeRootForcesOpen: !context.blockContext?.isNestedSurface,
+    targetElement: event.currentTarget,
+    ...(renderScopeId ? {renderScopeId} : {}),
+  }
+}
+
+/**
+ * Recognises the double-click and tap gestures on a block's content surface and
+ * dispatches them through the pointer path; what they DO (enter edit mode) lives
+ * in `enterBlockEditModeOnGestureAction`, decoratable like any other action.
+ * Interactive-target and edit-mode exclusion are the block-pointer context's
+ * job (`pointerTargetFilter`), so this only recognises the gesture and routes
+ * it. The dispatch path applies preventDefault/stopPropagation when an action
+ * handles the gesture — which suppresses the synthetic click a tap would
+ * otherwise raise (a single click focuses in vim, so an un-suppressed tap would
+ * focus instead of edit).
+ */
 export const vimContentSurfaceBehavior: BlockContentSurfaceContribution = context => {
   const {block, uiStateBlock} = context
   const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
     ? context.blockContext.renderScopeId
     : undefined
 
+  const dispatchGesture = (event: PointerGestureEvent): void => {
+    dispatchPointerAction(event, suppliedGestureDeps(context, event))
+  }
+
   return {
-    onMouseDownCapture: (event: MouseEvent) => {
+    onMouseDownCapture: (event: MouseEvent<HTMLElement>) => {
       if (event.defaultPrevented) return
-      if (isInteractiveContentEvent(event)) return
       if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) return
-      // detail === 2 catches double-click before native text-selection kicks in
+      // detail === 2 catches the double-click before native text-selection kicks
+      // in; it dispatches at the pointerdown phase to beat that selection.
       if (event.detail !== 2) return
-      event.preventDefault()
-      event.stopPropagation()
-      void enterBlockEditMode(context, {x: event.clientX, y: event.clientY})
+      dispatchGesture(event)
     },
-    onTouchStart: (event: TouchEvent) => {
-      if (isInteractiveContentEvent(event)) {
+    onTouchStart: (event: TouchEvent<HTMLElement>) => {
+      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) {
         touchStartByBlockId.delete(block.id)
         return
       }
-      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) return
       const touch = event.touches[0]
       if (!touch) return
       touchStartByBlockId.set(block.id, {
@@ -86,23 +178,17 @@ export const vimContentSurfaceBehavior: BlockContentSurfaceContribution = contex
         time: Date.now(),
       })
     },
-    onTouchEnd: (event: TouchEvent) => {
-      if (isInteractiveContentEvent(event)) {
-        touchStartByBlockId.delete(block.id)
-        return
-      }
-      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) return
+    onTouchEnd: (event: TouchEvent<HTMLElement>) => {
       const start = touchStartByBlockId.get(block.id)
       touchStartByBlockId.delete(block.id)
+      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) return
       const touch = event.changedTouches[0]
       if (!start || !touch) return
 
       const end = {x: touch.clientX, y: touch.clientY, time: Date.now()}
       if (!isTap(start, end)) return
 
-      event.preventDefault()
-      event.stopPropagation()
-      void enterBlockEditMode(context, {x: touch.clientX, y: touch.clientY})
+      dispatchGesture(event)
     },
   }
 }

--- a/src/plugins/vim-normal-mode/interactions.ts
+++ b/src/plugins/vim-normal-mode/interactions.ts
@@ -1,10 +1,10 @@
 import type { MouseEvent, TouchEvent } from 'react'
 import {
+  blockPointerDepsFrom,
   BlockContentSurfaceContribution,
   enterEditModeForBlock,
   focusBlockWithoutEditing,
   ShortcutActivationContribution,
-  type BlockResolveContext,
   type EditorActivationSelection,
 } from '@/extensions/blockInteraction.js'
 import {
@@ -113,29 +113,6 @@ const isBlockInEditMode = (uiStateBlock: Block, blockId: string, renderScopeId?:
   Boolean(uiStateBlock.peekProperty(isEditingProp))
 
 /**
- * Build the deps a pointer-dispatched gesture needs from the block's resolve
- * context plus the live event. `currentTarget` (the content surface) is read
- * synchronously before React nulls it. Mirrors the shell's `suppliedPointerDeps`
- * but sourced from the content-surface contribution's context.
- */
-const suppliedGestureDeps = (
-  context: BlockResolveContext,
-  event: PointerGestureEvent,
-): BlockPointerDependencies => {
-  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
-    ? context.blockContext.renderScopeId
-    : undefined
-  return {
-    block: context.block,
-    uiStateBlock: context.uiStateBlock,
-    scopeRootId: context.scopeRootId,
-    scopeRootForcesOpen: !context.blockContext?.isNestedSurface,
-    targetElement: event.currentTarget,
-    ...(renderScopeId ? {renderScopeId} : {}),
-  }
-}
-
-/**
  * Recognises the double-click and tap gestures on a block's content surface and
  * dispatches them through the pointer path; what they DO (enter edit mode) lives
  * in `enterBlockEditModeOnGestureAction`, decoratable like any other action.
@@ -153,7 +130,7 @@ export const vimContentSurfaceBehavior: BlockContentSurfaceContribution = contex
     : undefined
 
   const dispatchGesture = (event: PointerGestureEvent): void => {
-    dispatchPointerAction(event, suppliedGestureDeps(context, event))
+    dispatchPointerAction(event, blockPointerDepsFrom(context, event))
   }
 
   return {

--- a/src/plugins/vim-normal-mode/interactions.ts
+++ b/src/plugins/vim-normal-mode/interactions.ts
@@ -1,16 +1,9 @@
-import type { MouseEvent, TouchEvent } from 'react'
 import {
-  blockPointerDepsFrom,
-  BlockContentSurfaceContribution,
   enterEditModeForBlock,
   focusBlockWithoutEditing,
   ShortcutActivationContribution,
   type EditorActivationSelection,
 } from '@/extensions/blockInteraction.js'
-import {
-  dispatchPointerAction,
-  type PointerGestureEvent,
-} from '@/shortcuts/pointerAction.js'
 import {
   ActionContextTypes,
   type ActionConfig,
@@ -18,9 +11,7 @@ import {
   type ActionTrigger,
   type BlockPointerDependencies,
 } from '@/shortcuts/types.js'
-import { isEditingProp, isFocusedBlock } from '@/data/properties.js'
 import { ENTER_BLOCK_EDIT_MODE_ACTION_ID } from '@/plugins/plain-outliner/clickToEditAction.js'
-import { Block } from '../../data/block'
 
 /**
  * Vim normal mode: a single click focuses the block instead of entering edit
@@ -73,15 +64,14 @@ const pointerSelectionFromTrigger = (
  * counterpart to `vimClickToFocusTransform`, which makes a single click focus
  * rather than edit. A pointer-bound `block-pointer` action, so it dispatches
  * through the same `resolve` + coordinator path as click-to-edit and selection,
- * with the clicked/tapped block's deps SUPPLIED. The context's
- * `pointerTargetFilter` keeps it off interactive descendants and the CodeMirror
- * editor (once editing, the surface is contenteditable → filtered → native
- * double-click word-select stands).
+ * with the block's deps SUPPLIED. The gesture is RECOGNISED and routed by core's
+ * `blockContentPointerGestures` content-surface contribution; this plugin only
+ * contributes what the gesture does (enter edit mode) as a bound action.
  *
- * Double-click binds at `pointerdown` to beat the browser's native
- * text-selection, which the `click` phase is too late to suppress; the tap
- * binds at the touch `tap` phase, dispatched from the content surface's
- * touchend once it has recognised the gesture.
+ * The double-click binds at `pointerdown` (not `click`) so the dispatch's
+ * preventDefault beats the browser's native word-selection; the tap binds at the
+ * touch `tap` phase. In a non-vim config nothing binds these gestures, so the
+ * core surface routes them and they no-op — single click already edits there.
  */
 export const enterBlockEditModeOnGestureAction: ActionConfig<typeof ActionContextTypes.BLOCK_POINTER> = {
   id: ENTER_BLOCK_EDIT_MODE_GESTURE_ACTION_ID,
@@ -99,75 +89,6 @@ export const enterBlockEditModeOnGestureAction: ActionConfig<typeof ActionContex
       pointerSelectionFromTrigger(trigger),
     )
   },
-}
-
-type TouchStart = { x: number; y: number; time: number }
-
-const touchStartByBlockId = new Map<string, TouchStart>()
-
-const isTap = (start: TouchStart, end: TouchStart) =>
-  Math.abs(end.x - start.x) <= 10 && Math.abs(end.y - start.y) <= 10 && (end.time - start.time) <= 300
-
-const isBlockInEditMode = (uiStateBlock: Block, blockId: string, renderScopeId?: string): boolean =>
-  isFocusedBlock(uiStateBlock, blockId, renderScopeId) &&
-  Boolean(uiStateBlock.peekProperty(isEditingProp))
-
-/**
- * Recognises the double-click and tap gestures on a block's content surface and
- * dispatches them through the pointer path; what they DO (enter edit mode) lives
- * in `enterBlockEditModeOnGestureAction`, decoratable like any other action.
- * Interactive-target and edit-mode exclusion are the block-pointer context's
- * job (`pointerTargetFilter`), so this only recognises the gesture and routes
- * it. The dispatch path applies preventDefault/stopPropagation when an action
- * handles the gesture — which suppresses the synthetic click a tap would
- * otherwise raise (a single click focuses in vim, so an un-suppressed tap would
- * focus instead of edit).
- */
-export const vimContentSurfaceBehavior: BlockContentSurfaceContribution = context => {
-  const {block, uiStateBlock} = context
-  const renderScopeId = typeof context.blockContext?.renderScopeId === 'string'
-    ? context.blockContext.renderScopeId
-    : undefined
-
-  const dispatchGesture = (event: PointerGestureEvent): void => {
-    dispatchPointerAction(event, blockPointerDepsFrom(context, event))
-  }
-
-  return {
-    onMouseDownCapture: (event: MouseEvent<HTMLElement>) => {
-      if (event.defaultPrevented) return
-      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) return
-      // detail === 2 catches the double-click before native text-selection kicks
-      // in; it dispatches at the pointerdown phase to beat that selection.
-      if (event.detail !== 2) return
-      dispatchGesture(event)
-    },
-    onTouchStart: (event: TouchEvent<HTMLElement>) => {
-      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) {
-        touchStartByBlockId.delete(block.id)
-        return
-      }
-      const touch = event.touches[0]
-      if (!touch) return
-      touchStartByBlockId.set(block.id, {
-        x: touch.clientX,
-        y: touch.clientY,
-        time: Date.now(),
-      })
-    },
-    onTouchEnd: (event: TouchEvent<HTMLElement>) => {
-      const start = touchStartByBlockId.get(block.id)
-      touchStartByBlockId.delete(block.id)
-      if (isBlockInEditMode(uiStateBlock, block.id, renderScopeId)) return
-      const touch = event.changedTouches[0]
-      if (!start || !touch) return
-
-      const end = {x: touch.clientX, y: touch.clientY, time: Date.now()}
-      if (!isTap(start, end)) return
-
-      dispatchGesture(event)
-    },
-  }
 }
 
 export const vimNormalModeActivation: ShortcutActivationContribution = context => {

--- a/src/plugins/vim-normal-mode/test/interactions.test.ts
+++ b/src/plugins/vim-normal-mode/test/interactions.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { MouseEvent, TouchEvent } from 'react'
 import type { Block } from '../../../data/block'
 import type { Repo } from '../../../data/repo'
 import {
-  blockContentSurfacePropsFacet,
   BlockInteractionContext,
   shortcutSurfaceActivationsFacet,
 } from '@/extensions/blockInteraction.js'
@@ -18,15 +16,13 @@ import { ENTER_BLOCK_EDIT_MODE_ACTION_ID } from '@/plugins/plain-outliner/clickT
 import {
   enterBlockEditModeOnGestureAction,
   vimClickToFocusTransform,
-  vimContentSurfaceBehavior,
   vimNormalModeActivation,
 } from '../interactions.ts'
 
-const dispatchPointerAction = vi.hoisted(() =>
-  vi.fn<(event: unknown, deps: unknown) => boolean>(() => true),
-)
-vi.mock('@/shortcuts/pointerAction.js', () => ({dispatchPointerAction}))
-
+// Vim contributes only actions/transforms now — the double-click/tap gestures
+// are recognised and dispatched by core's `blockContentPointerGestures`
+// (covered in defaultEditorInteractions.test.ts), so this suite mocks the edit
+// helpers and exercises the action handler + transform directly.
 const enterEditModeForBlock = vi.hoisted(() => vi.fn())
 const focusBlockWithoutEditing = vi.hoisted(() => vi.fn())
 vi.mock('@/extensions/blockInteraction.js', async (importOriginal) => ({
@@ -35,21 +31,12 @@ vi.mock('@/extensions/blockInteraction.js', async (importOriginal) => ({
   focusBlockWithoutEditing,
 }))
 
-// isBlockInEditMode short-circuits on isFocusedBlock, so this gate alone decides
-// whether the surface treats the block as currently editing.
-const isFocusedBlock = vi.hoisted(() => vi.fn(() => false))
-vi.mock('@/data/properties.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/data/properties.js')>()),
-  isFocusedBlock,
-}))
-
 const context = {
   block: {id: 'block-1'} as Block,
   repo: {} as Repo,
-  uiStateBlock: {id: 'panel', peekProperty: () => true} as unknown as Block,
+  uiStateBlock: {id: 'panel'} as Block,
   types: [],
   topLevelBlockId: 'root',
-  scopeRootId: 'root',
   inFocus: true,
   inEditMode: false,
   isSelected: false,
@@ -57,98 +44,7 @@ const context = {
   contentRenderers: [],
 } satisfies BlockInteractionContext
 
-const surfaceProps = () => {
-  const runtime = resolveFacetRuntimeSync([
-    blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior),
-  ])
-  return runtime.read(blockContentSurfacePropsFacet)(context)
-}
-
-const mouseDown = (overrides: Partial<MouseEvent<HTMLDivElement>> = {}): MouseEvent<HTMLDivElement> => ({
-  type: 'mousedown',
-  detail: 2,
-  defaultPrevented: false,
-  currentTarget: document.createElement('div'),
-  preventDefault: vi.fn(),
-  stopPropagation: vi.fn(),
-  ...overrides,
-}) as unknown as MouseEvent<HTMLDivElement>
-
-const touchAt = (x: number, y: number) => ({
-  currentTarget: document.createElement('div'),
-  touches: [{clientX: x, clientY: y}],
-  changedTouches: [{clientX: x, clientY: y}],
-  preventDefault: vi.fn(),
-  stopPropagation: vi.fn(),
-}) as unknown as TouchEvent<HTMLDivElement>
-
 describe('vim normal mode interactions', () => {
-  it('contributes content-surface props for double-click and tap detection', () => {
-    const props = surfaceProps()
-    expect(props.onMouseDownCapture).toBeDefined()
-    expect(props.onTouchStart).toBeDefined()
-    expect(props.onTouchEnd).toBeDefined()
-  })
-
-  describe('double-click dispatch', () => {
-    it('dispatches a block-pointer gesture with the clicked block deps supplied', () => {
-      dispatchPointerAction.mockClear()
-      isFocusedBlock.mockReturnValue(false)
-      const props = surfaceProps()
-      const event = mouseDown({detail: 2})
-
-      props.onMouseDownCapture?.(event)
-
-      expect(dispatchPointerAction).toHaveBeenCalledTimes(1)
-      const [dispatchedEvent, deps] = dispatchPointerAction.mock.calls[0] as [
-        MouseEvent<HTMLDivElement>,
-        BlockPointerDependencies,
-      ]
-      expect(dispatchedEvent).toBe(event)
-      expect(deps.block).toBe(context.block)
-      expect(deps.uiStateBlock).toBe(context.uiStateBlock)
-      expect(deps.scopeRootId).toBe('root')
-      expect(deps.targetElement).toBe(event.currentTarget)
-    })
-
-    it('ignores a single click (only detail === 2 is a double-click)', () => {
-      dispatchPointerAction.mockClear()
-      isFocusedBlock.mockReturnValue(false)
-      surfaceProps().onMouseDownCapture?.(mouseDown({detail: 1}))
-      expect(dispatchPointerAction).not.toHaveBeenCalled()
-    })
-
-    it('does not dispatch while the block is already being edited', () => {
-      dispatchPointerAction.mockClear()
-      isFocusedBlock.mockReturnValue(true) // + peekProperty isEditing → true
-      surfaceProps().onMouseDownCapture?.(mouseDown({detail: 2}))
-      expect(dispatchPointerAction).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('tap dispatch', () => {
-    it('dispatches when touchstart→touchend stays within the tap thresholds', () => {
-      dispatchPointerAction.mockClear()
-      isFocusedBlock.mockReturnValue(false)
-      const props = surfaceProps()
-      props.onTouchStart?.(touchAt(5, 5))
-      const end = touchAt(6, 6)
-      props.onTouchEnd?.(end)
-
-      expect(dispatchPointerAction).toHaveBeenCalledTimes(1)
-      expect(dispatchPointerAction.mock.calls[0]?.[0]).toBe(end)
-    })
-
-    it('does not dispatch when the touch moves beyond the tap threshold (a drag)', () => {
-      dispatchPointerAction.mockClear()
-      isFocusedBlock.mockReturnValue(false)
-      const props = surfaceProps()
-      props.onTouchStart?.(touchAt(5, 5))
-      props.onTouchEnd?.(touchAt(80, 80))
-      expect(dispatchPointerAction).not.toHaveBeenCalled()
-    })
-  })
-
   describe('enterBlockEditModeOnGestureAction', () => {
     it('binds both a double-click and a tap', () => {
       expect(enterBlockEditModeOnGestureAction.context).toBe(ActionContextTypes.BLOCK_POINTER)

--- a/src/plugins/vim-normal-mode/test/interactions.test.ts
+++ b/src/plugins/vim-normal-mode/test/interactions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { TouchEvent } from 'react'
+import type { MouseEvent, TouchEvent } from 'react'
 import type { Block } from '../../../data/block'
 import type { Repo } from '../../../data/repo'
 import {
@@ -16,42 +16,40 @@ import {
 } from '@/shortcuts/types.js'
 import { ENTER_BLOCK_EDIT_MODE_ACTION_ID } from '@/plugins/plain-outliner/clickToEditAction.js'
 import {
+  enterBlockEditModeOnGestureAction,
   vimClickToFocusTransform,
   vimContentSurfaceBehavior,
   vimNormalModeActivation,
 } from '../interactions.ts'
 
+const dispatchPointerAction = vi.hoisted(() =>
+  vi.fn<(event: unknown, deps: unknown) => boolean>(() => true),
+)
+vi.mock('@/shortcuts/pointerAction.js', () => ({dispatchPointerAction}))
+
+const enterEditModeForBlock = vi.hoisted(() => vi.fn())
 const focusBlockWithoutEditing = vi.hoisted(() => vi.fn())
 vi.mock('@/extensions/blockInteraction.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/extensions/blockInteraction.js')>()),
+  enterEditModeForBlock,
   focusBlockWithoutEditing,
 }))
 
-const interactiveTargets: Array<[string, () => HTMLElement]> = [
-  ['anchor', () => {
-    const link = document.createElement('a')
-    link.href = 'https://example.com'
-    return link
-  }],
-  ['button', () => document.createElement('button')],
-  ['ARIA button', () => {
-    const button = document.createElement('span')
-    button.setAttribute('role', 'button')
-    return button
-  }],
-  ['controlled video', () => {
-    const video = document.createElement('video')
-    video.controls = true
-    return video
-  }],
-]
+// isBlockInEditMode short-circuits on isFocusedBlock, so this gate alone decides
+// whether the surface treats the block as currently editing.
+const isFocusedBlock = vi.hoisted(() => vi.fn(() => false))
+vi.mock('@/data/properties.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/data/properties.js')>()),
+  isFocusedBlock,
+}))
 
 const context = {
   block: {id: 'block-1'} as Block,
   repo: {} as Repo,
-  uiStateBlock: {} as Block,
+  uiStateBlock: {id: 'panel', peekProperty: () => true} as unknown as Block,
   types: [],
   topLevelBlockId: 'root',
+  scopeRootId: 'root',
   inFocus: true,
   inEditMode: false,
   isSelected: false,
@@ -59,17 +57,135 @@ const context = {
   contentRenderers: [],
 } satisfies BlockInteractionContext
 
+const surfaceProps = () => {
+  const runtime = resolveFacetRuntimeSync([
+    blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior),
+  ])
+  return runtime.read(blockContentSurfacePropsFacet)(context)
+}
+
+const mouseDown = (overrides: Partial<MouseEvent<HTMLDivElement>> = {}): MouseEvent<HTMLDivElement> => ({
+  type: 'mousedown',
+  detail: 2,
+  defaultPrevented: false,
+  currentTarget: document.createElement('div'),
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+  ...overrides,
+}) as unknown as MouseEvent<HTMLDivElement>
+
+const touchAt = (x: number, y: number) => ({
+  currentTarget: document.createElement('div'),
+  touches: [{clientX: x, clientY: y}],
+  changedTouches: [{clientX: x, clientY: y}],
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+}) as unknown as TouchEvent<HTMLDivElement>
+
 describe('vim normal mode interactions', () => {
   it('contributes content-surface props for double-click and tap detection', () => {
-    const runtime = resolveFacetRuntimeSync([
-      blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior),
-    ])
-
-    const props = runtime.read(blockContentSurfacePropsFacet)(context)
-
+    const props = surfaceProps()
     expect(props.onMouseDownCapture).toBeDefined()
     expect(props.onTouchStart).toBeDefined()
     expect(props.onTouchEnd).toBeDefined()
+  })
+
+  describe('double-click dispatch', () => {
+    it('dispatches a block-pointer gesture with the clicked block deps supplied', () => {
+      dispatchPointerAction.mockClear()
+      isFocusedBlock.mockReturnValue(false)
+      const props = surfaceProps()
+      const event = mouseDown({detail: 2})
+
+      props.onMouseDownCapture?.(event)
+
+      expect(dispatchPointerAction).toHaveBeenCalledTimes(1)
+      const [dispatchedEvent, deps] = dispatchPointerAction.mock.calls[0] as [
+        MouseEvent<HTMLDivElement>,
+        BlockPointerDependencies,
+      ]
+      expect(dispatchedEvent).toBe(event)
+      expect(deps.block).toBe(context.block)
+      expect(deps.uiStateBlock).toBe(context.uiStateBlock)
+      expect(deps.scopeRootId).toBe('root')
+      expect(deps.targetElement).toBe(event.currentTarget)
+    })
+
+    it('ignores a single click (only detail === 2 is a double-click)', () => {
+      dispatchPointerAction.mockClear()
+      isFocusedBlock.mockReturnValue(false)
+      surfaceProps().onMouseDownCapture?.(mouseDown({detail: 1}))
+      expect(dispatchPointerAction).not.toHaveBeenCalled()
+    })
+
+    it('does not dispatch while the block is already being edited', () => {
+      dispatchPointerAction.mockClear()
+      isFocusedBlock.mockReturnValue(true) // + peekProperty isEditing → true
+      surfaceProps().onMouseDownCapture?.(mouseDown({detail: 2}))
+      expect(dispatchPointerAction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('tap dispatch', () => {
+    it('dispatches when touchstart→touchend stays within the tap thresholds', () => {
+      dispatchPointerAction.mockClear()
+      isFocusedBlock.mockReturnValue(false)
+      const props = surfaceProps()
+      props.onTouchStart?.(touchAt(5, 5))
+      const end = touchAt(6, 6)
+      props.onTouchEnd?.(end)
+
+      expect(dispatchPointerAction).toHaveBeenCalledTimes(1)
+      expect(dispatchPointerAction.mock.calls[0]?.[0]).toBe(end)
+    })
+
+    it('does not dispatch when the touch moves beyond the tap threshold (a drag)', () => {
+      dispatchPointerAction.mockClear()
+      isFocusedBlock.mockReturnValue(false)
+      const props = surfaceProps()
+      props.onTouchStart?.(touchAt(5, 5))
+      props.onTouchEnd?.(touchAt(80, 80))
+      expect(dispatchPointerAction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('enterBlockEditModeOnGestureAction', () => {
+    it('binds both a double-click and a tap', () => {
+      expect(enterBlockEditModeOnGestureAction.context).toBe(ActionContextTypes.BLOCK_POINTER)
+      expect(enterBlockEditModeOnGestureAction.pointerBinding).toEqual([
+        {kind: 'mouse', detail: 2, phase: 'pointerdown'},
+        {kind: 'touch', phase: 'tap'},
+      ])
+    })
+
+    it('enters edit mode at the mouse coordinates a double-click carries', () => {
+      enterEditModeForBlock.mockClear()
+      const deps: BlockPointerDependencies = {
+        block: {id: 'b'} as Block,
+        uiStateBlock: {id: 'panel'} as Block,
+        targetElement: document.createElement('div'),
+        renderScopeId: 'scope-a',
+      }
+      enterBlockEditModeOnGestureAction.handler(
+        deps,
+        {clientX: 12, clientY: 34} as unknown as ActionTrigger,
+      )
+      expect(enterEditModeForBlock).toHaveBeenCalledWith(deps.block, deps.uiStateBlock, 'scope-a', {x: 12, y: 34})
+    })
+
+    it('enters edit mode at the changed-touch coordinates a tap carries', () => {
+      enterEditModeForBlock.mockClear()
+      const deps: BlockPointerDependencies = {
+        block: {id: 'b'} as Block,
+        uiStateBlock: {id: 'panel'} as Block,
+        targetElement: document.createElement('div'),
+      }
+      enterBlockEditModeOnGestureAction.handler(
+        deps,
+        {changedTouches: [{clientX: 9, clientY: 11}]} as unknown as ActionTrigger,
+      )
+      expect(enterEditModeForBlock).toHaveBeenCalledWith(deps.block, deps.uiStateBlock, undefined, {x: 9, y: 11})
+    })
   })
 
   describe('click-to-focus transform (single click focuses, does not edit)', () => {
@@ -99,37 +215,6 @@ describe('vim normal mode interactions', () => {
       expect(editAction.handler).not.toHaveBeenCalled()
       expect(focusBlockWithoutEditing).toHaveBeenCalledWith(deps.block, deps.uiStateBlock, 'scope-a')
     })
-  })
-
-  it.each(interactiveTargets)('does not turn %s taps into edit-mode taps', (_label, createTarget) => {
-    const runtime = resolveFacetRuntimeSync([
-      blockContentSurfacePropsFacet.of(vimContentSurfaceBehavior),
-    ])
-    const props = runtime.read(blockContentSurfacePropsFacet)(context)
-    const interactive = createTarget()
-    const child = document.createElement('span')
-    interactive.appendChild(child)
-
-    const startEvent = {
-      target: child,
-      touches: [{clientX: 1, clientY: 1}],
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-    } as unknown as TouchEvent<HTMLDivElement>
-    const endEvent = {
-      target: child,
-      changedTouches: [{clientX: 1, clientY: 1}],
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-    } as unknown as TouchEvent<HTMLDivElement>
-
-    props.onTouchStart?.(startEvent)
-    props.onTouchEnd?.(endEvent)
-
-    expect(startEvent.preventDefault).not.toHaveBeenCalled()
-    expect(startEvent.stopPropagation).not.toHaveBeenCalled()
-    expect(endEvent.preventDefault).not.toHaveBeenCalled()
-    expect(endEvent.stopPropagation).not.toHaveBeenCalled()
   })
 
   it('defines Vim normal mode as a shortcut surface activation', () => {

--- a/src/shortcuts/HotkeyReconciler.tsx
+++ b/src/shortcuts/HotkeyReconciler.tsx
@@ -13,7 +13,6 @@ import {
   ActiveContextsMap,
 } from '@/shortcuts/ActiveContexts.js'
 import { setRunActionDispatcher, setActionWithDepsDispatcher } from '@/shortcuts/runAction.js'
-import { setPointerActionDispatcher } from '@/shortcuts/pointerAction.js'
 import {
   actionRuntimeKey,
   getActiveActionById,
@@ -24,9 +23,12 @@ import { computeInstallableContexts, resolve, resolveDeps } from './resolve.ts'
 import {
   matchesMouseEvent,
   pointerBindingDescriptor,
+  type MouseEventLike,
   type PointerBindingSpec,
   type PointerPhase,
+  type TouchPhase,
 } from './canonicalizeChord.ts'
+import { setPointerActionDispatcher, type PointerGestureEvent } from '@/shortcuts/pointerAction.js'
 import {
   ActionConfig,
   ActionContextConfig,
@@ -38,7 +40,7 @@ import {
   EventOptions,
   ShortcutBindingDefaults,
 } from '@/shortcuts/types.js'
-import type { MouseEvent as ReactMouseEvent } from 'react'
+import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from 'react'
 import { hasEditableTarget, isTypingKeyEvent, withRecoveredLetterKey } from '@/shortcuts/utils.js'
 
 /**
@@ -227,15 +229,13 @@ export function HotkeyReconciler(): null {
     setPointerActionDispatcher((event, supplied) => {
       const active = activeRef.current
       const contextConfigsByType = contextConfigsByTypeRef.current
-      const phase = phaseOfPointerEvent(event)
-      const eventLike = {
-        button: event.button,
-        detail: event.detail,
-        shiftKey: event.shiftKey,
-        altKey: event.altKey,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
-      }
+      // A touch tap resolves at the `tap` phase and carries none of mouse's
+      // button/detail/modifiers; a mouse gesture's phase comes from its event
+      // type and matches on those fields. `eventLike` is null for touch so a
+      // mouse descriptor can never match a tap (and vice versa).
+      const phase: PointerPhase | TouchPhase =
+        isTouchGesture(event) ? 'tap' : phaseOfPointerEvent(event)
+      const eventLike = mouseEventLikeOf(event)
       const matched = getEffectiveActions(runtime).filter(action => {
         const spec = action.pointerBinding
         if (!spec) return false
@@ -244,12 +244,17 @@ export function HotkeyReconciler(): null {
         // descendants), so none of its actions become candidates here.
         const contextFilter = contextConfigsByType.get(action.context)?.pointerTargetFilter
         if (contextFilter && !contextFilter(event)) return false
-        // A binding may list several pointer chords (ctrl-click OR meta-click);
-        // the action matches if any of them does.
+        // A binding may list several pointer chords (ctrl-click OR meta-click,
+        // double-click OR tap); the action matches if any of them does.
         const specs: readonly PointerBindingSpec[] = Array.isArray(spec) ? spec : [spec]
         return specs.some(candidate => {
           const descriptor = pointerBindingDescriptor(candidate)
           if (descriptor.phase !== phase) return false
+          // A touch descriptor matches a tap on phase alone (no button/detail);
+          // a mouse descriptor needs the mouse fields, so a tap (eventLike null)
+          // can't satisfy it.
+          if (descriptor.kind === 'touch') return true
+          if (!eventLike) return false
           if (!matchesMouseEvent(descriptor, eventLike)) return false
           if (descriptor.role && !pointerRoleMatches(supplied.targetElement, descriptor.role)) return false
           return true
@@ -624,7 +629,26 @@ const runOrderedCandidates = (
   return false
 }
 
-/** Map a React pointer event to the binding phase it can satisfy. `click` is
+/** A touch gesture carries `changedTouches`; a mouse event does not — the
+ *  discriminator the dispatcher uses to pick the tap path over the mouse path. */
+const isTouchGesture = (event: PointerGestureEvent): event is ReactTouchEvent<HTMLElement> =>
+  'changedTouches' in event
+
+/** The mouse fields a {@link MouseChordDescriptor} matches against, or null for
+ *  a touch gesture (a tap has no button/detail/modifiers). */
+const mouseEventLikeOf = (event: PointerGestureEvent): MouseEventLike | null =>
+  isTouchGesture(event)
+    ? null
+    : {
+        button: event.button,
+        detail: event.detail,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+      }
+
+/** Map a React mouse event to the binding phase it can satisfy. `click` is
  *  the default; `pointerdown` lets a double-click beat native text selection. */
 const phaseOfPointerEvent = (event: ReactMouseEvent<HTMLElement>): PointerPhase => {
   switch (event.type) {
@@ -649,7 +673,7 @@ const pointerRoleMatches = (target: HTMLElement, role: string): boolean =>
  *  bubbling into edit-mode), so that is the default; a context can override via
  *  `defaultEventOptions`. */
 const applyPointerEventOptions = (
-  event: ReactMouseEvent<HTMLElement>,
+  event: PointerGestureEvent,
   action: ActionConfig,
   contextConfigsByType: ReadonlyMap<ActionContextType, ActionContextConfig>,
 ): void => {

--- a/src/shortcuts/canonicalizeChord.test.ts
+++ b/src/shortcuts/canonicalizeChord.test.ts
@@ -4,6 +4,7 @@ import {
   matchesMouseEvent,
   normalizeChord,
   parseChord,
+  pointerBindingDescriptor,
   type MouseChordDescriptor,
   type MouseEventLike,
 } from './canonicalizeChord.ts'
@@ -99,6 +100,25 @@ describe('matchesMouseEvent', () => {
     }
     expect(matchesMouseEvent(plainClick, mouseEvent())).toBe(true)
     expect(matchesMouseEvent(plainClick, mouseEvent({altKey: true}))).toBe(false)
+  })
+})
+
+describe('pointerBindingDescriptor', () => {
+  it('realizes a touch tap with only its kind and phase', () => {
+    expect(pointerBindingDescriptor({kind: 'touch'})).toEqual({kind: 'touch', phase: 'tap'})
+    expect(pointerBindingDescriptor({kind: 'touch', phase: 'tap'})).toEqual({kind: 'touch', phase: 'tap'})
+  })
+
+  it('defaults a mouse binding to a plain single primary click', () => {
+    expect(pointerBindingDescriptor({kind: 'mouse'})).toEqual({
+      kind: 'mouse', button: 0, detail: 1, mods: [], phase: 'click',
+    })
+  })
+
+  it('carries a double-click through at the pointerdown phase', () => {
+    expect(pointerBindingDescriptor({kind: 'mouse', detail: 2, phase: 'pointerdown'})).toEqual({
+      kind: 'mouse', button: 0, detail: 2, mods: [], phase: 'pointerdown',
+    })
   })
 })
 

--- a/src/shortcuts/canonicalizeChord.ts
+++ b/src/shortcuts/canonicalizeChord.ts
@@ -29,10 +29,17 @@ export type Modifier = '$mod' | 'Control' | 'Alt' | 'Shift'
  *  `phase` field in `types.ts`. */
 export type ChordPhase = 'keydown' | 'keyup' | 'hold'
 
-/** When in the pointer lifecycle a mouse/touch press resolves. A
+/** When in the pointer lifecycle a mouse press resolves. A
  *  double-click binds at `pointerdown` to beat the browser's native
  *  text-selection, which `click` is too late for. */
 export type PointerPhase = 'pointerdown' | 'pointerup' | 'click'
+
+/** When in the touch lifecycle a gesture resolves. Only `tap` today — the
+ *  block surface recognises the tap (its movement/duration thresholds live
+ *  there, not in the descriptor) and dispatches at touchend. Kept a separate
+ *  phase set from {@link PointerPhase} because a tap is not a mouse press and
+ *  carries none of button/detail/modifiers. */
+export type TouchPhase = 'tap'
 
 /**
  * One keyboard press within a chord. A plain chord ('Cmd+K') is a single
@@ -70,11 +77,22 @@ export interface MouseChordDescriptor {
 }
 
 /**
+ * A single touch gesture. The touch-side analogue of {@link MouseChordDescriptor}:
+ * a tap has no button/detail/modifiers, so `phase` is the only matched field.
+ * Recognising the tap (movement/duration thresholds) is the surface's job; by
+ * the time a descriptor is compared the gesture has already been classified.
+ */
+export interface TouchChordDescriptor {
+  readonly kind: 'touch'
+  readonly phase: TouchPhase
+}
+
+/**
  * One press within a chord. `kind` discriminates keyboard from pointer; the
  * field was left open in Phase 0 precisely so Phase 3 could add this variant
  * without a rewrite.
  */
-export type ChordDescriptor = KeyChordDescriptor | MouseChordDescriptor
+export type ChordDescriptor = KeyChordDescriptor | MouseChordDescriptor | TouchChordDescriptor
 
 /** A chord is a sequence of presses; an ordinary chord is length 1. */
 export type ChordSequence = readonly ChordDescriptor[]
@@ -209,12 +227,12 @@ export interface MouseEventLike extends PointerModifierState {
 }
 
 /**
- * A pointer (mouse) binding declared on an action — the pointer analogue of a
- * keyboard `defaultBinding`. Structured rather than a string because pointer
- * chords aren't sequences and don't share keyboard's phase set. Defaults:
- * primary button, single click, no modifiers, `click` phase.
+ * A mouse binding declared on an action — the pointer analogue of a keyboard
+ * `defaultBinding`. Structured rather than a string because pointer chords
+ * aren't sequences and don't share keyboard's phase set. Defaults: primary
+ * button, single click, no modifiers, `click` phase.
  */
-export interface PointerBindingSpec {
+export interface MousePointerBindingSpec {
   readonly kind: 'mouse'
   readonly button?: number
   readonly detail?: number
@@ -223,16 +241,38 @@ export interface PointerBindingSpec {
   readonly phase?: PointerPhase
 }
 
+/**
+ * A touch binding declared on an action. A tap carries none of mouse's
+ * button/detail/modifiers, so the spec is just the kind plus an optional phase
+ * (only `tap` today). Defaults: `tap` phase.
+ */
+export interface TouchPointerBindingSpec {
+  readonly kind: 'touch'
+  readonly phase?: TouchPhase
+}
+
+/**
+ * A pointer binding declared on an action — a mouse gesture (click, ctrl-click,
+ * double-click, …) or a touch gesture (tap). Both dispatch through the same
+ * `resolve` + coordinator path with the clicked/tapped block's deps supplied.
+ */
+export type PointerBindingSpec = MousePointerBindingSpec | TouchPointerBindingSpec
+
 /** Realize a {@link PointerBindingSpec}'s declared/defaulted fields into the
  *  descriptor the matcher and coordinator compare against. */
-export const pointerBindingDescriptor = (spec: PointerBindingSpec): MouseChordDescriptor => ({
-  kind: 'mouse',
-  button: spec.button ?? 0,
-  detail: spec.detail ?? 1,
-  mods: spec.mods ?? [],
-  ...(spec.role !== undefined ? {role: spec.role} : {}),
-  phase: spec.phase ?? 'click',
-})
+export const pointerBindingDescriptor = (
+  spec: PointerBindingSpec,
+): MouseChordDescriptor | TouchChordDescriptor =>
+  spec.kind === 'touch'
+    ? {kind: 'touch', phase: spec.phase ?? 'tap'}
+    : {
+        kind: 'mouse',
+        button: spec.button ?? 0,
+        detail: spec.detail ?? 1,
+        mods: spec.mods ?? [],
+        ...(spec.role !== undefined ? {role: spec.role} : {}),
+        phase: spec.phase ?? 'click',
+      }
 
 /**
  * Does a mouse event satisfy a {@link MouseChordDescriptor}? Button and click

--- a/src/shortcuts/pointerAction.ts
+++ b/src/shortcuts/pointerAction.ts
@@ -1,16 +1,26 @@
-import type { MouseEvent as ReactMouseEvent } from 'react'
+import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from 'react'
 import type { BlockPointerDependencies } from './types.js'
 
 /**
- * Dispatch a pointer (mouse) event through the same `resolve` + coordinator +
- * run-until-handled path keyboard chords use. The block shell calls this with
- * the clicked block's deps SUPPLIED (the gesture's context isn't keyboard-
- * active, so the deps can't come from the active-contexts map). Returns true
- * when a pointer-bound action handled the event, false when none matched or
+ * A pointer gesture event the dispatcher accepts: a mouse event (click,
+ * ctrl-click, double-click, …) or a touch event (tap). The coordinator
+ * discriminates the two — phase and matching differ — but the entry point is
+ * one so callers route every block gesture through a single path.
+ */
+export type PointerGestureEvent =
+  | ReactMouseEvent<HTMLElement>
+  | ReactTouchEvent<HTMLElement>
+
+/**
+ * Dispatch a pointer gesture through the same `resolve` + coordinator +
+ * run-until-handled path keyboard chords use. The block surface calls this with
+ * the clicked/tapped block's deps SUPPLIED (the gesture's context isn't
+ * keyboard-active, so the deps can't come from the active-contexts map). Returns
+ * true when a pointer-bound action handled the event, false when none matched or
  * every candidate declined — so the caller can fall back to a default.
  */
 export type DispatchPointerActionFn = (
-  event: ReactMouseEvent<HTMLElement>,
+  event: PointerGestureEvent,
   suppliedDeps: BlockPointerDependencies,
 ) => boolean
 

--- a/src/shortcuts/test/HotkeyReconciler.test.tsx
+++ b/src/shortcuts/test/HotkeyReconciler.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, afterEach, vi } from 'vitest'
 import { act, render, cleanup } from '@testing-library/react'
-import type { MouseEvent as ReactMouseEvent } from 'react'
+import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from 'react'
 import { HotkeyReconciler } from '@/shortcuts/HotkeyReconciler.js'
 import { dispatchPointerAction } from '@/shortcuts/pointerAction.js'
 import { dispatchActionWithDeps } from '@/shortcuts/runAction.js'
@@ -92,6 +92,18 @@ const pointerEvent = (
   stopPropagation: vi.fn(),
   ...overrides,
 }) as unknown as ReactMouseEvent<HTMLElement>
+
+// A touch gesture is discriminated from a mouse event by `changedTouches`; the
+// surface has already recognised the tap by the time it dispatches.
+const touchEvent = (
+  overrides: Partial<{target: EventTarget}> = {},
+): ReactTouchEvent<HTMLElement> => ({
+  type: 'touchend',
+  changedTouches: [{clientX: 1, clientY: 1}],
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+  ...overrides,
+}) as unknown as ReactTouchEvent<HTMLElement>
 
 const HIGH_CONTEXT = 'high-priority-mode' as ActionContextType
 const highContextConfig: ActionContextConfig = {
@@ -825,6 +837,83 @@ describe('HotkeyReconciler', () => {
 
       expect(declined).toHaveBeenCalledTimes(1)
       expect(fallback).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches a double-click (pointerdown, detail 2) but not a single click', () => {
+      const handler = vi.fn()
+      const action = pointerAction({
+        id: 'pointer.double',
+        handler,
+        pointerBinding: {kind: 'mouse', detail: 2, phase: 'pointerdown'},
+      })
+
+      render(<Harness actions={[action]} contexts={[blockPointerContextConfig]}/>)
+
+      // A single mousedown (detail 1) at the same phase doesn't match.
+      let handled = true
+      act(() => {
+        handled = dispatchPointerAction(
+          pointerEvent({type: 'mousedown', detail: 1}),
+          {marker: 'x'} as never,
+        )
+      })
+      expect(handled).toBe(false)
+      expect(handler).not.toHaveBeenCalled()
+
+      act(() => {
+        handled = dispatchPointerAction(
+          pointerEvent({type: 'mousedown', detail: 2}),
+          {marker: 'x'} as never,
+        )
+      })
+      expect(handled).toBe(true)
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches a touch tap to a touch-bound action', () => {
+      const handler = vi.fn()
+      const supplied = {marker: 'tapped'} as unknown as BaseShortcutDependencies
+      const action = pointerAction({
+        id: 'pointer.tap',
+        handler,
+        pointerBinding: {kind: 'touch', phase: 'tap'},
+      })
+
+      render(<Harness actions={[action]} contexts={[blockPointerContextConfig]}/>)
+
+      let handled = false
+      act(() => { handled = dispatchPointerAction(touchEvent(), supplied as never) })
+
+      expect(handled).toBe(true)
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler.mock.calls[0]?.[0]).toBe(supplied)
+    })
+
+    it('does not cross-match a mouse gesture to a touch binding (or vice versa)', () => {
+      const tapHandler = vi.fn()
+      const clickHandler = vi.fn()
+      const tapAction = pointerAction({
+        id: 'pointer.tap-only',
+        handler: tapHandler,
+        pointerBinding: {kind: 'touch', phase: 'tap'},
+      })
+      const clickAction = pointerAction({
+        id: 'pointer.click-only',
+        handler: clickHandler,
+        pointerBinding: {kind: 'mouse', mods: [], phase: 'click'},
+      })
+
+      render(<Harness actions={[tapAction, clickAction]} contexts={[blockPointerContextConfig]}/>)
+
+      // A plain click reaches the mouse action, not the touch one.
+      act(() => { dispatchPointerAction(pointerEvent({}), {marker: 'x'} as never) })
+      expect(clickHandler).toHaveBeenCalledTimes(1)
+      expect(tapHandler).not.toHaveBeenCalled()
+
+      // A tap reaches the touch action, not the mouse one.
+      act(() => { dispatchPointerAction(touchEvent(), {marker: 'x'} as never) })
+      expect(tapHandler).toHaveBeenCalledTimes(1)
+      expect(clickHandler).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -1,4 +1,9 @@
-import type { ComponentType, MouseEvent as ReactMouseEvent, SVGProps } from 'react';
+import type {
+  ComponentType,
+  MouseEvent as ReactMouseEvent,
+  TouchEvent as ReactTouchEvent,
+  SVGProps,
+} from 'react';
 import { Block } from '../data/block';
 import { EditorView } from '@codemirror/view'
 import type { PointerBindingSpec } from './canonicalizeChord.js'
@@ -74,10 +79,11 @@ export interface ActionContextConfig<T extends ActionContextType = ActionContext
    * that event. Lets a context declare "my gestures don't apply here" once,
    * centrally, instead of every action/handler re-checking — e.g. `block-pointer`
    * excludes clicks landing on interactive descendants (links, buttons) so they
-   * keep their native behavior. Keys off the actual event target. Only consulted
-   * on the pointer path; ignored for keyboard.
+   * keep their native behavior. Keys off the actual event target (works for
+   * mouse and touch alike). Only consulted on the pointer path; ignored for
+   * keyboard.
    */
-  pointerTargetFilter?: (event: ReactMouseEvent<HTMLElement>) => boolean;
+  pointerTargetFilter?: (event: ReactMouseEvent<HTMLElement> | ReactTouchEvent<HTMLElement>) => boolean;
   /**
    * Type guard function to validate the dependencies provided when activating the context.
    */
@@ -181,11 +187,16 @@ export interface ActionContextActivation {
 /**
  * The raw event handed to a handler as its second argument. Keyboard chords
  * deliver a `KeyboardEvent`, imperative/swipe callers a `CustomEvent`, and
- * pointer-bound actions the React `MouseEvent` (whose `currentTarget` the
- * handler reads synchronously before any await). The descriptor used for
- * resolution/ordering is internal to the coordinator and never reaches here.
+ * pointer-bound actions a React `MouseEvent` (click/double-click) or
+ * `TouchEvent` (tap) — whose `currentTarget` / coordinates the handler reads
+ * synchronously before any await. The descriptor used for resolution/ordering
+ * is internal to the coordinator and never reaches here.
  */
-export type ActionTrigger = KeyboardEvent | CustomEvent | ReactMouseEvent<HTMLElement>
+export type ActionTrigger =
+  | KeyboardEvent
+  | CustomEvent
+  | ReactMouseEvent<HTMLElement>
+  | ReactTouchEvent<HTMLElement>
 
 /**
  * Activation primitives surfaced to action handlers as the optional third


### PR DESCRIPTION
## Summary

Vim normal mode's double-click and tap-to-edit handlers entered edit mode **directly** from the block content surface, bypassing the `resolve` + coordinator + run-until-handled path every other block gesture goes through (click-to-edit, shift/ctrl-click selection, swipe). This was the last cluster of click/touch actions not on the unified dispatch path. This PR migrates both, generalizes the pointer dispatch entry point to accept touch, and moves the gesture *recognition* into core infrastructure so a plugin no longer owns generic DOM gesture plumbing.

### What changed

- **Touch joins the chord vocabulary.** `canonicalizeChord.ts` gains a `TouchChordDescriptor` / `TouchPointerBindingSpec` and a `tap` phase; `PointerBindingSpec` becomes a `mouse | touch` union. The dispatch entry point (`pointerAction.ts`) widens to accept `ReactMouseEvent | ReactTouchEvent` (`PointerGestureEvent`); `ActionTrigger` / `pointerTargetFilter` widen to match.
- **The coordinator discriminates the two.** A mouse gesture resolves at its event-derived phase and matches on button/detail/modifiers; a touch tap resolves at the `tap` phase and matches on phase alone (it carries none of mouse's fields). A tap can't satisfy a mouse binding and vice versa.
- **Gesture recognition is core, not vim.** A new core `blockContentSurfacePropsFacet` contribution — `blockContentPointerGestures` in `defaultEditorInteractions` — recognises a multi-click (pointerdown) and a touch tap on the block **content surface** and routes them through the same pointer dispatch the shell uses for clicks. It lives on the content surface (not the shell) so it never fires for the bullet, controls, or properties chrome; interactive descendants and the CodeMirror editor stay native via the context's `pointerTargetFilter`.
- **Vim contributes only behavior.** `enterBlockEditModeOnGestureAction` is a `block-pointer` action bound to *both* a double-click (`pointerdown`, `detail: 2` — to beat native word-selection that `click` is too late for) and a tap, plus the existing `vimClickToFocusTransform`. No DOM handlers. An unbound gesture is a no-op, so a non-vim config routes these gestures harmlessly (single click already edits there).
- **Dedup.** Extracted `blockPointerDepsFrom(context, event)` into `blockInteraction.ts` so the shell click path and the content-surface gesture path build supplied deps from one place.

### Behavior

Identical in normal operation: a non-interactive double-click or tap on a focused-but-not-editing block enters edit mode at the gesture point, and the dispatch path's `preventDefault` keeps a tap's synthetic click from falling through to single-click-focus.

### Tests

- `canonicalizeChord`: `pointerBindingDescriptor` realizes touch taps and mouse defaults / double-click.
- `HotkeyReconciler`: double-click (pointerdown, detail 2) dispatches but a single click doesn't; a touch tap dispatches to a touch-bound action; mouse and touch don't cross-match.
- `defaultEditorInteractions`: `blockContentPointerGestures` routes a multi-click and an in-threshold tap with the block's deps supplied; ignores single presses, drags, and already-preventDefaulted (shell selection) mousedowns.
- `vim-normal-mode/interactions`: the gesture action enters edit mode at the mouse/changed-touch coordinates; the click→focus transform focuses without editing.

`yarn run check` green — 282 files, 3056 tests, lint + typecheck clean.

https://claude.ai/code/session_019rpY1TcxUbQd7fZeRax2SA