### PR TITLE
Keep caret visible above on-screen keyboard while editing

### DIFF
--- a/src/components/BlockEditor.tsx
+++ b/src/components/BlockEditor.tsx
@@ -13,7 +13,8 @@ import { placeCursorAtX, placeCursorAtCoords } from '@/utils/codemirror.js'
 import { useContentRevision, usePropertyValue } from '@/hooks/block.js'
 import { shouldExitEditModeAfterBlur } from '@/utils/dom.js'
 import { EditorView } from '@codemirror/view'
-import { EditorSelection } from '@codemirror/state'
+import { EditorSelection, type Extension } from '@codemirror/state'
+import { keyboardAwareScroll } from '@/utils/keyboardAwareScroll.js'
 import { useShortcutSurfaceActivations } from '@/extensions/useShortcutSurfaceActivations.js'
 import { useBlockContext } from '@/context/block.js'
 
@@ -205,16 +206,30 @@ export const BlockEditor = ({
       editorView.focus()
 
       const selection = uiStateBlock.peekProperty(editorSelection)
-      if (cancelled || selection?.blockId !== block.id) return
-
-      if (selection.x !== undefined && selection.y !== undefined) {
-        placeCursorAtCoords(editorView, {x: selection.x, y: selection.y})
-      } else if (selection.x !== undefined) {
-        placeCursorAtX(editorView, selection.x, selection.line === 'last')
-      } else if (selection.start !== undefined) {
-        const end = selection.end ?? selection.start
-        editorView.dispatch({selection: {anchor: selection.start, head: end}})
+      if (!cancelled && selection?.blockId === block.id) {
+        if (selection.x !== undefined && selection.y !== undefined) {
+          placeCursorAtCoords(editorView, {x: selection.x, y: selection.y})
+        } else if (selection.x !== undefined) {
+          placeCursorAtX(editorView, selection.x, selection.line === 'last')
+        } else if (selection.start !== undefined) {
+          const end = selection.end ?? selection.start
+          editorView.dispatch({selection: {anchor: selection.start, head: end}})
+        }
       }
+
+      if (cancelled) return
+      // Pull the caret into view on edit-entry. `view.focus()` uses
+      // preventScroll (CodeMirror's default), so nothing else scrolls
+      // here — and when the on-screen keyboard is already up (tapping a
+      // second block while editing) no visualViewport resize fires for
+      // keyboardAwareScroll's plugin to catch, making this the only
+      // chance to lift the caret above the keyboard. The scrollMargins
+      // contributed by keyboardAwareScroll keep that landing keyboard-
+      // aware; on desktop the margin is 0 and this is a cheap no-op for
+      // an already-visible caret.
+      editorView.dispatch({
+        effects: EditorView.scrollIntoView(editorView.state.selection.main.head),
+      })
     })
 
     return () => {
@@ -228,6 +243,15 @@ export const BlockEditor = ({
   // mounted — for any consumer (markdown editor, extension editor, future).
   const shortcutSurfaceOptions = useMemo(() => ({editorView: editorView ?? undefined}), [editorView])
   useShortcutSurfaceActivations(block, 'codemirror', shortcutSurfaceOptions)
+
+  // Every block editor gets keyboard-aware scrolling so the caret stays
+  // above the on-screen keyboard (see keyboardAwareScroll). Prepended so
+  // a caller-supplied extension can still override anything if it needs to.
+  const {extensions: providedExtensions, ...restCodeMirrorProps} = codeMirrorProps
+  const mergedExtensions = useMemo<Extension[]>(
+    () => [keyboardAwareScroll(), ...(providedExtensions ?? [])],
+    [providedExtensions],
+  )
 
   if (!blockEditData) return null
 
@@ -287,7 +311,8 @@ export const BlockEditor = ({
           setIsEditing(false)
         })
       }}
-      {...codeMirrorProps}
+      extensions={mergedExtensions}
+      {...restCodeMirrorProps}
     />
   )
 }

--- a/src/utils/keyboardAwareScroll.ts
+++ b/src/utils/keyboardAwareScroll.ts
@@ -1,0 +1,71 @@
+import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view'
+import type { Extension } from '@codemirror/state'
+import { getKeyboardOverlap, subscribeKeyboardViewport } from './keyboardViewport.js'
+
+// Below this many CSS px we treat the overlap as viewport noise (URL-bar
+// jitter, sub-pixel rounding) rather than a real on-screen keyboard, and
+// don't bother re-asserting the caret. On-screen keyboards are far taller
+// than this, so it can't swallow a genuine keyboard.
+const MIN_KEYBOARD_OVERLAP = 60
+
+/** Keeps the caret visible above the on-screen keyboard while editing.
+ *
+ *  Two cooperating pieces:
+ *  - `scrollMargins` reserves the keyboard's height at the bottom of the
+ *    editor's scroll target, so CodeMirror's own "scroll the cursor into
+ *    view" (on edit-entry and as the user types near the bottom) lands
+ *    the caret above the keyboard instead of behind it. CodeMirror
+ *    measures the scroller in layout coordinates, which is exactly what
+ *    `getKeyboardOverlap` reports.
+ *  - a ViewPlugin re-asserts the caret when the keyboard *opens after*
+ *    focus. Tapping a block focuses it, but the keyboard then animates up
+ *    a few frames later — a visualViewport resize that the focus call
+ *    can't wait for. BlockEditor's edit-entry scroll covers the inverse
+ *    case (keyboard already up when you tap a second block), which fires
+ *    no resize.
+ *
+ *  Inert on desktop: with no keyboard the overlap is 0, so the margin is
+ *  null and the re-assert is gated out. */
+export const keyboardAwareScroll = (): Extension => [
+  EditorView.scrollMargins.of(() => {
+    const overlap = getKeyboardOverlap()
+    return overlap > 0 ? {bottom: overlap} : null
+  }),
+  ViewPlugin.fromClass(
+    class {
+      private unsubscribe: (() => void) | null = null
+
+      constructor(view: EditorView) {
+        // Only the focused editor needs to react to the keyboard; gating
+        // the subscription on focus keeps at most one live listener even
+        // when several editors are mounted.
+        if (view.hasFocus) this.subscribe(view)
+      }
+
+      update(update: ViewUpdate) {
+        if (!update.focusChanged) return
+        if (update.view.hasFocus) this.subscribe(update.view)
+        else this.teardown()
+      }
+
+      destroy() {
+        this.teardown()
+      }
+
+      private subscribe(view: EditorView) {
+        if (this.unsubscribe) return
+        this.unsubscribe = subscribeKeyboardViewport(() => {
+          if (!view.hasFocus || getKeyboardOverlap() < MIN_KEYBOARD_OVERLAP) return
+          view.dispatch({
+            effects: EditorView.scrollIntoView(view.state.selection.main.head),
+          })
+        })
+      }
+
+      private teardown() {
+        this.unsubscribe?.()
+        this.unsubscribe = null
+      }
+    },
+  ),
+]

--- a/src/utils/keyboardViewport.ts
+++ b/src/utils/keyboardViewport.ts
@@ -1,0 +1,74 @@
+/** Tracks how much of the layout viewport's bottom edge is currently
+ *  hidden behind the on-screen keyboard, in CSS px.
+ *
+ *  Measured in *layout* coordinates — the space that in-flow / scrolled
+ *  content (the panel scroller, a CodeMirror editor) lives in — via
+ *  `innerHeight - (visualViewport.height + offsetTop)`. That delta is the
+ *  keyboard's intrusion into the layout viewport and is invariant to the
+ *  URL bar (which moves both terms together, so it cancels):
+ *
+ *  - iOS Safari / Edge / Samsung Internet: the layout viewport stays full
+ *    height while the visual viewport shrinks → overlap == keyboard
+ *    height. The content's bottom rows sit behind the keyboard, so this
+ *    is exactly the margin to keep clear.
+ *  - Chrome on Android (resizes-content default): the layout viewport
+ *    itself shrinks with the keyboard → overlap == 0. The scroller
+ *    already shrank, so no extra margin is needed.
+ *
+ *  NB: this is deliberately a *different* quantity from the mobile
+ *  toolbar's `useKeyboardInset`. That one answers "where do I pin a
+ *  position:fixed element?", which depends on how the browser anchors
+ *  fixed elements (and needs a sentinel probe to detect). For scroll
+ *  margins on layout-positioned content the formula above is uniform
+ *  across browsers, so the two can't share an implementation. */
+
+const computeOverlap = (): number => {
+  if (typeof window === 'undefined') return 0
+  const vv = window.visualViewport
+  if (!vv) return 0
+  return Math.max(0, Math.round(window.innerHeight - (vv.height + vv.offsetTop)))
+}
+
+/** Current keyboard overlap, recomputed live. Cheap enough to read from a
+ *  CodeMirror scrollMargins facet on every scroll computation. */
+export const getKeyboardOverlap = (): number => computeOverlap()
+
+type Listener = () => void
+
+const listeners = new Set<Listener>()
+let attached = false
+
+const notify = () => {
+  for (const listener of listeners) listener()
+}
+
+const attach = () => {
+  if (attached || typeof window === 'undefined') return
+  attached = true
+  const vv = window.visualViewport
+  vv?.addEventListener('resize', notify)
+  vv?.addEventListener('scroll', notify)
+  window.addEventListener('resize', notify)
+}
+
+const detach = () => {
+  if (!attached || typeof window === 'undefined') return
+  attached = false
+  const vv = window.visualViewport
+  vv?.removeEventListener('resize', notify)
+  vv?.removeEventListener('scroll', notify)
+  window.removeEventListener('resize', notify)
+}
+
+/** Subscribe to visual-viewport geometry changes (keyboard open/close,
+ *  URL-bar collapse, rotation). Listeners are attached lazily on the
+ *  first subscription and torn down once the last one leaves, so an app
+ *  with no active editors carries no global listeners. */
+export const subscribeKeyboardViewport = (listener: Listener): (() => void) => {
+  listeners.add(listener)
+  attach()
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) detach()
+  }
+}

--- a/src/utils/test/keyboardViewport.test.ts
+++ b/src/utils/test/keyboardViewport.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getKeyboardOverlap, subscribeKeyboardViewport } from '@/utils/keyboardViewport'
+
+/** Minimal stand-in for window.visualViewport that lets tests drive the
+ *  height/offsetTop the overlap formula reads, and records listeners so
+ *  the subscribe lifecycle can be asserted. */
+const installViewport = (initial: {height: number; offsetTop?: number}) => {
+  const listeners = new Map<string, Set<() => void>>()
+  const vv = {
+    height: initial.height,
+    offsetTop: initial.offsetTop ?? 0,
+    addEventListener: (type: string, cb: () => void) => {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type)!.add(cb)
+    },
+    removeEventListener: (type: string, cb: () => void) => {
+      listeners.get(type)?.delete(cb)
+    },
+    emit: (type: string) => listeners.get(type)?.forEach(cb => cb()),
+    listenerCount: () =>
+      [...listeners.values()].reduce((sum, set) => sum + set.size, 0),
+  }
+  vi.stubGlobal('visualViewport', vv)
+  return vv
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getKeyboardOverlap', () => {
+  it('reports the keyboard height when the layout viewport stays full (iOS Safari / Edge)', () => {
+    vi.stubGlobal('innerHeight', 800)
+    installViewport({height: 500})
+    expect(getKeyboardOverlap()).toBe(300)
+  })
+
+  it('reports zero when the layout viewport shrinks with the keyboard (Chrome resizes-content)', () => {
+    vi.stubGlobal('innerHeight', 500)
+    installViewport({height: 500})
+    expect(getKeyboardOverlap()).toBe(0)
+  })
+
+  it('stays URL-bar invariant by subtracting the visual viewport offset', () => {
+    // Visual viewport pushed down by 60px (URL bar) and 240px shorter:
+    // only the keyboard portion (800 - 60 - 500) should count.
+    vi.stubGlobal('innerHeight', 800)
+    installViewport({height: 500, offsetTop: 60})
+    expect(getKeyboardOverlap()).toBe(240)
+  })
+
+  it('never goes negative', () => {
+    vi.stubGlobal('innerHeight', 500)
+    installViewport({height: 760})
+    expect(getKeyboardOverlap()).toBe(0)
+  })
+})
+
+describe('subscribeKeyboardViewport', () => {
+  it('attaches on first subscriber and detaches once the last leaves', () => {
+    const vv = installViewport({height: 500})
+    expect(vv.listenerCount()).toBe(0)
+
+    const unsubA = subscribeKeyboardViewport(() => {})
+    const unsubB = subscribeKeyboardViewport(() => {})
+    expect(vv.listenerCount()).toBeGreaterThan(0)
+
+    unsubA()
+    expect(vv.listenerCount()).toBeGreaterThan(0) // B still listening
+    unsubB()
+    expect(vv.listenerCount()).toBe(0)
+  })
+
+  it('notifies subscribers when the viewport changes', () => {
+    const vv = installViewport({height: 500})
+    const seen = vi.fn()
+    const unsub = subscribeKeyboardViewport(seen)
+
+    vv.emit('resize')
+    vv.emit('scroll')
+    expect(seen).toHaveBeenCalledTimes(2)
+
+    unsub()
+    vv.emit('resize')
+    expect(seen).toHaveBeenCalledTimes(2) // no longer notified
+  })
+})


### PR DESCRIPTION
## Summary
Adds keyboard-aware scroll behavior to the CodeMirror editor to ensure the caret remains visible above the on-screen keyboard on mobile devices. This prevents the keyboard from obscuring the text being edited.

## Key Changes
- **New `keyboardViewport.ts` utility**: Measures keyboard overlap by computing the difference between the layout viewport height and visual viewport dimensions. Handles browser differences (iOS Safari keeps layout viewport full while Chrome resizes it) and URL bar offsets. Provides `getKeyboardOverlap()` for reading current overlap and `subscribeKeyboardViewport()` for listening to viewport changes with lazy attachment/detachment of global listeners.

- **New `keyboardAwareScroll.ts` extension**: CodeMirror extension that:
  - Sets `scrollMargins` to reserve space at the bottom of the editor equal to keyboard overlap
  - Adds a ViewPlugin that re-asserts caret visibility when the keyboard opens after focus (via visualViewport resize events)
  - Only subscribes to keyboard events when the editor has focus, keeping at most one active listener

- **Updated `BlockEditor.tsx`**:
  - Integrates `keyboardAwareScroll()` extension into all block editors
  - Adds explicit scroll-into-view dispatch on edit-entry to handle the case where keyboard is already open when tapping a second block (no resize event fires in this scenario)
  - Refactored selection logic for clarity

## Implementation Details
- The keyboard overlap formula (`innerHeight - (visualViewport.height + offsetTop)`) is invariant to URL bar position since both terms move together
- Minimum overlap threshold of 60px filters out URL bar jitter and sub-pixel rounding noise
- Inert on desktop where keyboard overlap is always 0
- Comprehensive test coverage for overlap calculation across browser behaviors and viewport changes

https://claude.ai/code/session_01KbeEUVuTm5V6rkiCTFRAFo