### PR TITLE
fix(sync): heal deterministic-id default-shadows-server via write provenance

### DIFF
--- a/docs/deterministic-id-shadow-handoff.md
+++ b/docs/deterministic-id-shadow-handoff.md
@@ -1,7 +1,59 @@
 # Handoff: deterministic-id "default shadows server" bug
 
-Status as of this session. Two interim fixes have shipped; the real fix is still
-open. This doc is self-contained so a fresh session can pick it up.
+**Status: RESOLVED** (provenance fix, Option 1). The interim disk-only heal has
+been superseded by a full live fix; the bug description and root cause below are
+retained as the record. See **Resolution (shipped)** for what landed and why.
+
+## Resolution (shipped)
+
+Implemented Option 1 (write provenance), `system:<userId>` author, across five
+commits:
+
+1. `system:<userId>` author helpers (`api/user.ts`: `systemAuthor` /
+   `isSystemAuthor`).
+2. `systemMint` insert-only opt on `tx.create` / `tx.createOrGet`
+   (`TxInsertOpts`), with same-tx author inheritance (a per-tx id set so the
+   `addTypeInTx` / `setProperty` shaping a mint does inherits the system author
+   instead of promoting the row to a real edit).
+3. Marked every speculative deterministic-id mint site (`stateBlocks`,
+   `kernelPage`, journal / daily-note / daily-note seat, alias seats via the
+   shared `createOrRestoreTargetBlock`, shortcuts). Roam import and
+   `ensureLocalPersonalWorkspace` deliberately NOT marked.
+4. Provenance-aware reconcile gate: a non-pending strictly-newer local row
+   yields to the server iff it's THIS client's own system mint
+   (`updated_by === systemAuthor(currentUserId)`); a real edit keeps
+   strictly-newer protection (replay-safe). Plus a `healing` gate mode and
+   `healWorkspace`, wired into `scheduleReconcileRescan`, so pre-provenance
+   (real-user-stamped) shadows still un-shadow on upgrade.
+5. Live cache heal: `BlockCache.applyFromSync(after, before)` force-applies the
+   server row when the cache still matches the pre-write disk row, so the heal
+   is in-session (no reload). Freeze-safe because replay is skip-staled at the
+   disk gate before it reaches the cache.
+
+Key decisions made during implementation:
+
+- **`system:` marker lives ONLY on `updated_by`, not `created_by`.** `updated_by`
+  is the field the gate reads and that self-clears on the first edit (it's
+  restamped every write); `created_by` stays the real user so it remains a
+  trustworthy identity and `created_by = X` queries stay clean. The marker is
+  contained to the one column that structurally needs it.
+- **Per-user derivation** (`system:<userId>`, not a global sentinel): keeps the
+  mint attributable (history/SQL show which client minted it), makes the
+  reserved namespace collision-safe (real ids are UUIDs), and lets the gate
+  exact-match THIS client's own mint.
+- **No server-side blocker**: the `blocks_write` RLS policy gates on
+  workspace-writer membership only — it never compares `created_by`/`updated_by`
+  to `auth.uid()` — and `apply_block_patches` is `SECURITY INVOKER` and passes
+  the author through. So `system:<userId>` uploads fine.
+- The original `tentative`-flag / props_json-flag / separate-column alternatives
+  were re-evaluated and rejected: each re-introduces a promote-on-edit step,
+  because only `updated_by` tracks "not yet user-edited" for free.
+
+---
+
+## Original investigation (retained)
+
+The sections below are the pre-fix handoff, kept for the record.
 
 ## The bug
 

--- a/src/data/api/tx.ts
+++ b/src/data/api/tx.ts
@@ -19,14 +19,15 @@ export interface TxWriteOpts {
  *  deliberately NOT on the shared {@link TxWriteOpts}: a row may only be
  *  born as a speculative engine default, never *promoted* into one by a
  *  later update — so `tx.update(..., {systemMint})` is a type error by
- *  construction. When set, the inserted row's `created_by` / `updated_by`
- *  are stamped with the current user's `system:<userId>` author (see
- *  `systemAuthor`), and same-tx follow-up writes to that row inherit the
- *  system authorship rather than promoting it to a real user edit — so the
- *  `addTypeInTx` / `setProperty` shaping every deterministic-id mint does
- *  stays pristine for the reconcile gate. The first real edit in a LATER
- *  tx promotes it. Ignored alongside `skipMetadata` (a system mint is not
- *  a metadata-skipping bookkeeping write). */
+ *  construction. When set, the inserted row's `updated_by` is stamped with
+ *  the current user's `system:<userId>` author (see `systemAuthor`);
+ *  `created_by` stays the real user (the prefix is contained to `updated_by`,
+ *  the gate's self-clearing signal). Same-tx follow-up writes to that row
+ *  inherit the system authorship rather than promoting it to a real user edit
+ *  — so the `addTypeInTx` / `setProperty` shaping every deterministic-id mint
+ *  does stays pristine for the reconcile gate. The first real edit in a LATER
+ *  tx promotes `updated_by`. Ignored alongside `skipMetadata` (a system mint
+ *  is not a metadata-skipping bookkeeping write). */
 export interface TxInsertOpts extends TxWriteOpts {
   systemMint?: boolean
 }

--- a/src/data/api/tx.ts
+++ b/src/data/api/tx.ts
@@ -15,6 +15,22 @@ export interface TxWriteOpts {
   skipMetadata?: boolean
 }
 
+/** Insert-only opts (`tx.create` / `tx.createOrGet`). `systemMint` is
+ *  deliberately NOT on the shared {@link TxWriteOpts}: a row may only be
+ *  born as a speculative engine default, never *promoted* into one by a
+ *  later update — so `tx.update(..., {systemMint})` is a type error by
+ *  construction. When set, the inserted row's `created_by` / `updated_by`
+ *  are stamped with the current user's `system:<userId>` author (see
+ *  `systemAuthor`), and same-tx follow-up writes to that row inherit the
+ *  system authorship rather than promoting it to a real user edit — so the
+ *  `addTypeInTx` / `setProperty` shaping every deterministic-id mint does
+ *  stays pristine for the reconcile gate. The first real edit in a LATER
+ *  tx promotes it. Ignored alongside `skipMetadata` (a system mint is not
+ *  a metadata-skipping bookkeeping write). */
+export interface TxInsertOpts extends TxWriteOpts {
+  systemMint?: boolean
+}
+
 /** Tx metadata exposed to mutators / processor `apply` bodies.
  *  - `txId` — uuid for this tx; written into `command_events.tx_id` and
  *    every `row_events.tx_id` for this tx.
@@ -69,7 +85,7 @@ export interface Tx {
    *  storage trigger's collapsed parent/workspace constraint can surface.
    *  Soft-deleted-parent is a kernel-mutator UX rule and does NOT fire on
    *  raw `tx.create` — see §4.7 Layer 1 (v4.30). */
-  create(data: NewBlockData, opts?: TxWriteOpts): Promise<string>
+  create(data: NewBlockData, opts?: TxInsertOpts): Promise<string>
 
   /** Insert OR fetch the live row at a deterministic id. **No tombstone
    *  resurrection in the primitive** — see §10.4. Throws
@@ -80,7 +96,7 @@ export interface Tx {
    *  The insert path uses the same parent preflight as `tx.create`. */
   createOrGet(
     data: NewBlockData & { id: string },
-    opts?: TxWriteOpts,
+    opts?: TxInsertOpts,
   ): Promise<{ id: string; inserted: boolean }>
 
   /** Soft-delete: sets `deleted = 1`. Fires the UPDATE trigger; row_events

--- a/src/data/api/user.test.ts
+++ b/src/data/api/user.test.ts
@@ -5,8 +5,10 @@ describe('system author', () => {
   // The namespace-safety property the whole provenance fix rests on: a
   // real user id (opaque UUID) must never read as a system author, and an
   // engine mint must always read back as one. The exact prefix string is
-  // an implementation detail not worth restating; these two invariants are
-  // the contract the reconcile gate and display surfaces depend on.
+  // an implementation detail not worth restating. `isSystemAuthor` is the
+  // *display*-side check (badge/hide automatic writes — see useUserPage /
+  // UpdateIndicator); the reconcile gate uses the stronger EXACT match
+  // against the current user's system author, not this predicate.
   it('round-trips a minted author and rejects a real user id', () => {
     const userId = '99b1b4e5-6f58-4fd2-9089-dc3b358dd4df'
     expect(isSystemAuthor(systemAuthor(userId))).toBe(true)

--- a/src/data/api/user.test.ts
+++ b/src/data/api/user.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isSystemAuthor, systemAuthor } from './user'
+
+describe('system author', () => {
+  // The namespace-safety property the whole provenance fix rests on: a
+  // real user id (opaque UUID) must never read as a system author, and an
+  // engine mint must always read back as one. The exact prefix string is
+  // an implementation detail not worth restating; these two invariants are
+  // the contract the reconcile gate and display surfaces depend on.
+  it('round-trips a minted author and rejects a real user id', () => {
+    const userId = '99b1b4e5-6f58-4fd2-9089-dc3b358dd4df'
+    expect(isSystemAuthor(systemAuthor(userId))).toBe(true)
+    expect(isSystemAuthor(userId)).toBe(false)
+  })
+
+  it('carries the originating user id so the mint stays attributable', () => {
+    // The derived-per-user design (vs a single global sentinel) exists so
+    // a mint remains traceable to the client that wrote it. Two users mint
+    // distinguishable authors for the same logical default.
+    expect(systemAuthor('alice')).not.toBe(systemAuthor('bob'))
+    expect(systemAuthor('alice').endsWith('alice')).toBe(true)
+  })
+
+  it('does not treat an empty author as a system author', () => {
+    // `skipMetadata` writes leave `updated_by` as '' — that's a bookkeeping
+    // write, not a system mint, and must not be mistaken for one.
+    expect(isSystemAuthor('')).toBe(false)
+  })
+})

--- a/src/data/api/user.ts
+++ b/src/data/api/user.ts
@@ -24,15 +24,17 @@ export interface User {
  *  user id (those are opaque UUIDs and never start with `system:`). */
 export const SYSTEM_AUTHOR_PREFIX = 'system:'
 
-/** The system author for a given user — the value written to
- *  `created_by` / `updated_by` on that user's client when it mints a
- *  speculative deterministic-id default. */
+/** The system author for a given user — the value written to `updated_by`
+ *  (NOT `created_by`) on that user's client when it mints a speculative
+ *  deterministic-id default. `created_by` stays the real user: the prefix is
+ *  contained to `updated_by`, the one field the gate reads and that
+ *  self-clears to the real user on the first edit. */
 export const systemAuthor = (userId: string): string => `${SYSTEM_AUTHOR_PREFIX}${userId}`
 
-/** True iff `author` is any client's system author (a `created_by` /
- *  `updated_by` value that was engine-minted, not a real user edit).
- *  Display surfaces use this to badge / hide automatic writes; the
- *  reconcile gate uses the stronger *exact* match against the current
- *  user's system author (only this client's own pristine mint yields). */
+/** True iff `author` is any client's system author (an `updated_by` value
+ *  that was engine-minted, not a real user edit). Display surfaces use this
+ *  to badge / hide automatic writes; the reconcile gate uses the stronger
+ *  *exact* match against the current user's system author (only this client's
+ *  own pristine mint yields). */
 export const isSystemAuthor = (author: string): boolean =>
   author.startsWith(SYSTEM_AUTHOR_PREFIX)

--- a/src/data/api/user.ts
+++ b/src/data/api/user.ts
@@ -6,3 +6,33 @@ export interface User {
   id: string
   name?: string
 }
+
+/** Author prefix for engine-minted speculative defaults — the
+ *  deterministic-id bootstrap rows (settings, ui-state, the user page,
+ *  kernel pages, daily-note seats, …). These are minted the moment a
+ *  deterministic-id row is read-as-absent, *before* the server's
+ *  authoritative version has materialized, so they must NOT outrank a
+ *  real-but-older synced row under wall-clock LWW. Stamping their
+ *  `updated_by` with this prefix is the conflict-resolution discriminator
+ *  the reconcile gate reads to let such a pristine default yield to the
+ *  server (see `decideStagingRow`).
+ *
+ *  Derived per-user (`system:<userId>`) rather than a single global
+ *  sentinel so the write stays attributable — which device/user's
+ *  bootstrap minted the row is still legible in `blocks_history` and in
+ *  plain SQL — and so the reserved namespace can't collide with a real
+ *  user id (those are opaque UUIDs and never start with `system:`). */
+export const SYSTEM_AUTHOR_PREFIX = 'system:'
+
+/** The system author for a given user — the value written to
+ *  `created_by` / `updated_by` on that user's client when it mints a
+ *  speculative deterministic-id default. */
+export const systemAuthor = (userId: string): string => `${SYSTEM_AUTHOR_PREFIX}${userId}`
+
+/** True iff `author` is any client's system author (a `created_by` /
+ *  `updated_by` value that was engine-minted, not a real user edit).
+ *  Display surfaces use this to badge / hide automatic writes; the
+ *  reconcile gate uses the stronger *exact* match against the current
+ *  user's system author (only this client's own pristine mint yields). */
+export const isSystemAuthor = (author: string): boolean =>
+  author.startsWith(SYSTEM_AUTHOR_PREFIX)

--- a/src/data/api/user.ts
+++ b/src/data/api/user.ts
@@ -20,8 +20,10 @@ export interface User {
  *  Derived per-user (`system:<userId>`) rather than a single global
  *  sentinel so the write stays attributable — which device/user's
  *  bootstrap minted the row is still legible in `blocks_history` and in
- *  plain SQL — and so the reserved namespace can't collide with a real
- *  user id (those are opaque UUIDs and never start with `system:`). */
+ *  plain SQL — and so it can't collide with a real author: no real *user
+ *  id* starts with `system:` (they're opaque UUIDs). (The `system:` prefix
+ *  is used elsewhere for built-in plugin/property ids, but those never land
+ *  in `created_by` / `updated_by`, so there's no overlap in this column.) */
 export const SYSTEM_AUTHOR_PREFIX = 'system:'
 
 /** The system author for a given user — the value written to `updated_by`

--- a/src/data/blockCache.ts
+++ b/src/data/blockCache.ts
@@ -47,6 +47,12 @@ export class BlockCacheMetrics {
    *  expected — every cached row re-read during a query resolves to
    *  a reject — and are essentially free (Map.get + comparison). */
   applyIfNewerHydrateRejected = 0
+  /** `applyFromSync` force-applies: a sync row the disk gate accepted that
+   *  replaced a cache snapshot still matching the pre-write disk row, even
+   *  though it was older-stamped (the in-session deterministic-id shadow
+   *  heal). A non-zero count on a fresh client confirms the live heal fired;
+   *  the rest of `applyFromSync` falls through to the `applyIfNewer` buckets. */
+  applyFromSyncForced = 0
   /** Total internal `notify(id)` invocations across all paths
    *  (setSnapshot writes, deleteSnapshot, markMissing, clearMissing).
    *  Counts the call, not the per-listener fan-out. */
@@ -60,6 +66,7 @@ export class BlockCacheMetrics {
     this.applyIfNewerSyncRejected = 0
     this.applyIfNewerHydrateCalls = 0
     this.applyIfNewerHydrateRejected = 0
+    this.applyFromSyncForced = 0
     this.notifies = 0
   }
 
@@ -74,6 +81,7 @@ export class BlockCacheMetrics {
       applyIfNewerSyncRejected: this.applyIfNewerSyncRejected,
       applyIfNewerHydrateCalls: this.applyIfNewerHydrateCalls,
       applyIfNewerHydrateRejected: this.applyIfNewerHydrateRejected,
+      applyFromSyncForced: this.applyFromSyncForced,
       notifies: this.notifies,
     })
   }
@@ -181,6 +189,36 @@ export class BlockCache {
       return false
     }
     return this.setSnapshot(snapshot)
+  }
+
+  /** Heal-aware sync write, used by the Layout B observer for rows the disk
+   *  gate ALREADY applied (server-wins — including the own-system-mint shadow
+   *  heal). Unlike `applyIfNewer`, this can land an OLDER-stamped row, but
+   *  only when the cache still matches the pre-write disk row (`before`) the
+   *  observer based its decision on. In that case the observer's `after` is
+   *  the authoritative successor, so it replaces the stale cache snapshot
+   *  LIVE (no reload) — which is what heals the deterministic-id shadow
+   *  in-session, where `applyIfNewer`'s LWW would reject the older value and
+   *  defer the heal to the next reload.
+   *
+   *  If the cache has DIVERGED from `before` (a local commit advanced it
+   *  between the observer's before-read and here), fall back to the LWW gate
+   *  so a newer local edit is never clobbered. This is safe against the
+   *  upload-window replay freeze: the disk gate skip-stales a strictly-newer
+   *  real edit BEFORE it enters the observer's snapshots, so a replay delivery
+   *  never reaches here — the force path only ever lands a genuine server-wins
+   *  heal, and waking handles for that one-time transition is correct. */
+  applyFromSync(after: BlockData, before: BlockData | null): boolean {
+    const existing = this.snapshots.get(after.id)
+    const cacheMatchesBefore =
+      before !== null &&
+      existing !== undefined &&
+      blockFingerprint(existing) === blockFingerprint(before)
+    if (cacheMatchesBefore) {
+      this.metrics.applyFromSyncForced++
+      return this.setSnapshot(after)
+    }
+    return this.applyIfNewer(after, 'sync')
   }
 
   deleteSnapshot(id: string): boolean {

--- a/src/data/globalState.ts
+++ b/src/data/globalState.ts
@@ -18,6 +18,7 @@ import { useUser } from '@/components/Login.js'
 import { useRepo } from '@/context/repo.js'
 import {
   ChangeScope,
+  isSystemAuthor,
   type PropertySchema,
   type TypeContribution,
 } from '@/data/api'
@@ -94,11 +95,18 @@ export function useUserPage(userId: string): {name: string; blockId?: string} {
   const workspaceId = requireWorkspaceId(repo, 'useUserPage')
   const id = userPageBlockId(workspaceId, userId)
   const block = repo.block(id)
-  return useHandle(block, {
+  const resolved = useHandle(block, {
     selector: doc => doc
       ? {name: doc.content || userId, blockId: id}
       : {name: userId},
   })
+  // A system author (`system:<userId>`, written to `updated_by` on a pristine
+  // deterministic-id mint) is not a user — render it as "System" with no link
+  // rather than leaking the raw prefixed id into attribution surfaces. (The
+  // useHandle subscription above runs unconditionally per the rules of hooks;
+  // its result is simply unused for system authors.)
+  if (isSystemAuthor(userId)) return {name: 'System'}
+  return resolved
 }
 
 /** Hook to access and modify a UI-state property on the active UI-state

--- a/src/data/internals/txEngine.ts
+++ b/src/data/internals/txEngine.ts
@@ -37,12 +37,14 @@ import type {
   SiblingAnchor,
   SiblingDirection,
   Tx,
+  TxInsertOpts,
   TxMeta,
   TxSource,
   TxWriteOpts,
   User,
 } from '@/data/api'
 import {
+  systemAuthor,
   BlockNotFoundError,
   CycleError,
   DeletedConflictError,
@@ -215,6 +217,16 @@ export class TxImpl implements Tx {
    *  (or first write candidate that the engine validated to insert). */
   private workspacePinned = false
 
+  /** Ids inserted in THIS tx via a `{systemMint: true}` create/createOrGet.
+   *  Same-tx follow-up writes (`update` / `setProperty` / `move` / …) to one
+   *  of these inherit the `system:<userId>` author instead of stamping the
+   *  real user — mirrors the upload compactor's same-tx CREATE+PATCH fusion
+   *  (`createTxId`), so the multi-write shaping a deterministic-id mint does
+   *  (content + alias prop + type marker) stays a single pristine system
+   *  default. Per-tx (the engine builds a fresh TxImpl per `repo.tx`), so it
+   *  never leaks across transactions. */
+  private readonly systemMintedIds = new Set<string>()
+
   constructor(ctx: TxImplContext) {
     this.ctx = ctx
     this.meta = ctx.meta
@@ -238,7 +250,7 @@ export class TxImpl implements Tx {
 
   // ──── Lifecycle ────
 
-  async create(data: NewBlockData, opts?: TxWriteOpts): Promise<string> {
+  async create(data: NewBlockData, opts?: TxInsertOpts): Promise<string> {
     this.checkWorkspace(data.workspaceId)
     await this.requireParentInWorkspace(data.parentId, data.workspaceId)
     const id = data.id ?? this.ctx.newId()
@@ -249,6 +261,7 @@ export class TxImpl implements Tx {
       if (isUniqueConstraint(e, 'blocks.id')) throw new DuplicateIdError(id)
       throw e
     }
+    this.markSystemMint(id, opts)
     this.pinWorkspace(data.workspaceId)
     recordWrite(this.ctx.snapshots, id, null, row)
     return id
@@ -256,7 +269,7 @@ export class TxImpl implements Tx {
 
   async createOrGet(
     data: NewBlockData & { id: string },
-    opts?: TxWriteOpts,
+    opts?: TxInsertOpts,
   ): Promise<{ id: string; inserted: boolean }> {
     this.checkWorkspace(data.workspaceId)
     const existing = await this.ctx.txDb.getOptional<BlockRow>(SELECT_BY_ID_SQL, [data.id])
@@ -265,6 +278,7 @@ export class TxImpl implements Tx {
       await this.requireParentInWorkspace(data.parentId, data.workspaceId)
       const row = this.buildNewBlockRow(data.id, data, opts)
       await this.ctx.txDb.execute(INSERT_SQL, blockToRowParams(row))
+      this.markSystemMint(data.id, opts)
       this.pinWorkspace(data.workspaceId)
       recordWrite(this.ctx.snapshots, data.id, null, row)
       return {id: data.id, inserted: true}
@@ -302,7 +316,7 @@ export class TxImpl implements Tx {
     const after: BlockData = {
       ...before,
       deleted: true,
-      ...this.metadataPatch(false),
+      ...this.metadataPatch(id, false),
     }
     await this.ctx.txDb.execute(
       `UPDATE blocks SET deleted = 1, updated_at = ?, updated_by = ? WHERE id = ?`,
@@ -327,7 +341,7 @@ export class TxImpl implements Tx {
       // see src/data/internals/normalizeReferencesProcessor.ts.
       ...(patch?.references !== undefined ? {references: patch.references} : {}),
       ...(patch?.properties !== undefined ? {properties: patch.properties} : {}),
-      ...this.metadataPatch(opts?.skipMetadata),
+      ...this.metadataPatch(id, opts?.skipMetadata),
     }
     await this.ctx.txDb.execute(
       `UPDATE blocks SET deleted = 0, content = ?, references_json = ?, properties_json = ?, updated_at = ?, updated_by = ? WHERE id = ?`,
@@ -356,7 +370,7 @@ export class TxImpl implements Tx {
       // See note on `restore` above re: same-tx normalization.
       ...(patch.references !== undefined ? {references: patch.references} : {}),
       ...(patch.properties !== undefined ? {properties: patch.properties} : {}),
-      ...this.metadataPatch(opts?.skipMetadata),
+      ...this.metadataPatch(id, opts?.skipMetadata),
     }
     await this.ctx.txDb.execute(
       `UPDATE blocks SET content = ?, references_json = ?, properties_json = ?, updated_at = ?, updated_by = ? WHERE id = ?`,
@@ -406,7 +420,7 @@ export class TxImpl implements Tx {
       ...before,
       parentId: target.parentId,
       orderKey: target.orderKey,
-      ...this.metadataPatch(opts?.skipMetadata),
+      ...this.metadataPatch(id, opts?.skipMetadata),
     }
     await this.ctx.txDb.execute(
       `UPDATE blocks SET parent_id = ?, order_key = ?, updated_at = ?, updated_by = ? WHERE id = ?`,
@@ -432,7 +446,7 @@ export class TxImpl implements Tx {
     const after: BlockData = {
       ...before,
       properties,
-      ...this.metadataPatch(opts?.skipMetadata),
+      ...this.metadataPatch(id, opts?.skipMetadata),
     }
     await this.ctx.txDb.execute(
       `UPDATE blocks SET properties_json = ?, updated_at = ?, updated_by = ? WHERE id = ?`,
@@ -695,26 +709,50 @@ export class TxImpl implements Tx {
     this.workspacePinned = true
   }
 
-  private metadataPatch(skipMetadata?: boolean): {
+  /** Record that `id` was just system-minted in this tx, so same-tx
+   *  follow-up writes inherit the system author (see `systemMintedIds`).
+   *  No-op unless `opts.systemMint` — and `systemMint` is insert-only at the
+   *  type level ({@link TxInsertOpts}), so this is only ever reached from
+   *  `create` / `createOrGet`. */
+  private markSystemMint(id: string, opts: TxInsertOpts | undefined): void {
+    if (opts?.systemMint) this.systemMintedIds.add(id)
+  }
+
+  /** The author to stamp on a write to `id`: the current user, unless the
+   *  row was system-minted in THIS tx, in which case follow-up writes
+   *  inherit the system author so the whole mint stays one pristine
+   *  default. */
+  private authorFor(id: string): string {
+    const userId = this.meta.user.id
+    return this.systemMintedIds.has(id) ? systemAuthor(userId) : userId
+  }
+
+  private metadataPatch(id: string, skipMetadata?: boolean): {
     updatedAt: number
     updatedBy: string
   } | Record<string, never> {
     if (skipMetadata) return {}
-    return {updatedAt: this.ctx.now(), updatedBy: this.meta.user.id}
+    return {updatedAt: this.ctx.now(), updatedBy: this.authorFor(id)}
   }
 
   /** Build a fresh BlockData for `tx.create` / `tx.createOrGet` insert
    *  paths. Engine sets all four metadata columns from tx_context unless
-   *  `opts.skipMetadata` (used only by bookkeeping writes). */
+   *  `opts.skipMetadata` (used only by bookkeeping writes). `opts.systemMint`
+   *  stamps the system author on `created_by` / `updated_by` so the row is
+   *  born as a speculative default the reconcile gate can let yield. */
   private buildNewBlockRow(
     id: string,
     data: NewBlockData,
-    opts: TxWriteOpts | undefined,
+    opts: TxInsertOpts | undefined,
   ): BlockData {
     const now = this.ctx.now()
     const userId = this.meta.user.id
     const ts = opts?.skipMetadata ? 0 : now
-    const by = opts?.skipMetadata ? '' : userId
+    const by = opts?.skipMetadata
+      ? ''
+      : opts?.systemMint
+        ? systemAuthor(userId)
+        : userId
     return {
       id,
       workspaceId: data.workspaceId,

--- a/src/data/internals/txEngine.ts
+++ b/src/data/internals/txEngine.ts
@@ -737,9 +737,16 @@ export class TxImpl implements Tx {
 
   /** Build a fresh BlockData for `tx.create` / `tx.createOrGet` insert
    *  paths. Engine sets all four metadata columns from tx_context unless
-   *  `opts.skipMetadata` (used only by bookkeeping writes). `opts.systemMint`
-   *  stamps the system author on `created_by` / `updated_by` so the row is
-   *  born as a speculative default the reconcile gate can let yield. */
+   *  `opts.skipMetadata` (used only by bookkeeping writes).
+   *
+   *  `opts.systemMint` marks the row as a speculative default the reconcile
+   *  gate can let yield — but ONLY on `updated_by`, not `created_by`. The
+   *  `system:` prefix is load-bearing on `updated_by` (the field the gate
+   *  reads, restamped on every write, so it self-clears to the real user on
+   *  the first edit). `created_by` is pure identity/ownership — always the
+   *  real user, so it stays a trustworthy user id for every consumer and
+   *  "blocks created by X" is a clean `created_by = X`. Containing the prefix
+   *  to the one column that needs it keeps it out of creator attribution. */
   private buildNewBlockRow(
     id: string,
     data: NewBlockData,
@@ -748,7 +755,8 @@ export class TxImpl implements Tx {
     const now = this.ctx.now()
     const userId = this.meta.user.id
     const ts = opts?.skipMetadata ? 0 : now
-    const by = opts?.skipMetadata
+    const createdBy = opts?.skipMetadata ? '' : userId
+    const updatedBy = opts?.skipMetadata
       ? ''
       : opts?.systemMint
         ? systemAuthor(userId)
@@ -766,8 +774,8 @@ export class TxImpl implements Tx {
       references: data.references ?? [],
       createdAt: ts,
       updatedAt: ts,
-      createdBy: by,
-      updatedBy: by,
+      createdBy,
+      updatedBy,
       deleted: false,
     }
   }

--- a/src/data/kernelPage.ts
+++ b/src/data/kernelPage.ts
@@ -98,7 +98,7 @@ export const getOrCreateKernelPage = async (
       parentId: null,
       orderKey,
       content: spec.alias,
-    })
+    }, {systemMint: true})
     await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: aliases}, typeSnapshot)
     await repo.addTypeInTx(tx, id, spec.markerType, {[aliasesProp.name]: aliases}, typeSnapshot)
   }, {scope: ChangeScope.BlockDefault})

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -381,12 +381,15 @@ export interface RepoOptions {
   startSyncObserver?: boolean
   /** Options forwarded to the sync observer when started. */
   syncObserverOptions?: SyncObserverOptions
-  /** Layout B materialization deps — the §6 mode/key resolver (getCek +
+  /** Layout B materialization POLICY — the §6 mode/key resolver (getCek +
    *  getMaterializability). Production (initRepo) passes the real resolver so
    *  e2ee rows decrypt, plaintext copies through, and locked/unpinned
    *  workspaces defer. Omitted in tests, which fall back to the plaintext
-   *  copy-through stub below (no key). */
-  syncObserverDeps?: MaterializeDeps
+   *  copy-through stub below (no key). The remaining materialization input —
+   *  `currentUserId`, which the reconcile gate needs to recognize this
+   *  client's own system mints — is the Repo's own identity (`this.user.id`),
+   *  injected in `startSyncObserver`, not supplied by the caller. */
+  syncObserverDeps?: Omit<MaterializeDeps, 'currentUserId'>
 }
 
 /** Repo-level knobs for the Layout B sync observer. `db` / `cache` /
@@ -676,8 +679,9 @@ export class Repo {
    *  created on first start, replaced on subsequent starts. Tests can
    *  `dispose()` and re-`start` for deterministic flushing. */
   private syncObserver: BlocksSyncedObserver | null = null
-  /** §6 mode/key resolver for the observer (undefined ⇒ plaintext stub). */
-  private readonly syncObserverDeps?: MaterializeDeps
+  /** §6 mode/key resolver for the observer (undefined ⇒ plaintext stub).
+   *  Policy only — `currentUserId` is injected from `this.user.id` at start. */
+  private readonly syncObserverDeps?: Omit<MaterializeDeps, 'currentUserId'>
   /** Backing field for `activeWorkspaceId` (see getter/setter below). */
   private _activeWorkspaceId: string | null = null
   /** Instance discriminator for memoization keys that need to vary
@@ -901,9 +905,14 @@ export class Repo {
       handleStore: this.handleStore,
       // Production passes the §6 mode/key resolver (initRepo). Tests omit it
       // and fall back to plaintext copy-through with no key — the historical
-      // behavior, so non-e2ee tests are unaffected.
-      deps: this.syncObserverDeps
-        ?? { getMaterializability: (): Materializability => 'copy', getCek: async () => null },
+      // behavior, so non-e2ee tests are unaffected. The Repo injects its own
+      // identity (`currentUserId`) — the gate needs it to recognize this
+      // client's own system mints — so callers supply policy only.
+      deps: {
+        ...(this.syncObserverDeps
+          ?? { getMaterializability: (): Materializability => 'copy', getCek: async () => null }),
+        currentUserId: this.user.id,
+      },
       getInvalidationRules: () => this.invalidationRules,
       onCycleDetected: options?.onCycleDetected,
       throttleMs: options?.throttleMs,
@@ -934,6 +943,17 @@ export class Repo {
    *  if the observer isn't running. */
   async drainSyncWorkspace(workspaceId: string): Promise<void> {
     if (this.syncObserver) await this.syncObserver.drainWorkspace(workspaceId)
+  }
+
+  /** One-time recovery re-materialization: re-reads `blocks_synced` directly
+   *  and re-applies the reconcile gate in `healing` mode, so a pre-provenance
+   *  shadow — a default minted by code that stamped the real user, which the
+   *  steady-state strict gate would now PROTECT as if it were an edit — still
+   *  yields to the server. Used only by `scheduleReconcileRescan`; steady-state
+   *  drains use `drainSyncWorkspace` (strict). No-op if the observer isn't
+   *  running. */
+  async healSyncWorkspace(workspaceId: string): Promise<void> {
+    if (this.syncObserver) await this.syncObserver.healWorkspace(workspaceId)
   }
 
   /** Frozen snapshot of internal data-layer counters + timings
@@ -1905,15 +1925,27 @@ export class Repo {
 
   /**
    * One-time post-upgrade recovery for the deterministic-id shadow bug. A client
-   * that skip-staled the server's authoritative row under the *old* reconcile
+   * that skip-staled the server's authoritative row under an *old* reconcile
    * gate consumed its `blocks_synced_changes` entry, so a normal queue-driven
    * drain never re-evaluates it — the shadow persists across reloads. This
-   * re-runs `drainWorkspace`, which re-reads `blocks_synced` DIRECTLY (bypassing
-   * the consumed queue) and re-applies the relaxed gate, healing the shadow on
-   * disk. Marker-gated to run at most once per (workspace, client); deferred off
-   * the open path; windowed + resumable (drainWorkspace) and idempotent (a
-   * settled workspace re-scans to no-ops). The live cache still holds the stale
-   * default this session — it rehydrates from the healed disk on next reload.
+   * re-runs the materialization for the workspace via `healWorkspace`, which
+   * re-reads `blocks_synced` DIRECTLY (bypassing the consumed queue) and
+   * re-applies the gate in HEALING mode, un-shadowing the server's value on disk.
+   *
+   * Healing (not strict) mode is essential here: a shadow minted by
+   * pre-provenance code is stamped with the real user, so the steady-state
+   * strict gate would now PROTECT it as a real edit and re-permanent it. Healing
+   * mode lets the server win on any strictly-newer non-pending row (the interim
+   * rule), while the pending + equal-stamp guards still hold — so an unsent edit
+   * is never lost. This also covers clients that upgrade straight from a
+   * pre-interim build (no `reconcile_rescan` marker yet) past the provenance
+   * build in one step.
+   *
+   * Marker-gated to run at most once per (workspace, client); deferred off the
+   * open path; windowed + resumable (healWorkspace) and idempotent (a settled
+   * workspace re-scans to no-ops). The live cache still holds the stale default
+   * this session — it rehydrates from the healed disk on next reload (the live
+   * cache heal is a separate path).
    *
    * Call after the access gate (a locked/unverified workspace must not be
    * re-materialized here — its own gate-resolution path runs drainWorkspace).
@@ -1938,9 +1970,9 @@ export class Repo {
     const done = await this.db.getOptional<{key: string}>(SELECT_RECONCILE_RESCAN_MARKER_SQL, [key])
     if (done) return
     try {
-      await this.drainSyncWorkspace(workspaceId)
+      await this.healSyncWorkspace(workspaceId)
       // Marker only after a clean pass — a thrown/interrupted re-scan leaves it
-      // unset so the next open retries (drainWorkspace is resumable + idempotent).
+      // unset so the next open retries (healWorkspace is resumable + idempotent).
       await this.db.execute(RECORD_RECONCILE_RESCAN_MARKER_SQL, [key])
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)

--- a/src/data/stateBlocks.ts
+++ b/src/data/stateBlocks.ts
@@ -166,7 +166,7 @@ const ensureStateChild = async (
       orderKey: 'a0',
       content: displayContent,
       properties: initialProperties,
-    })
+    }, {systemMint: true})
     if (type) {
       await repo.addTypeInTx(tx, childId, type.id, {}, typeSnapshot)
     }
@@ -286,7 +286,7 @@ export const getUserBlock = memoize(
         parentId: null,
         orderKey: 'a0',
         content: displayName,
-      })
+      }, {systemMint: true})
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: aliases}, typeSnapshot)
       await repo.addTypeInTx(tx, id, USER_TYPE, {[userIdProp.name]: user.id}, typeSnapshot)
     }, {scope: ChangeScope.UserPrefs})

--- a/src/data/targets.ts
+++ b/src/data/targets.ts
@@ -68,11 +68,20 @@ export interface CreateOrRestoreArgs {
   orderKey: string
   /** Applied on both insert and restore. */
   freshContent: string
+  /** Mint the row as a speculative engine default (`system:<userId>`
+   *  author) so it yields to an older-but-authoritative server row under
+   *  the reconcile gate. Applies to the INSERT path only — a tombstone
+   *  restore is an update and stays user-authored (create-only, per
+   *  TxInsertOpts). Seat materializers (alias / daily-note seats,
+   *  shortcuts) set this; content-bearing creators (Roam import, which
+   *  uses its own tx.create, not this primitive) do not. */
+  systemMint?: boolean
   /** Optional callback invoked after the row is inserted OR restored
    *  (NOT on the live-row-hit path). Used by per-domain wrappers to
    *  write properties (e.g. the alias list via tx.setProperty) that
    *  need codec encoding. The callback runs synchronously inside the
-   *  outer tx; awaitable. */
+   *  outer tx; awaitable. On the insert path, these same-tx writes
+   *  inherit the system author when `systemMint` is set. */
   onInsertedOrRestored?: (tx: Tx, id: string) => Promise<void> | void
 }
 
@@ -89,7 +98,7 @@ export const createOrRestoreTargetBlock = async (
       parentId: args.parentId,
       orderKey: args.orderKey,
       content: args.freshContent,
-    })
+    }, {systemMint: args.systemMint})
     if (result.inserted && args.onInsertedOrRestored) {
       await args.onInsertedOrRestored(tx, args.id)
     }
@@ -374,6 +383,9 @@ export const ensureAliasTarget = async (
     parentId: null,
     orderKey: keyAtEnd(),
     freshContent: seed.content,
+    // A freshly-probed alias seat is a speculative default: if the server
+    // already has a real page for this alias, the local seat must yield.
+    systemMint: true,
     // The setProperty + addTypeInTx pair below must produce exactly
     // `seed.properties` on disk; the `ensureAliasTarget writes the seed
     // shape` test in targets.test.ts asserts this and is the contract

--- a/src/data/test/blockCache.test.ts
+++ b/src/data/test/blockCache.test.ts
@@ -220,6 +220,48 @@ describe('BlockCache applyIfNewer (LWW)', () => {
   })
 })
 
+describe('BlockCache applyFromSync (heal-aware sync write)', () => {
+  it('force-applies an OLDER row when the cache still matches the pre-write disk row', () => {
+    // The live shadow heal: cache holds a now-stamped default; the observer
+    // applied the older server row to disk and passes the default as `before`.
+    // Because the cache still equals `before`, the older `after` replaces it.
+    const cache = new BlockCache()
+    const staleDefault = snap({content: 'default', updatedAt: 9000})
+    cache.setSnapshot(staleDefault)
+
+    const healed = cache.applyFromSync(snap({content: 'real config', updatedAt: 3000}), staleDefault)
+
+    expect(healed).toBe(true)
+    expect(cache.getSnapshot('block-1')?.content).toBe('real config')
+    expect(cache.metrics.applyFromSyncForced).toBe(1)
+  })
+
+  it('falls back to LWW (no clobber) when the cache has diverged from before', () => {
+    // A local commit advanced the cache past `before` after the observer read
+    // it. The older `after` must NOT clobber the newer local edit — fall back
+    // to the LWW gate, which rejects it.
+    const cache = new BlockCache()
+    const before = snap({content: 'default', updatedAt: 9000})
+    cache.setSnapshot(snap({content: 'local edit', updatedAt: 12000})) // cache moved on
+
+    const out = cache.applyFromSync(snap({content: 'older server', updatedAt: 3000}), before)
+
+    expect(out).toBe(false)
+    expect(cache.getSnapshot('block-1')?.content).toBe('local edit')
+    expect(cache.metrics.applyFromSyncForced).toBe(0)
+  })
+
+  it('falls back to LWW for a first-seen row (before is null)', () => {
+    // No pre-write disk row: nothing to "match", so this is an ordinary
+    // newer-wins sync write through the LWW gate.
+    const cache = new BlockCache()
+    const out = cache.applyFromSync(snap({content: 'fresh', updatedAt: 100}), null)
+    expect(out).toBe(true)
+    expect(cache.getSnapshot('block-1')?.content).toBe('fresh')
+    expect(cache.metrics.applyFromSyncForced).toBe(0)
+  })
+})
+
 describe('BlockCache trackedIds', () => {
   it('returns the set of subscribed ids', () => {
     const cache = new BlockCache()
@@ -382,6 +424,7 @@ describe('BlockCache metrics counters', () => {
       applyIfNewerSyncRejected: 0,
       applyIfNewerHydrateCalls: 0,
       applyIfNewerHydrateRejected: 0,
+      applyFromSyncForced: 0,
       notifies: 0,
     })
   })

--- a/src/data/test/repoLifecycle.test.ts
+++ b/src/data/test/repoLifecycle.test.ts
@@ -248,7 +248,8 @@ describe('repo.scheduleReconcileRescan — one-time shadow recovery', () => {
   }
 
   it('re-scans a workspace once, marks it done, and no-ops on the next open', async () => {
-    const spy = vi.spyOn(env.repo, 'drainSyncWorkspace').mockResolvedValue()
+    // The rescan heals (not strict drains) so pre-provenance shadows still yield.
+    const spy = vi.spyOn(env.repo, 'healSyncWorkspace').mockResolvedValue()
 
     env.repo.scheduleReconcileRescan('ws-1')
     await settle(env.repo)
@@ -262,7 +263,7 @@ describe('repo.scheduleReconcileRescan — one-time shadow recovery', () => {
   })
 
   it('re-scans each workspace independently (per-workspace marker)', async () => {
-    const spy = vi.spyOn(env.repo, 'drainSyncWorkspace').mockResolvedValue()
+    const spy = vi.spyOn(env.repo, 'healSyncWorkspace').mockResolvedValue()
 
     env.repo.scheduleReconcileRescan('ws-1')
     await settle(env.repo)
@@ -273,7 +274,7 @@ describe('repo.scheduleReconcileRescan — one-time shadow recovery', () => {
   })
 
   it('leaves the marker unset on failure so the next open retries', async () => {
-    const spy = vi.spyOn(env.repo, 'drainSyncWorkspace')
+    const spy = vi.spyOn(env.repo, 'healSyncWorkspace')
       .mockRejectedValueOnce(new Error('drain failed'))
       .mockResolvedValue()
     vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/data/test/systemMint.test.ts
+++ b/src/data/test/systemMint.test.ts
@@ -2,15 +2,17 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { Repo } from '../repo'
 import { BlockCache } from '../blockCache'
 import { ChangeScope, systemAuthor } from '../api'
+import { createOrRestoreTargetBlock } from '../targets'
 import { createTestDb, resetTestDb, type TestDb } from './createTestDb'
 
 /**
  * Write-side provenance: `tx.create` / `tx.createOrGet` with `{systemMint:
- * true}` stamp `created_by` / `updated_by` as the current user's system
- * author, and same-tx follow-up writes (the `addTypeInTx` / `setProperty`
- * shaping every deterministic-id mint does) inherit that authorship instead
- * of promoting the row back to a real user edit. The first real edit in a
- * LATER tx promotes it. This is the discriminator the reconcile gate reads.
+ * true}` stamp `updated_by` (NOT `created_by`, which stays the real user) as
+ * the current user's system author, and same-tx follow-up writes (the
+ * `addTypeInTx` / `setProperty` shaping every deterministic-id mint does)
+ * inherit that authorship instead of promoting the row back to a real user
+ * edit. The first real edit in a LATER tx promotes `updated_by`. This is the
+ * discriminator the reconcile gate reads.
  */
 describe('systemMint authorship', () => {
   const USER = 'user-1'
@@ -87,5 +89,41 @@ describe('systemMint authorship', () => {
     // user all along (the row's owner never changed).
     expect(row?.updatedBy).toBe(USER)
     expect(row?.createdBy).toBe(USER)
+  })
+
+  it('does NOT inherit system authorship on a createOrGet live-hit', async () => {
+    // markSystemMint fires only on a real INSERT. A createOrGet that hits a
+    // live row must not mark it, or a same-tx edit would demote a real user's
+    // row to system: and let the gate yield it to the server. Guards against a
+    // refactor that marks the row before the insert/live branch.
+    await create('exists') // plain user-authored row
+    await repo.tx(async tx => {
+      const result = await tx.createOrGet(
+        {id: 'exists', workspaceId: 'ws', parentId: null, orderKey: 'a0', content: 'x'},
+        {systemMint: true},
+      )
+      expect(result.inserted).toBe(false) // live hit, no insert
+      await tx.update('exists', {content: 'edited'})
+    }, {scope: ChangeScope.BlockDefault})
+    expect((await repo.load('exists'))?.updatedBy).toBe(USER)
+  })
+
+  it('a tombstone restore stays user-authored even via the systemMint primitive', async () => {
+    // createOrRestoreTargetBlock's tombstone branch restores via tx.restore,
+    // which is an UPDATE — systemMint is insert-only, so a RESTORED seat is NOT
+    // a system mint. This is deliberate (the restore-door is a separate, narrower
+    // concern); pin it so a future "make restore inherit the mint author" change
+    // — which would re-introduce shadow-on-restore — fails loudly here.
+    const seat = {id: 'seat', workspaceId: 'ws', parentId: null, orderKey: 'a0', freshContent: 's', systemMint: true}
+    await repo.tx(async tx => { await createOrRestoreTargetBlock(tx, seat) }, {scope: ChangeScope.BlockDefault})
+    expect((await repo.load('seat'))?.updatedBy).toBe(SYS) // born a system mint
+
+    await repo.tx(async tx => { await tx.delete('seat') }, {scope: ChangeScope.BlockDefault})
+    const restored = await repo.tx(
+      async tx => createOrRestoreTargetBlock(tx, seat),
+      {scope: ChangeScope.BlockDefault},
+    )
+    expect(restored.inserted).toBe(true) // restore counts as "this tx wrote it"
+    expect((await repo.load('seat'))?.updatedBy).toBe(USER) // restored ⇒ user, not system
   })
 })

--- a/src/data/test/systemMint.test.ts
+++ b/src/data/test/systemMint.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { Repo } from '../repo'
+import { BlockCache } from '../blockCache'
+import { ChangeScope, systemAuthor } from '../api'
+import { createTestDb, resetTestDb, type TestDb } from './createTestDb'
+
+/**
+ * Write-side provenance: `tx.create` / `tx.createOrGet` with `{systemMint:
+ * true}` stamp `created_by` / `updated_by` as the current user's system
+ * author, and same-tx follow-up writes (the `addTypeInTx` / `setProperty`
+ * shaping every deterministic-id mint does) inherit that authorship instead
+ * of promoting the row back to a real user edit. The first real edit in a
+ * LATER tx promotes it. This is the discriminator the reconcile gate reads.
+ */
+describe('systemMint authorship', () => {
+  const USER = 'user-1'
+  const SYS = systemAuthor(USER)
+  let sharedDb: TestDb
+  let repo: Repo
+
+  beforeAll(async () => { sharedDb = await createTestDb() })
+  afterAll(async () => { await sharedDb.cleanup() })
+  beforeEach(async () => {
+    await resetTestDb(sharedDb.db)
+    repo = new Repo({db: sharedDb.db, cache: new BlockCache(), user: {id: USER}, startSyncObserver: false})
+  })
+  afterEach(() => { repo.stopSyncObserver() })
+
+  const create = (id: string, opts?: {systemMint?: boolean}) =>
+    repo.tx(async tx => {
+      await tx.create(
+        {id, workspaceId: 'ws', parentId: null, orderKey: 'a0', content: 'x'},
+        opts,
+      )
+    }, {scope: ChangeScope.BlockDefault})
+
+  it('stamps a plain create with the real user', async () => {
+    await create('plain')
+    const row = await repo.load('plain')
+    expect(row?.updatedBy).toBe(USER)
+    expect(row?.createdBy).toBe(USER)
+  })
+
+  it('stamps a systemMint create with the system author', async () => {
+    await create('mint', {systemMint: true})
+    const row = await repo.load('mint')
+    expect(row?.updatedBy).toBe(SYS)
+    expect(row?.createdBy).toBe(SYS)
+  })
+
+  it('stamps a systemMint createOrGet insert with the system author', async () => {
+    await repo.tx(async tx => {
+      await tx.createOrGet(
+        {id: 'cog', workspaceId: 'ws', parentId: null, orderKey: 'a0', content: 'x'},
+        {systemMint: true},
+      )
+    }, {scope: ChangeScope.BlockDefault})
+    const row = await repo.load('cog')
+    expect(row?.updatedBy).toBe(SYS)
+  })
+
+  it('keeps same-tx follow-up writes on a system mint system-authored', async () => {
+    // The realistic mint shape: create the row, then shape it (set content,
+    // a property) in the SAME tx. Without inheritance the follow-up write
+    // would stamp the real user and defeat the discriminator.
+    await repo.tx(async tx => {
+      await tx.createOrGet(
+        {id: 'seat', workspaceId: 'ws', parentId: null, orderKey: 'a0', content: 'seed'},
+        {systemMint: true},
+      )
+      await tx.update('seat', {content: 'shaped'})
+    }, {scope: ChangeScope.BlockDefault})
+    const row = await repo.load('seat')
+    expect(row?.content).toBe('shaped')
+    expect(row?.updatedBy).toBe(SYS)
+  })
+
+  it('promotes to the real user on the first edit in a later tx', async () => {
+    await create('mint2', {systemMint: true})
+    await repo.tx(async tx => {
+      await tx.update('mint2', {content: 'user-edit'})
+    }, {scope: ChangeScope.BlockDefault})
+    const row = await repo.load('mint2')
+    expect(row?.updatedBy).toBe(USER)
+    // created_by is immutable — the mint provenance is still legible there.
+    expect(row?.createdBy).toBe(SYS)
+  })
+})

--- a/src/data/test/systemMint.test.ts
+++ b/src/data/test/systemMint.test.ts
@@ -41,11 +41,13 @@ describe('systemMint authorship', () => {
     expect(row?.createdBy).toBe(USER)
   })
 
-  it('stamps a systemMint create with the system author', async () => {
+  it('stamps a systemMint create: system updated_by, real-user created_by', async () => {
+    // The `system:` marker is contained to updated_by (the gate's self-clearing
+    // signal). created_by stays the real user — pure identity/ownership.
     await create('mint', {systemMint: true})
     const row = await repo.load('mint')
     expect(row?.updatedBy).toBe(SYS)
-    expect(row?.createdBy).toBe(SYS)
+    expect(row?.createdBy).toBe(USER)
   })
 
   it('stamps a systemMint createOrGet insert with the system author', async () => {
@@ -75,14 +77,15 @@ describe('systemMint authorship', () => {
     expect(row?.updatedBy).toBe(SYS)
   })
 
-  it('promotes to the real user on the first edit in a later tx', async () => {
+  it('promotes updated_by to the real user on the first edit in a later tx', async () => {
     await create('mint2', {systemMint: true})
     await repo.tx(async tx => {
       await tx.update('mint2', {content: 'user-edit'})
     }, {scope: ChangeScope.BlockDefault})
     const row = await repo.load('mint2')
+    // updated_by self-clears on the first real edit; created_by was the real
+    // user all along (the row's owner never changed).
     expect(row?.updatedBy).toBe(USER)
-    // created_by is immutable — the mint provenance is still legible there.
-    expect(row?.createdBy).toBe(SYS)
+    expect(row?.createdBy).toBe(USER)
   })
 })

--- a/src/plugins/daily-notes/dailyNotes.ts
+++ b/src/plugins/daily-notes/dailyNotes.ts
@@ -140,7 +140,7 @@ export const getOrCreateJournalBlock = async (
       parentId: null,
       orderKey: 'a0',
       content: JOURNAL_ALIAS,
-    })
+    }, {systemMint: true})
     await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: JOURNAL_ALIASES}, typeSnapshot)
   }, {scope: ChangeScope.BlockDefault})
 
@@ -240,7 +240,7 @@ export const getOrCreateDailyNote = async (
       parentId: journal.id,
       orderKey,
       content: longLabel,
-    })
+    }, {systemMint: true})
     await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: dailyAliases}, typeSnapshot)
     await repo.addTypeInTx(
       tx, id, DAILY_NOTE_TYPE,
@@ -314,6 +314,10 @@ export const ensureDailyNoteTarget = async (
     parentId: null,
     orderKey: keyAtEnd(),
     freshContent: date,
+    // A daily-note seat materialized from a reference is a speculative
+    // default — it must yield to a real daily-note row the server already
+    // has for this date.
+    systemMint: true,
     onInsertedOrRestored: async (tx, id) => {
       await tx.setProperty(id, aliasesProp, [date])
       await repo.addTypeInTx(tx, id, PAGE_TYPE, {[aliasesProp.name]: [date]}, typeSnapshot)

--- a/src/plugins/left-sidebar/shortcuts.ts
+++ b/src/plugins/left-sidebar/shortcuts.ts
@@ -50,6 +50,7 @@ export const getOrCreateShortcutsBlock = memoize(
         parentId: userBlock.id,
         orderKey: keyAtEnd(siblings.at(-1)?.orderKey ?? null),
         freshContent: SHORTCUTS_BLOCK_CONTENT,
+        systemMint: true,
       })
 
       // Only seed default children on first creation / restore of the
@@ -63,6 +64,7 @@ export const getOrCreateShortcutsBlock = memoize(
         parentId: shortcutsId,
         orderKey: keyAtEnd(),
         freshContent: JOURNAL_SHORTCUT_CONTENT,
+        systemMint: true,
         onInsertedOrRestored: async (tx, id) => {
           await tx.update(id, {
             references: [{id: journal.id, alias: JOURNAL_SHORTCUT_ALIAS}],

--- a/src/plugins/update-indicator/UpdateIndicator.tsx
+++ b/src/plugins/update-indicator/UpdateIndicator.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { isSystemAuthor } from '@/data/api'
 import { Block } from '../../data/block'
 import { useInFocus, usePluginPrefsProperty, useUserPage } from '@/data/globalState'
 import { useUpdateMetadata } from '@/hooks/block.js'
@@ -19,7 +20,11 @@ export const UpdateIndicator = ({block}: { block: Block }) => {
 
   if (!updateInfo) return null
 
+  // A pristine deterministic-id mint is authored `system:<self>` until the
+  // first real edit. That is not "another user" — don't raise the indicator
+  // for it (and `system:<self> !== self` would otherwise read as one).
   const updatedByOtherUser = updateInfo.updatedBy !== block.repo.user.id
+    && !isSystemAuthor(updateInfo.updatedBy)
     && updateInfo.updatedAt > (previousLoadTime ?? 0)
   const shouldShowUpdateIndicator = updatedByOtherUser && !seen
 

--- a/src/sync/observer/cutoverParity.test.ts
+++ b/src/sync/observer/cutoverParity.test.ts
@@ -96,7 +96,7 @@ const stageAndMaterialize = async (db: TestDb['db'], b: BlockData) => {
   return materializeStagingRows(
     db,
     { upserted: [b.id], removed: [] },
-    { getMaterializability: constMat('copy'), getCek: noKey },
+    { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: 'user-1' },
   )
 }
 
@@ -153,7 +153,7 @@ describe('cutover parity — plaintext block: observer path vs a direct blocks w
     const out = await materializeStagingRows(
       obs.db,
       { upserted: [], removed: [block.id] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: 'user-1' },
     )
     expect(out.deleted).toEqual([block.id])
 

--- a/src/sync/observer/invalidate.test.ts
+++ b/src/sync/observer/invalidate.test.ts
@@ -74,6 +74,8 @@ describe('applySyncInvalidation', () => {
     cache.applyIfNewer(block({ content: 'newer', updatedAt: 5000 }), 'sync')
     const handle = target()
 
+    // `before: null` ⇒ applyFromSync can't force; it falls back to LWW, which
+    // rejects the older delivery.
     const stale = block({ content: 'older', updatedAt: 2000 })
     const out = applySyncInvalidation(cache, handle, snapshots({ b1: { before: null, after: stale } }))
 
@@ -81,6 +83,27 @@ describe('applySyncInvalidation', () => {
     expect(cache.getSnapshot('b1')).toMatchObject({ content: 'newer' })
     expect(out).toBeNull()
     expect(handle.calls).toHaveLength(0)
+  })
+
+  it('heals the cache LIVE: an older server row replaces a default the cache still matches', () => {
+    // The deterministic-id shadow heal in-session. The cache holds the stale
+    // default; the observer applied the older server row to disk and passes the
+    // default as `before`. applyFromSync force-applies, and because the cache
+    // changed, the row's handles are invalidated so the UI re-reads.
+    const cache = new BlockCache()
+    const staleDefault = block({ content: 'default', updatedAt: 9000 })
+    cache.applyIfNewer(staleDefault, 'sync')
+    const handle = target()
+
+    const serverValue = block({ content: 'real synced config', updatedAt: 3000 })
+    const out = applySyncInvalidation(
+      cache, handle, snapshots({ b1: { before: staleDefault, after: serverValue } }),
+    )
+
+    expect(cache.getSnapshot('b1')).toMatchObject({ content: 'real synced config' })
+    expect(out).not.toBeNull()
+    expect(arr(out!.rowIds)).toEqual(['b1'])
+    expect(handle.calls).toHaveLength(1)
   })
 
   it('evicts on removal and invalidates the row + its prior parent', () => {

--- a/src/sync/observer/invalidate.test.ts
+++ b/src/sync/observer/invalidate.test.ts
@@ -106,6 +106,27 @@ describe('applySyncInvalidation', () => {
     expect(handle.calls).toHaveLength(1)
   })
 
+  it('does NOT force-heal the cache when forceHeal is false (one-time healing rescan)', () => {
+    // The healing rescan heals disk but passes forceHeal=false so the cache
+    // stays LWW-masked — a real edit that just drained but not echoed must not
+    // be force-clobbered in the live cache during the rescan window. The older
+    // server `after` is rejected by LWW even though it matches `before`.
+    const cache = new BlockCache()
+    const staleDefault = block({ content: 'default', updatedAt: 9000 })
+    cache.applyIfNewer(staleDefault, 'sync')
+    const handle = target()
+
+    const serverValue = block({ content: 'real synced config', updatedAt: 3000 })
+    const out = applySyncInvalidation(
+      cache, handle, snapshots({ b1: { before: staleDefault, after: serverValue } }), [], false,
+    )
+
+    // Cache keeps the default (heals on reload from disk); nothing dispatched.
+    expect(cache.getSnapshot('b1')).toMatchObject({ content: 'default' })
+    expect(out).toBeNull()
+    expect(handle.calls).toHaveLength(0)
+  })
+
   it('evicts on removal and invalidates the row + its prior parent', () => {
     const cache = new BlockCache()
     cache.applyIfNewer(block({ id: 'child', parentId: 'parent-1' }), 'sync')

--- a/src/sync/observer/invalidate.ts
+++ b/src/sync/observer/invalidate.ts
@@ -37,7 +37,7 @@ export interface SyncInvalidationTarget {
 }
 
 /** The cache surface the observer writes through. */
-export type SyncCache = Pick<BlockCache, 'applyFromSync' | 'markMissing'>
+export type SyncCache = Pick<BlockCache, 'applyFromSync' | 'applyIfNewer' | 'markMissing'>
 
 /**
  * Reflect a materialization pass's `snapshots` into the cache and notify
@@ -53,6 +53,13 @@ export const applySyncInvalidation = (
   handleStore: SyncInvalidationTarget,
   snapshots: ReadonlyMap<string, SyncSnapshot>,
   invalidationRules: readonly InvalidationRule[] = [],
+  /** Whether the cache may FORCE-apply an older server row that still matches
+   *  the pre-write disk row (the live shadow heal). True for the steady-state
+   *  strict gate. The one-time HEALING rescan passes false so it heals disk
+   *  only and lets the cache rehydrate on reload (interim LWW masking): a real
+   *  edit that just drained but hasn't echoed could otherwise be force-clobbered
+   *  in the live cache during the rescan window — a transient the LWW gate hides. */
+  forceHeal = true,
 ): ChangeNotification | null => {
   const accepted = new Map<string, ChangeSnapshot>()
   for (const [id, snap] of snapshots) {
@@ -64,7 +71,9 @@ export const applySyncInvalidation = (
     // invalidate its parent-edge deps. Mirrors the fast path's post-commit
     // cache walk (commitPipeline step 6) and the retired tail's delete branch.
     const changed = snap.after
-      ? cache.applyFromSync(snap.after, snap.before)
+      ? (forceHeal
+          ? cache.applyFromSync(snap.after, snap.before)
+          : cache.applyIfNewer(snap.after, 'sync'))
       : cache.markMissing(id)
     if (changed) accepted.set(id, snap)
   }

--- a/src/sync/observer/invalidate.ts
+++ b/src/sync/observer/invalidate.ts
@@ -10,12 +10,16 @@
  * re-deriving them from a serialized audit row.
  *
  * One gate, not two: `materializeStagingRows` already consulted `ps_crud` /
- * `updated_at` to decide what to write to disk, so `snapshots` only contains
- * rows that won that gate. The remaining cache gate here is the in-memory LWW
- * (`applyIfNewer`), which also dedups fingerprint-identical re-deliveries — a
- * row the cache rejects produced no user-visible change, so (as in the old
- * tail) it contributes no invalidation, avoiding the re-read flicker that
- * waking handles to stale SQL would cause.
+ * `updated_at` / provenance to decide what to write to disk, so `snapshots`
+ * only contains rows that won that gate. The cache write here is
+ * `applyFromSync(after, before)`: it takes the observer's row when the cache
+ * still matches the pre-write disk row (`before`) — healing the
+ * deterministic-id shadow LIVE even when `after` is older-stamped — and
+ * otherwise falls back to the in-memory LWW so a newer local edit is never
+ * clobbered. A row the cache rejects produced no user-visible change, so (as in
+ * the old tail) it contributes no invalidation, avoiding the re-read flicker
+ * that waking handles to stale SQL would cause. Replay deliveries are already
+ * skip-staled at the disk gate, so they never reach this force path.
  */
 
 import type { BlockCache } from '@/data/blockCache.js'
@@ -33,13 +37,13 @@ export interface SyncInvalidationTarget {
 }
 
 /** The cache surface the observer writes through. */
-export type SyncCache = Pick<BlockCache, 'applyIfNewer' | 'markMissing'>
+export type SyncCache = Pick<BlockCache, 'applyFromSync' | 'markMissing'>
 
 /**
  * Reflect a materialization pass's `snapshots` into the cache and notify
- * handles. Updates each row's cache snapshot (`applyIfNewer('sync')` for an
- * apply, `markMissing` for a removal) and, for the rows the cache accepted,
- * emits one `ChangeNotification` (rowIds / parentIds / workspaceIds / plugin).
+ * handles. Updates each row's cache snapshot (`applyFromSync` for an apply,
+ * `markMissing` for a removal) and, for the rows the cache accepted, emits one
+ * `ChangeNotification` (rowIds / parentIds / workspaceIds / plugin).
  *
  * Returns the notification that was dispatched, or null if every row was
  * rejected by the cache gate (nothing to notify).
@@ -60,7 +64,7 @@ export const applySyncInvalidation = (
     // invalidate its parent-edge deps. Mirrors the fast path's post-commit
     // cache walk (commitPipeline step 6) and the retired tail's delete branch.
     const changed = snap.after
-      ? cache.applyIfNewer(snap.after, 'sync')
+      ? cache.applyFromSync(snap.after, snap.before)
       : cache.markMissing(id)
     if (changed) accepted.set(id, snap)
   }

--- a/src/sync/observer/materialize.test.ts
+++ b/src/sync/observer/materialize.test.ts
@@ -25,10 +25,16 @@ import { materializeStagingRows, type Materializability } from './materialize.js
 import { encodeForWire, type GetCek } from '../transform.js'
 import { generateWorkspaceKeyBytes, importWorkspaceKey } from '../crypto/workspaceKey.js'
 import type { BlockData } from '@/data/api'
+import { systemAuthor } from '@/data/api'
 import type { PowerSyncDb } from '@/data/internals/commitPipeline.js'
 
 const COLUMN_NAMES = BLOCK_STORAGE_COLUMNS.map(c => c.name)
 const INSERT_BLOCK_SQL = `INSERT INTO blocks (${COLUMN_NAMES.join(', ')}) VALUES (${COLUMN_NAMES.map(() => '?').join(', ')})`
+
+// The gate compares a local row's `updated_by` to `systemAuthor(currentUserId)`.
+// The default seeded `blockData` is authored by `user-1`, so deps use the same
+// id; tests that exercise the own-system-mint branch stamp `system:user-1`.
+const USER = 'user-1'
 
 const blockData = (overrides: Partial<BlockData> = {}): BlockData => ({
   id: 'b1',
@@ -120,7 +126,7 @@ describe('materializeStagingRows — copy-through (plaintext workspace)', () => 
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.applied).toEqual(['b1'])
@@ -167,7 +173,7 @@ describe('materializeStagingRows — decrypt (e2ee workspace with WK)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['enc1'], removed: [] },
-      { getMaterializability: constMat('decrypt'), getCek },
+      { getMaterializability: constMat('decrypt'), getCek, currentUserId: USER },
     )
 
     expect(out.applied).toEqual(['enc1'])
@@ -193,7 +199,7 @@ describe('materializeStagingRows — defer (not materializable yet)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['locked'], removed: [] },
-      { getMaterializability: constMat('defer'), getCek: noKey },
+      { getMaterializability: constMat('defer'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.deferred).toEqual(['locked'])
@@ -218,30 +224,16 @@ describe('materializeStagingRows — skip-stale (local edit must win)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.skippedStale).toEqual(['b1'])
     expect((await allBlocks())[0]!.content).toBe('local edit')
   })
 
-  it('applies an older server snapshot over a non-pending newer local row (server-authoritative)', async () => {
-    // A non-pending local row that is strictly newer than the server snapshot is
-    // NOT a protected local edit — it's a speculative bootstrap default (or a
-    // dropped upload). The server's older-but-authoritative row wins, un-shadowing
-    // real synced config. Only a pending upload or an equal stamp protects local.
-    await seedLocalBlock(blockData({ content: 'newer local', updatedAt: 500 }))
-    await stageRow(blockData({ content: 'older server', updatedAt: 200 }))
-
-    const out = await materializeStagingRows(
-      env.db,
-      { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
-    )
-
-    expect(out.applied).toEqual(['b1'])
-    expect((await allBlocks())[0]!.content).toBe('older server')
-  })
+  // (The "non-pending strictly-newer local row" case is now split by write
+  //  provenance — heal vs replay-protect — and covered at DB level in the
+  //  "provenance gate" describe below, and exhaustively in reconcile.test.ts.)
 
   it('skips a pending-protected e2ee row WITHOUT decrypting it (undecryptable ciphertext cannot abort the batch)', async () => {
     const key = await importWorkspaceKey(generateWorkspaceKeyBytes())
@@ -266,7 +258,7 @@ describe('materializeStagingRows — skip-stale (local edit must win)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['x'], removed: [] },
-      { getMaterializability: constMat('decrypt'), getCek },
+      { getMaterializability: constMat('decrypt'), getCek, currentUserId: USER },
     )
 
     expect(out.skippedStale).toEqual(['x'])
@@ -280,7 +272,7 @@ describe('materializeStagingRows — skip-stale (local edit must win)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.applied).toEqual(['b1'])
@@ -297,8 +289,11 @@ describe('materializeStagingRows — batched gate (mixed outcomes, chunked)', ()
 
     // apply: strictly-newer staging snapshot, no local row.
     await stageRow(blockData({ id: 'apply', content: 'fresh', updatedAt: 300 }))
-    // apply: a NON-pending local row that's newer is not protected — server wins.
-    await seedLocalBlock(blockData({ id: 'newer', content: 'local newer', updatedAt: 500 }))
+    // apply (heal): a newer local row that is THIS client's own system mint
+    // yields to the older server row — the shadow heal.
+    await seedLocalBlock(blockData({
+      id: 'newer', content: 'local newer', updatedAt: 500, updatedBy: systemAuthor(USER),
+    }))
     await stageRow(blockData({ id: 'newer', content: 'stale server', updatedAt: 200 }))
     // skip: an unsent local edit is queued for this id (pending always wins).
     await seedLocalBlock(blockData({ id: 'pending', content: 'local pending', updatedAt: 100 }))
@@ -311,7 +306,7 @@ describe('materializeStagingRows — batched gate (mixed outcomes, chunked)', ()
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['apply', 'newer', 'pending'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
       { readChunkSize: 2 }, // 3 ids → 2 read chunks, so the bulk maps span a boundary
     )
 
@@ -319,6 +314,68 @@ describe('materializeStagingRows — batched gate (mixed outcomes, chunked)', ()
     expect(out.skippedStale).toEqual(['pending'])
     const byId = Object.fromEntries((await allBlocks()).map(b => [b.id, b.content]))
     expect(byId).toEqual({ apply: 'fresh', newer: 'stale server', pending: 'local pending' })
+  })
+})
+
+describe('materializeStagingRows — provenance gate (deterministic-id shadow)', () => {
+  // The headline fix. A deterministic-id default minted on read-as-absent gets a
+  // fresh `now` stamp; the server's authoritative row is older. Same shape, two
+  // outcomes, decided by updated_by.
+
+  it('heals: an own pristine system default yields to the older server row', async () => {
+    // Local mint stamped now (500) by THIS client's system author; server's real
+    // config is older (200). Without provenance the local default would shadow
+    // the server forever — with it, the server wins on disk.
+    await seedLocalBlock(blockData({
+      content: 'local default', updatedAt: 500, updatedBy: systemAuthor(USER),
+    }))
+    await stageRow(blockData({ content: 'real synced config', updatedAt: 200 }))
+
+    const out = await materializeStagingRows(
+      env.db,
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
+    )
+
+    expect(out.applied).toEqual(['b1'])
+    expect((await allBlocks())[0]!.content).toBe('real synced config')
+  })
+
+  it('protects: a real strictly-newer local edit skips the older delivery (replay-safe)', async () => {
+    // Identical stamps to the heal case, but authored by the real user — a
+    // just-uploaded edit facing a stale older in-flight delivery. Must NOT be
+    // clobbered (the QuickFind-freeze pattern).
+    await seedLocalBlock(blockData({ content: 'my edit', updatedAt: 500, updatedBy: USER }))
+    await stageRow(blockData({ content: 'stale server', updatedAt: 200 }))
+
+    const out = await materializeStagingRows(
+      env.db,
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
+    )
+
+    expect(out.applied).toEqual([])
+    expect(out.skippedStale).toEqual(['b1'])
+    expect((await allBlocks())[0]!.content).toBe('my edit')
+  })
+
+  it('does not treat another client\'s system mint as a local default (exact-user match)', async () => {
+    // `system:other` arrived via sync — it is already server truth, not a row we
+    // minted. A strictly-newer such row is protected like any real edit; only
+    // OUR own system author yields.
+    await seedLocalBlock(blockData({
+      content: 'theirs', updatedAt: 500, updatedBy: systemAuthor('other-user'),
+    }))
+    await stageRow(blockData({ content: 'older delivery', updatedAt: 200 }))
+
+    const out = await materializeStagingRows(
+      env.db,
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
+    )
+
+    expect(out.skippedStale).toEqual(['b1'])
+    expect((await allBlocks())[0]!.content).toBe('theirs')
   })
 })
 
@@ -348,7 +405,7 @@ describe('materializeStagingRows — quarantine (undecryptable)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['good', 'bad'], removed: [] },
-      { getMaterializability: constMat('decrypt'), getCek: async () => key },
+      { getMaterializability: constMat('decrypt'), getCek: async () => key, currentUserId: USER },
     )
     warn.mockRestore()
 
@@ -366,7 +423,7 @@ describe('materializeStagingRows — chunked staging reads', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: ids, removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
       { readChunkSize: 2 }, // 5 ids → 3 chunks (2, 2, 1)
     )
 
@@ -387,7 +444,7 @@ describe('materializeStagingRows — removed (stream-exit)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: [], removed: ['b1'] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.deleted).toEqual(['b1'])
@@ -413,7 +470,7 @@ describe('materializeStagingRows — removed (stream-exit)', () => {
     const out = await materializeStagingRows(
       env.db,
       { upserted: [], removed: ['b1'] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.deleted).toEqual([])
@@ -425,9 +482,12 @@ describe('materializeStagingRows — Phase-1/Phase-2 TOCTOU re-gate', () => {
   // The Phase-1 staleness reads run outside the write tx, so a local edit can
   // land between them and the lock. These cover the race the second phase exists
   // to close — Phase 1 sees a clean gate, something changes in the window, and
-  // the in-tx re-gate re-reads the authoritative state. The PROTECTED change is a
-  // pending upload (an unsent local edit): the re-gate must skip it. A bare
-  // stamp bump with no pending is NOT a protected edit, so the re-gate applies.
+  // the in-tx re-gate re-reads the AUTHORITATIVE state (both updated_at and
+  // updated_by). Two ways a window change protects the local row: a pending
+  // upload, and — under the strict provenance gate — a real (non-system) edit
+  // that bumps the stamp strictly above staging. A window change to an own
+  // system mint instead heals (applies), proving the re-gate isn't a mere
+  // skip-detector.
 
   it('skips a candidate when a local edit is queued for upload in the window', async () => {
     await seedLocalBlock(blockData({ content: 'local v1', updatedAt: 200 }))
@@ -436,7 +496,7 @@ describe('materializeStagingRows — Phase-1/Phase-2 TOCTOU re-gate', () => {
     const out = await materializeStagingRows(
       racingDb(env.db, () => queuePendingUpload('b1')),
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.applied).toEqual([])
@@ -445,7 +505,7 @@ describe('materializeStagingRows — Phase-1/Phase-2 TOCTOU re-gate', () => {
     expect((await allBlocks())[0]!.content).toBe('local v1')
   })
 
-  it('applies when the local row is bumped newer (non-pending) in the window — only pending protects', async () => {
+  it('skips when a real edit bumps the local stamp strictly-newer in the window', async () => {
     await seedLocalBlock(blockData({ content: 'local v1', updatedAt: 200 }))
     await stageRow(blockData({ content: 'server v2', updatedAt: 300 }))
 
@@ -454,12 +514,34 @@ describe('materializeStagingRows — Phase-1/Phase-2 TOCTOU re-gate', () => {
         await env.db.execute('UPDATE blocks SET updated_at = ? WHERE id = ?', [999, 'b1'])
       }),
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
-    // The re-gate re-reads the bumped stamp (999) but a non-pending row is not a
-    // protected edit, so the server snapshot still applies. (The sibling test —
-    // a pending upload queued in the window — is what skip-stales.)
+    // Phase 1 saw local@200 < staging@300 (applyable). The window bumped the
+    // real-user row to 999; the re-gate re-reads it and now protects the edit
+    // (strict gate — replay-safe). Proves Phase 2 uses authoritative in-tx
+    // state, not the stale Phase-1 read.
+    expect(out.applied).toEqual([])
+    expect(out.skippedStale).toEqual(['b1'])
+    expect((await allBlocks())[0]!.content).toBe('local v1')
+  })
+
+  it('applies (heals) when an own system mint is bumped newer in the window', async () => {
+    await seedLocalBlock(blockData({ content: 'local v1', updatedAt: 200, updatedBy: systemAuthor(USER) }))
+    await stageRow(blockData({ content: 'server v2', updatedAt: 300 }))
+
+    const out = await materializeStagingRows(
+      racingDb(env.db, async () => {
+        await env.db.execute('UPDATE blocks SET updated_at = ? WHERE id = ?', [999, 'b1'])
+      }),
+      { upserted: ['b1'], removed: [] },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
+    )
+
+    // The window bumps the stamp but leaves updated_by = system:user-1, so the
+    // re-gate still recognizes a pristine default and the server's value heals
+    // it — Phase 2 reading updated_by authoritatively is what makes this apply
+    // rather than skip.
     expect(out.applied).toEqual(['b1'])
     expect((await allBlocks())[0]!.content).toBe('server v2')
   })
@@ -478,7 +560,7 @@ describe('materializeStagingRows — soft-delete (tombstone) materialization', (
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.applied).toEqual(['b1'])
@@ -497,7 +579,7 @@ describe('materializeStagingRows — soft-delete (tombstone) materialization', (
     const out = await materializeStagingRows(
       env.db,
       { upserted: ['b1'], removed: [] },
-      { getMaterializability: constMat('copy'), getCek: noKey },
+      { getMaterializability: constMat('copy'), getCek: noKey, currentUserId: USER },
     )
 
     expect(out.applied).toEqual(['b1'])

--- a/src/sync/observer/materialize.ts
+++ b/src/sync/observer/materialize.ts
@@ -33,8 +33,13 @@ import {
   type BlockRow,
 } from '@/data/blockSchema.js'
 import type { BlockData } from '@/data/api'
+import { systemAuthor } from '@/data/api'
 import type { PowerSyncDb } from '@/data/internals/commitPipeline.js'
-import { decideStagingRow, type Materializability } from './reconcile.js'
+import {
+  decideStagingRow,
+  type Materializability,
+  type ReconcileMode,
+} from './reconcile.js'
 import { decodeFromWire, type GetCek } from '../transform.js'
 
 export type { Materializability } from './reconcile.js'
@@ -92,6 +97,12 @@ export interface MaterializeDeps {
   readonly getMaterializability: GetMaterializability
   /** Workspace-key lookup, threaded to {@link decodeFromWire} for decrypt. */
   readonly getCek: GetCek
+  /** The current client's user id. The gate compares a local row's
+   *  `updated_by` against `systemAuthor(currentUserId)` to recognize THIS
+   *  client's own pristine speculative default (which yields to the server).
+   *  A `system:other` row that arrived via sync is already server truth and
+   *  must not be treated as a local mint, hence the exact-current-user match. */
+  readonly currentUserId: string
 }
 
 /** The staging-table delta to process: ids whose staging row changed, and ids
@@ -169,20 +180,29 @@ const readStagingRows = async (
   return out
 }
 
-/** Local `updated_at` for the `ids` the app already has a `blocks` row for (the
- *  LWW gate's local stamp), keyed by id. Chunked so the IN-clause never exceeds
- *  SQLite's bound-parameter limit. Absent ids = no local row. */
-const readLocalUpdatedAt = async (
+/** The local gate inputs for one id: the `blocks` row's `updated_at` (the LWW
+ *  stamp) and `updated_by` (the provenance discriminator). */
+interface LocalGateRow {
+  readonly updatedAt: number
+  readonly updatedBy: string
+}
+
+/** Local gate inputs for the `ids` the app already has a `blocks` row for,
+ *  keyed by id. Chunked so the IN-clause never exceeds SQLite's bound-parameter
+ *  limit. Absent ids = no local row. This is the Phase-1 slim read (id +
+ *  updated_at + updated_by) — Phase 2 re-derives the same fields from the full
+ *  before-rows it already loads. */
+const readLocalGateRows = async (
   db: RowsReader, ids: readonly string[], chunkSize: number,
-): Promise<Map<string, number>> => {
-  const out = new Map<string, number>()
+): Promise<Map<string, LocalGateRow>> => {
+  const out = new Map<string, LocalGateRow>()
   for (let i = 0; i < ids.length; i += chunkSize) {
     const chunk = ids.slice(i, i + chunkSize)
-    const rows = await db.getAll<{ id: string; updated_at: number }>(
-      `SELECT id, updated_at FROM blocks WHERE id IN (${buildInClause(chunk.length)})`,
+    const rows = await db.getAll<{ id: string; updated_at: number; updated_by: string }>(
+      `SELECT id, updated_at, updated_by FROM blocks WHERE id IN (${buildInClause(chunk.length)})`,
       chunk,
     )
-    for (const row of rows) out.set(row.id, row.updated_at)
+    for (const row of rows) out.set(row.id, { updatedAt: row.updated_at, updatedBy: row.updated_by })
   }
   return out
 }
@@ -233,6 +253,11 @@ const readExistingStagingIds = async (
 /** Tunables (batch sizing). Defaults are production values; tests override. */
 export interface MaterializeOptions {
   readonly readChunkSize?: number
+  /** Which conflict rule the gate applies (default `strict`). The one-time
+   *  recovery rescan passes `healing` so pre-provenance shadows — stamped with
+   *  the real user, so `strict` would protect them — still yield to the
+   *  server. See {@link ReconcileMode}. */
+  readonly gateMode?: ReconcileMode
 }
 
 /**
@@ -258,6 +283,11 @@ export const materializeStagingRows = async (
 ): Promise<MaterializeOutcome> => {
   const { getMaterializability, getCek } = deps
   const readChunkSize = options.readChunkSize ?? STAGING_READ_CHUNK
+  const gateMode = options.gateMode ?? 'strict'
+  // This client's own system author. A local row whose `updated_by` equals it
+  // is a pristine speculative default we minted ourselves (yields to the
+  // server); `system:<otherUser>` and real-user authors do not match.
+  const ownSystemAuthor = systemAuthor(deps.currentUserId)
   const deferred: string[] = []
   const skippedStale: string[] = []
   const quarantined: string[] = []
@@ -268,7 +298,7 @@ export const materializeStagingRows = async (
   // two awaited probes per row. On a large backlog those per-row probes — a
   // `blocks` lookup plus a `ps_crud` json_extract scan, each a serialized
   // round-trip to the SQLite worker — were the dominant cost, not the copy.
-  const localUpdatedAtById = await readLocalUpdatedAt(
+  const localGateRowById = await readLocalGateRows(
     db, stagingRows.map(row => row.id), readChunkSize,
   )
   const pendingUploadIds = await readPendingUploadIds(db)
@@ -290,10 +320,12 @@ export const materializeStagingRows = async (
       deferred.push(row.id)
       continue
     }
+    const localRow = localGateRowById.get(row.id)
     const action = decideStagingRow(materializability, row.updated_at, {
-      localUpdatedAt: localUpdatedAtById.get(row.id) ?? null,
+      localUpdatedAt: localRow?.updatedAt ?? null,
       hasPendingUpload: pendingUploadIds.has(row.id),
-    })
+      isOwnSystemMint: localRow?.updatedBy === ownSystemAuthor,
+    }, gateMode)
     if (action.kind !== 'apply') {
       // Skip-stale BEFORE decrypt: a stale ciphertext never gets decoded.
       skippedStale.push(row.id)
@@ -351,7 +383,8 @@ export const materializeStagingRows = async (
       const action = decideStagingRow(materializability, stagingUpdatedAt, {
         localUpdatedAt: beforeRow?.updated_at ?? null,
         hasPendingUpload: pendingNow.has(plaintext.id),
-      })
+        isOwnSystemMint: beforeRow?.updated_by === ownSystemAuthor,
+      }, gateMode)
       if (action.kind === 'apply') {
         await tx.execute(UPSERT_BLOCK_SQL, blockRowParams(plaintext))
         applied.push(plaintext.id)

--- a/src/sync/observer/observer.test.ts
+++ b/src/sync/observer/observer.test.ts
@@ -125,8 +125,8 @@ const waitFor = async (cond: () => Promise<boolean>, ms = 3000): Promise<void> =
   }
 }
 
-describe('blocksSyncedObserver — server overrides an own system default (disk heal)', () => {
-  it('a stale own system default is overwritten on disk by the older server row (heals on reload)', async () => {
+describe('blocksSyncedObserver — server overrides an own system default (disk + live heal)', () => {
+  it('overwrites a stale own system default with the older server row, on disk AND in the cache', async () => {
     // A bootstrap default minted with a fresh now-stamp and THIS client's system
     // author (start() runs as currentUserId 'user-1'), non-pending (no ps_crud),
     // read into the cache at app start — the deterministic-id shadow setup.
@@ -140,15 +140,11 @@ describe('blocksSyncedObserver — server overrides an own system default (disk 
     await observer.flush()
 
     // Disk: the server value replaced the pristine default despite the older
-    // stamp (the strict gate lets an own system mint yield), so the shadow is
-    // gone from the persistent table — a reload, which rehydrates the cache from
-    // disk, surfaces it.
+    // stamp (the strict gate lets an own system mint yield).
     expect(await blocks()).toEqual([{ id: 'b1', content: 'real synced config' }])
-    // Cache (in-session): the cache's own applyIfNewer LWW still rejects the
-    // older value, so the live cache isn't healed yet — the interim limitation,
-    // and what keeps this disk write from waking handles. Heals on reload (and
-    // live once applyFromSync lands).
-    expect(cache.getSnapshot('b1')).toMatchObject({ content: 'default' })
+    // Cache (in-session): applyFromSync force-applies the server row because the
+    // cache still matched the pre-write disk row — the LIVE heal, no reload.
+    expect(cache.getSnapshot('b1')).toMatchObject({ content: 'real synced config' })
   })
 
   it('protects a strictly-newer REAL local edit from an older delivery (replay-safe)', async () => {

--- a/src/sync/observer/observer.test.ts
+++ b/src/sync/observer/observer.test.ts
@@ -170,7 +170,8 @@ describe('blocksSyncedObserver — server overrides an own system default (disk 
       content: 'shadow default', updatedAt: 9000, updatedBy: 'user-1', workspaceId: 'ws-heal',
     })
     await seedLocalBlock(preProvenanceShadow)
-    const { observer } = start({ getMaterializability: constMat('copy') })
+    const { observer, cache } = start({ getMaterializability: constMat('copy') })
+    cache.setSnapshot(preProvenanceShadow)
 
     await put(data({ content: 'real synced config', updatedAt: 3000, workspaceId: 'ws-heal' }))
     await observer.flush() // strict queue drain
@@ -178,9 +179,13 @@ describe('blocksSyncedObserver — server overrides an own system default (disk 
     // Strict mode protects it (the re-permanent risk healing mode exists to fix).
     expect(await blocks()).toEqual([{ id: 'b1', content: 'shadow default' }])
 
-    // Healing rescan re-reads blocks_synced directly and lets the server win.
+    // Healing rescan re-reads blocks_synced directly and lets the server win ON
+    // DISK. The cache is NOT force-healed (healing mode passes forceHeal=false),
+    // so it stays masked this session and rehydrates from disk on reload —
+    // avoiding a force-clobber of any concurrently-draining real edit.
     await observer.healWorkspace('ws-heal')
     expect(await blocks()).toEqual([{ id: 'b1', content: 'real synced config' }])
+    expect(cache.getSnapshot('b1')).toMatchObject({ content: 'shadow default' })
   })
 })
 

--- a/src/sync/observer/observer.test.ts
+++ b/src/sync/observer/observer.test.ts
@@ -15,6 +15,7 @@ import { encodeForWire, type GetCek } from '../transform.js'
 import { generateWorkspaceKeyBytes, importWorkspaceKey } from '../crypto/workspaceKey.js'
 import type { ChangeNotification } from '@/data/internals/handleStore'
 import type { BlockData, CycleDetectedEvent } from '@/data/api'
+import { systemAuthor } from '@/data/api'
 
 const data = (o: Partial<BlockData> = {}): BlockData => ({
   id: 'b1', workspaceId: 'ws-plain', parentId: null, orderKey: 'a0', content: 'hello',
@@ -87,7 +88,11 @@ const start = (opts: {
     db: env.db,
     cache,
     handleStore: { invalidate: (n) => notifications.push(n) },
-    deps: { getMaterializability: opts.getMaterializability, getCek: opts.getCek ?? noKey },
+    deps: {
+      getMaterializability: opts.getMaterializability,
+      getCek: opts.getCek ?? noKey,
+      currentUserId: 'user-1',
+    },
     onCycleDetected: opts.onCycleDetected,
     throttleMs: 5,
     drainChunkSize: opts.drainChunkSize,
@@ -120,11 +125,12 @@ const waitFor = async (cond: () => Promise<boolean>, ms = 3000): Promise<void> =
   }
 }
 
-describe('blocksSyncedObserver — server overrides a non-pending local default (disk heal)', () => {
-  it('a stale local default is overwritten on disk by the older server row (heals on reload)', async () => {
-    // A bootstrap default minted with a fresh now-stamp, non-pending (no ps_crud),
-    // and read into the cache at app start — the deterministic-id shadow setup.
-    const localDefault = data({ content: 'default', updatedAt: 9000 })
+describe('blocksSyncedObserver — server overrides an own system default (disk heal)', () => {
+  it('a stale own system default is overwritten on disk by the older server row (heals on reload)', async () => {
+    // A bootstrap default minted with a fresh now-stamp and THIS client's system
+    // author (start() runs as currentUserId 'user-1'), non-pending (no ps_crud),
+    // read into the cache at app start — the deterministic-id shadow setup.
+    const localDefault = data({ content: 'default', updatedAt: 9000, updatedBy: systemAuthor('user-1') })
     await seedLocalBlock(localDefault)
     const { observer, cache } = start({ getMaterializability: constMat('copy') })
     cache.setSnapshot(localDefault)
@@ -133,15 +139,52 @@ describe('blocksSyncedObserver — server overrides a non-pending local default 
     await put(data({ content: 'real synced config', updatedAt: 3000 }))
     await observer.flush()
 
-    // Disk: the server value replaced the default despite the older stamp
-    // (decideStagingRow no longer skip-stales a non-pending strictly-newer local),
-    // so the shadow is gone from the persistent table — a reload, which rehydrates
-    // the cache from disk, surfaces it.
+    // Disk: the server value replaced the pristine default despite the older
+    // stamp (the strict gate lets an own system mint yield), so the shadow is
+    // gone from the persistent table — a reload, which rehydrates the cache from
+    // disk, surfaces it.
     expect(await blocks()).toEqual([{ id: 'b1', content: 'real synced config' }])
     // Cache (in-session): the cache's own applyIfNewer LWW still rejects the
     // older value, so the live cache isn't healed yet — the interim limitation,
-    // and what keeps this disk write from waking handles. Heals on reload.
+    // and what keeps this disk write from waking handles. Heals on reload (and
+    // live once applyFromSync lands).
     expect(cache.getSnapshot('b1')).toMatchObject({ content: 'default' })
+  })
+
+  it('protects a strictly-newer REAL local edit from an older delivery (replay-safe)', async () => {
+    // Same shape, but the local row is a real user edit (updated_by = the real
+    // user), not a system mint. The strict gate must NOT overwrite it — this is
+    // the upload-window replay the QuickFind-freeze canary guards.
+    const localEdit = data({ content: 'my edit', updatedAt: 9000, updatedBy: 'user-1' })
+    await seedLocalBlock(localEdit)
+    const { observer } = start({ getMaterializability: constMat('copy') })
+
+    await put(data({ content: 'stale server', updatedAt: 3000 }))
+    await observer.flush()
+
+    expect(await blocks()).toEqual([{ id: 'b1', content: 'my edit' }])
+  })
+
+  it('healWorkspace un-shadows a pre-provenance (real-user-stamped) default the strict drain protects', async () => {
+    // A shadow minted by PRE-provenance code is stamped with the real user, so
+    // the steady-state strict gate protects it as if it were an edit — it would
+    // re-permanent on upgrade. The one-time recovery rescan runs in healing
+    // mode, where the server wins on any strictly-newer non-pending row.
+    const preProvenanceShadow = data({
+      content: 'shadow default', updatedAt: 9000, updatedBy: 'user-1', workspaceId: 'ws-heal',
+    })
+    await seedLocalBlock(preProvenanceShadow)
+    const { observer } = start({ getMaterializability: constMat('copy') })
+
+    await put(data({ content: 'real synced config', updatedAt: 3000, workspaceId: 'ws-heal' }))
+    await observer.flush() // strict queue drain
+
+    // Strict mode protects it (the re-permanent risk healing mode exists to fix).
+    expect(await blocks()).toEqual([{ id: 'b1', content: 'shadow default' }])
+
+    // Healing rescan re-reads blocks_synced directly and lets the server win.
+    await observer.healWorkspace('ws-heal')
+    expect(await blocks()).toEqual([{ id: 'b1', content: 'real synced config' }])
   })
 })
 

--- a/src/sync/observer/observer.ts
+++ b/src/sync/observer/observer.ts
@@ -43,6 +43,7 @@ import {
   type MaterializeOutcome,
   type SyncSnapshot,
 } from './materialize.js'
+import type { ReconcileMode } from './reconcile.js'
 import {
   applySyncInvalidation,
   type SyncCache,
@@ -84,8 +85,14 @@ export interface BlocksSyncedObserver {
    *  drain enqueued before it). */
   flush(): Promise<void>
   /** Re-materialize a workspace's staged rows after it becomes materializable
-   *  (WK paste / plaintext confirm). Reads `blocks_synced` directly. */
+   *  (WK paste / plaintext confirm). Reads `blocks_synced` directly. Uses the
+   *  strict reconcile gate (steady-state semantics). */
   drainWorkspace(workspaceId: string): Promise<void>
+  /** One-time recovery rescan: like {@link drainWorkspace}, but runs the gate
+   *  in `healing` mode so a pre-provenance shadow (a real-user-stamped default
+   *  that the strict gate would protect) still yields to the server. Used by
+   *  `Repo.scheduleReconcileRescan`. */
+  healWorkspace(workspaceId: string): Promise<void>
   /** Stop the subscription. Idempotent. */
   dispose(): void
 }
@@ -173,8 +180,9 @@ export const startBlocksSyncedObserver = (
   const applyWindow = async (
     upserted: readonly string[],
     removed: readonly string[],
+    gateMode: ReconcileMode = 'strict',
   ): Promise<void> => {
-    const outcome = await materializeStagingRows(db, { upserted, removed }, deps)
+    const outcome = await materializeStagingRows(db, { upserted, removed }, deps, { gateMode })
     await applyOutcome(outcome)
   }
 
@@ -215,7 +223,10 @@ export const startBlocksSyncedObserver = (
     }
   }
 
-  const materializeWorkspace = async (workspaceId: string): Promise<void> => {
+  const materializeWorkspace = async (
+    workspaceId: string,
+    gateMode: ReconcileMode = 'strict',
+  ): Promise<void> => {
     if (disposed) return
     const ids = (await db.getAll<{ id: string }>(
       'SELECT id FROM blocks_synced WHERE workspace_id = ? ORDER BY id',
@@ -232,7 +243,7 @@ export const startBlocksSyncedObserver = (
     // re-invocation resume (already-materialized rows LWW-skip next pass).
     for (let i = 0; i < ids.length; i += drainChunk) {
       if (disposed) return
-      await applyWindow(ids.slice(i, i + drainChunk), [])
+      await applyWindow(ids.slice(i, i + drainChunk), [], gateMode)
     }
   }
 
@@ -254,7 +265,9 @@ export const startBlocksSyncedObserver = (
 
   const flush = (): Promise<void> => enqueue(drainQueueOnce)
   const drainWorkspace = (workspaceId: string): Promise<void> =>
-    enqueue(() => materializeWorkspace(workspaceId))
+    enqueue(() => materializeWorkspace(workspaceId, 'strict'))
+  const healWorkspace = (workspaceId: string): Promise<void> =>
+    enqueue(() => materializeWorkspace(workspaceId, 'healing'))
 
   // Subscribe first, then drain once: the subscription catches future appends,
   // and the initial drain catches rows already queued — including any that
@@ -272,6 +285,7 @@ export const startBlocksSyncedObserver = (
   return {
     flush,
     drainWorkspace,
+    healWorkspace,
     dispose() {
       if (disposed) return
       disposed = true

--- a/src/sync/observer/observer.ts
+++ b/src/sync/observer/observer.ts
@@ -167,9 +167,14 @@ export const startBlocksSyncedObserver = (
   }
 
   /** Post-materialization side effects shared by both drain paths: invalidate
-   *  cache + handles (one LWW gate), then run cycle detection. */
-  const applyOutcome = async (outcome: MaterializeOutcome): Promise<void> => {
-    applySyncInvalidation(cache, handleStore, outcome.snapshots, rules())
+   *  cache + handles, then run cycle detection. Only the steady-state strict
+   *  gate force-heals the live cache; the one-time healing rescan heals disk
+   *  and lets the cache rehydrate on reload (see `applySyncInvalidation`). */
+  const applyOutcome = async (
+    outcome: MaterializeOutcome,
+    gateMode: ReconcileMode,
+  ): Promise<void> => {
+    applySyncInvalidation(cache, handleStore, outcome.snapshots, rules(), gateMode === 'strict')
     await runCycleScan(outcome.snapshots)
   }
 
@@ -183,7 +188,7 @@ export const startBlocksSyncedObserver = (
     gateMode: ReconcileMode = 'strict',
   ): Promise<void> => {
     const outcome = await materializeStagingRows(db, { upserted, removed }, deps, { gateMode })
-    await applyOutcome(outcome)
+    await applyOutcome(outcome, gateMode)
   }
 
   const drainQueueOnce = async (): Promise<void> => {

--- a/src/sync/observer/reconcile.test.ts
+++ b/src/sync/observer/reconcile.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, it } from 'vitest'
 import { decideStagingRow, type LocalRowState } from './reconcile.js'
 
-const noLocal: LocalRowState = { localUpdatedAt: null, hasPendingUpload: false }
+const noLocal: LocalRowState = {
+  localUpdatedAt: null,
+  hasPendingUpload: false,
+  isOwnSystemMint: false,
+}
+
+/** A non-pending local row with the given stamp; `isOwnSystemMint` toggles
+ *  whether it's this client's pristine speculative default or a real edit. */
+const local = (
+  localUpdatedAt: number,
+  opts: { pending?: boolean; systemMint?: boolean } = {},
+): LocalRowState => ({
+  localUpdatedAt,
+  hasPendingUpload: opts.pending ?? false,
+  isOwnSystemMint: opts.systemMint ?? false,
+})
 
 describe('decideStagingRow — materializability', () => {
   it('defers when the workspace is not materializable (locked / quarantine)', () => {
@@ -26,32 +41,49 @@ describe('decideStagingRow — materializability', () => {
 
 describe('decideStagingRow — local-edit reconciliation', () => {
   it('skips when an upload is pending for this id (echo will reconcile)', () => {
-    const action = decideStagingRow('copy', 999, { localUpdatedAt: 1, hasPendingUpload: true })
+    const action = decideStagingRow('copy', 999, local(1, { pending: true }))
     expect(action).toEqual({ kind: 'skip-stale' })
   })
 
   it('pending upload wins even if the staging row looks newer', () => {
     // hasPendingUpload short-circuits before the stamp comparison.
-    const action = decideStagingRow('decrypt', Number.MAX_SAFE_INTEGER, {
-      localUpdatedAt: 0,
-      hasPendingUpload: true,
-    })
+    const action = decideStagingRow('decrypt', Number.MAX_SAFE_INTEGER, local(0, { pending: true }))
     expect(action).toEqual({ kind: 'skip-stale' })
   })
 
-  it('applies even when the local row is strictly newer (non-pending → server wins)', () => {
-    // A non-pending local row that differs from the server is NOT a local edit
-    // (PowerSync's model: server-authoritative-except-pending) — it's a
-    // speculative bootstrap default minted with a fresh `now` stamp, or a
-    // dropped upload. The server's older-but-authoritative value must win, or it
-    // shadows real synced config on every fresh client. Only `hasPendingUpload`
-    // (a genuine local edit) or an equal stamp protects the local row.
-    const action = decideStagingRow('copy', 100, { localUpdatedAt: 200, hasPendingUpload: false })
+  it('strict: protects a strictly-newer REAL local edit (replay-safe)', () => {
+    // A non-pending, non-system local row strictly newer than the staging
+    // snapshot is a just-uploaded edit facing a stale older in-flight delivery.
+    // Protect it — overwriting on disk then re-healing via the upload echo is
+    // the QuickFind-freeze pattern the canary guards.
+    const action = decideStagingRow('copy', 100, local(200))
+    expect(action).toEqual({ kind: 'skip-stale' })
+  })
+
+  it('strict: a strictly-newer OWN system mint yields to the server (heals)', () => {
+    // The pristine speculative default minted on read-as-absent. The server's
+    // older-but-authoritative value must win or it shadows real synced config.
+    const action = decideStagingRow('copy', 100, local(200, { systemMint: true }))
     expect(action).toEqual({ kind: 'apply', decrypt: false })
   })
 
+  it('healing: a strictly-newer REAL local edit also yields (pre-provenance shadow)', () => {
+    // Pre-provenance shadows are stamped with the real user, so strict mode
+    // would protect them. The one-time recovery rescan runs in healing mode,
+    // where the server wins on any strictly-newer non-pending row.
+    const action = decideStagingRow('copy', 100, local(200), 'healing')
+    expect(action).toEqual({ kind: 'apply', decrypt: false })
+  })
+
+  it('healing still respects the pending-upload guard', () => {
+    // Healing relaxes only the strictly-newer branch — an unsent edit is never
+    // lost, in either mode.
+    const action = decideStagingRow('copy', 100, local(200, { pending: true }), 'healing')
+    expect(action).toEqual({ kind: 'skip-stale' })
+  })
+
   it('applies when the staging row is newer than the local row', () => {
-    const action = decideStagingRow('decrypt', 300, { localUpdatedAt: 200, hasPendingUpload: false })
+    const action = decideStagingRow('decrypt', 300, local(200))
     expect(action).toEqual({ kind: 'apply', decrypt: true })
   })
 
@@ -60,15 +92,11 @@ describe('decideStagingRow — local-edit reconciliation', () => {
     // updated_at. The observer materializes into the persistent SQLite `blocks`
     // table, so applying an equal-stamp snapshot would overwrite a local edit on
     // disk and resurface it after reload — the cache gate can't guard that.
-    const action = decideStagingRow('copy', 200, { localUpdatedAt: 200, hasPendingUpload: false })
-    expect(action).toEqual({ kind: 'skip-stale' })
-  })
-
-  it('a pending upload still wins over a strictly-older staging row', () => {
-    // The pending guard is the genuine-local-edit signal; it must short-circuit
-    // before the (now relaxed) stamp comparison so an unsent edit is never lost.
-    const action = decideStagingRow('copy', 100, { localUpdatedAt: 200, hasPendingUpload: true })
-    expect(action).toEqual({ kind: 'skip-stale' })
+    // Holds in both modes, and even for an own system mint.
+    expect(decideStagingRow('copy', 200, local(200))).toEqual({ kind: 'skip-stale' })
+    expect(decideStagingRow('copy', 200, local(200, { systemMint: true })))
+      .toEqual({ kind: 'skip-stale' })
+    expect(decideStagingRow('copy', 200, local(200), 'healing')).toEqual({ kind: 'skip-stale' })
   })
 
   it('applies a first-seen row (no local copy yet)', () => {
@@ -77,7 +105,7 @@ describe('decideStagingRow — local-edit reconciliation', () => {
 
   it('defer takes precedence over any local state', () => {
     expect(
-      decideStagingRow('defer', 1, { localUpdatedAt: 999, hasPendingUpload: true }),
+      decideStagingRow('defer', 1, local(999, { pending: true })),
     ).toEqual({ kind: 'defer' })
   })
 })

--- a/src/sync/observer/reconcile.ts
+++ b/src/sync/observer/reconcile.ts
@@ -49,7 +49,31 @@ export interface LocalRowState {
    *  edit for this block id. A pending edit always wins over an incoming
    *  snapshot regardless of stamps — the echo will reconcile. */
   readonly hasPendingUpload: boolean
+  /** True iff the local `blocks` row is THIS client's own pristine
+   *  speculative default — `updated_by === system:<currentUserId>` (see
+   *  `systemAuthor`). Such a row was minted on read-as-absent before the
+   *  server's authoritative version materialized; under the strict gate it
+   *  yields to an older server row (heals the shadow) where a real edit
+   *  keeps strictly-newer protection. Exact-match the CURRENT user (not any
+   *  `system:*`) so only a row we minted ourselves yields — a `system:other`
+   *  row that arrived via sync is already server truth. */
+  readonly isOwnSystemMint: boolean
 }
+
+/** Which conflict rule the gate applies when a non-pending local row is
+ *  strictly newer than the incoming staging snapshot.
+ *
+ *   - `strict` (steady state): the server wins ONLY for this client's own
+ *     pristine system mint (heals the shadow); a real local edit keeps
+ *     strictly-newer protection so the upload-window replay can't clobber it.
+ *
+ *   - `healing` (one-time recovery rescan): the server always wins on a
+ *     strictly-newer non-pending row — the interim rule. Needed because
+ *     shadows minted by PRE-provenance code are stamped with the real user,
+ *     so `strict` would protect them as if they were edits and re-permanent
+ *     them. Pending + equal-stamp guards still hold, so the blast radius is
+ *     the same as the already-shipped interim relaxation. */
+export type ReconcileMode = 'strict' | 'healing'
 
 export type ReconcileAction =
   /** Materialize the staging row into `blocks`. `decrypt` = run the
@@ -66,11 +90,13 @@ export type ReconcileAction =
  * @param materializability how the row's workspace can be materialized
  * @param stagingUpdatedAt  `updated_at` of the incoming staging row
  * @param local             local state for this block id
+ * @param mode              strict (steady state) or healing (recovery rescan)
  */
 export const decideStagingRow = (
   materializability: Materializability,
   stagingUpdatedAt: number,
   local: LocalRowState,
+  mode: ReconcileMode = 'strict',
 ): ReconcileAction => {
   if (materializability === 'defer') {
     return { kind: 'defer' }
@@ -84,36 +110,33 @@ export const decideStagingRow = (
     // snapshot overwrite it. The upload echo reconciles when it returns.
     return { kind: 'skip-stale' }
   }
-  if (local.localUpdatedAt !== null && local.localUpdatedAt === stagingUpdatedAt) {
-    // EQUAL stamps only. A stale in-flight server read can carry different
-    // content under the same ms-stamp; applying it would overwrite a local edit
-    // on disk and resurface after reload (the in-memory cache gate can't guard
-    // the persistent write). This is the one deliberate skip — see commit
-    // 429fd4b2.
-    return { kind: 'skip-stale' }
+  if (local.localUpdatedAt !== null && local.localUpdatedAt >= stagingUpdatedAt) {
+    // The local row is newer-or-equal to this incoming snapshot. Decide whether
+    // that local row is authoritative (protect it) or a speculative default the
+    // server should overwrite (heal).
+    if (local.localUpdatedAt === stagingUpdatedAt) {
+      // EQUAL stamps. A stale in-flight server read can carry different content
+      // under the same ms-stamp; applying it would overwrite a local edit on
+      // disk and resurface after reload (the in-memory cache gate can't guard
+      // the persistent write). The one deliberate skip in both modes — see
+      // commit 429fd4b2.
+      return { kind: 'skip-stale' }
+    }
+    // STRICTLY newer local row. The shadow/replay ambiguity the doc calls out:
+    // both a speculative default and a just-uploaded edit present as
+    // non-pending + strictly-newer-than-staging. The discriminator is write
+    // provenance:
+    //   - healing mode: server always wins (interim rule) — heals pre-provenance
+    //     shadows, which are stamped with the real user and so look like edits.
+    //   - strict mode: server wins ONLY for this client's own pristine system
+    //     mint (heals the new-style shadow); a real edit is protected so the
+    //     upload-window replay can't clobber it (the QuickFind-freeze canary).
+    const serverWins = mode === 'healing' || local.isOwnSystemMint
+    if (!serverWins) {
+      return { kind: 'skip-stale' }
+    }
+    // else fall through to apply — the server's older value heals the default.
   }
-
-  // We do NOT skip when the local row is *strictly* newer (PowerSync never had
-  // that branch). It let a speculative bootstrap default — minted with a `now`
-  // stamp the moment a deterministic-id row is read-as-absent — permanently
-  // outrank the server's older-but-authoritative row, shadowing real synced
-  // config (settings, etc.) on every fresh client. Letting the server win on
-  // disk means that shadow now HEALS ON RELOAD (a fresh `blocks` read rehydrates
-  // the cache from the server value) instead of being permanent.
-  //
-  // KNOWN-PARTIAL (intentional, interim — see the follow-up to distinguish a
-  // speculative default from a real edit, e.g. by write provenance):
-  //   * In-session, the cache's own `applyIfNewer` LWW still rejects the older
-  //     value, so the heal isn't live — it lands on the next reload. That same
-  //     cache gate is what keeps this relaxation from waking handles to the
-  //     transient disk write (the QuickFind-freeze pattern), so the disk write
-  //     stays user-invisible.
-  //   * It cannot tell a speculative default from a genuine just-drained edit
-  //     facing a stale older in-flight delivery (both are non-pending,
-  //     strictly-newer-than-staging). The latter is briefly clobbered on disk
-  //     and re-heals via its authoritative upload echo — transient, and masked
-  //     from the UI by the cache gate above.
-  return { kind: 'apply', decrypt: materializability === 'decrypt' }
 
   return { kind: 'apply', decrypt: materializability === 'decrypt' }
 }


### PR DESCRIPTION
## Problem

Deterministic-id blocks — settings/prefs, ui-state, the user page, daily-note seats, the Journal/Types/Properties pages, alias seats — are minted as speculative defaults the moment they're read-as-absent, *before* the server's authoritative row has materialized. The mint is a normal `repo.tx` write with a fresh `now` stamp, so under Layout B's wall-clock LWW it **outranks the server's older-but-authoritative row** and permanently shadows real synced config on a fresh client. It was permanent on both disk and the in-memory cache, and a reload rehydrated from the shadowed disk row, so nothing healed.

The shadow case and the upload-window **replay** case are indistinguishable to the reconcile gate (both present as `materializable`, non-pending, `localUpdatedAt > stagingUpdatedAt`), so no timestamp rule wins both. The fix adds a **source-side discriminator**: write provenance.

## Approach (Option 1: write provenance)

A speculative mint stamps its `updated_by` with `system:<userId>` (the minting client's id). The reconcile gate then lets a non-pending strictly-newer local row yield to the server **only if it is this client's own pristine system mint** — a real edit keeps strictly-newer protection, so replay-safety is preserved. `updated_by` is restamped on every write, so the marker **self-clears** on the first real edit with zero extra bookkeeping (this is why provenance lives in `updated_by` and not a separate column/flag, which would each need an explicit promote-on-edit step).

Built as 10 reviewable commits:

1. `system:<userId>` author helpers (`api/user.ts`)
2. `systemMint` insert-only opt (`TxInsertOpts`) + same-tx author inheritance — so the `addTypeInTx`/`setProperty` shaping a mint does inherits the system author instead of promoting the row
3. `refactor`: contain the `system:` marker to `updated_by`; `created_by` stays the real user (one trustworthy identity column; clean `created_by = X` queries)
4. mark every speculative mint site as `systemMint` (state blocks, kernel pages, journal/daily-note/seats, alias seats, shortcuts) — Roam import and local-workspace bootstrap deliberately not marked
5. provenance-aware reconcile gate + `healing` gate mode + `healWorkspace` recovery rescan (un-shadows pre-provenance, real-user-stamped shadows on upgrade)
6. live cache heal via `BlockCache.applyFromSync` (heals in-session, not just on reload)
7. mark the handoff doc resolved
8. `fix(ui)`: render system authors as "System" (don't leak the `system:<id>` prefix into "Changed by" / the update indicator)
9. `fix(sync)`: force-heal the live cache only in the strict steady-state path, not the one-time healing rescan (avoids a transient cache flicker)
10. `test`: guard restore-stays-user-authored and createOrGet live-hit; doc nits

Net behavior: new divergences never form, the replay clobber is gone, and existing shadows heal — live in-session for the current client, and on first open (then reload) for stragglers via the healing rescan.

## Key decisions

- **Marker on `updated_by` only, `created_by` stays real.** `updated_by` is the field the gate reads and that self-clears; `created_by` is identity/ownership and stays a real user id, so the prefix never leaks into creator attribution or `created_by = X` queries.
- **Per-user derivation** (`system:<userId>`, not a global sentinel): keeps the mint attributable (history/SQL show which client minted it), makes the namespace collision-safe (real ids are UUIDs), and lets the gate exact-match *this* client's own mint.
- **No server change needed.** The `blocks_write` RLS policy gates on workspace-writer membership only — it never compares `created_by`/`updated_by` to `auth.uid()` — and `apply_block_patches` is `SECURITY INVOKER` and passes the author through. So `system:<userId>` uploads fine; this is **client-only — no Supabase migration or PowerSync sync-config change**.
- **Healing-mode recovery rescan** is essential on upgrade: a shadow minted by pre-provenance code is real-user-stamped, so the strict gate would protect it and re-permanent it. The rescan runs the gate in healing mode (server wins on any strictly-newer non-pending row; pending + equal-stamp guards still hold) so existing shadows un-shadow.

## Testing

- `yarn run check` green (3109 tests, 0 errors).
- Provenance gate covered at unit (`reconcile.test.ts`), DB (`materialize.test.ts`), and observer-integration (`observer.test.ts`) layers, including heal vs replay-protect, equal-stamp, healing mode, exact-user-match, the Phase-1/Phase-2 TOCTOU re-gate, and the live cache heal.
- The replay-freeze canary (`invalidation.test.ts:645`) still genuinely guards (verified it skip-stales via the new strict branch, not for the wrong reason).

## Reviewer notes

- This change was put through a three-perspective review (correctness/data-integrity, design/abstraction, test-coverage); commits 8–10 are the resulting fixes (UI prefix leak, healing-mode cache flicker, two regression-guard tests).
- The live-heal force path relies on `blockFingerprint` (a `JSON.stringify`) matching between the cache snapshot and the observer's pre-write `before` row — the same canonical-key-order assumption the existing cache dedup already depends on. If a future change reorders `BlockData` fields in one construction path and not another, both degrade to LWW (heal defers to reload) rather than breaking.
