### PR TITLE
fix(mobile): keep the caret above the editing toolbar, not just the keyboard

### DIFF
--- a/src/plugins/mobile-keyboard-toolbar/MobileKeyboardToolbar.tsx
+++ b/src/plugins/mobile-keyboard-toolbar/MobileKeyboardToolbar.tsx
@@ -13,6 +13,7 @@ import { useRunAction } from '@/shortcuts/runAction.js'
 import { useActiveContextsState } from '@/shortcuts/ActiveContexts.js'
 import { ActionContextTypes, type CodeMirrorEditModeDependencies } from '@/shortcuts/types.js'
 import { acquireBlurExitSuppression } from '@/components/BlockEditor.js'
+import { setEditingToolbarHeight } from '@/utils/keyboardViewport.js'
 import {
   INSERT_BLOCK_REF_TRIGGER_ACTION_ID,
   INSERT_PAGE_REF_TRIGGER_ACTION_ID,
@@ -183,6 +184,27 @@ export function MobileKeyboardToolbar() {
   // toolbar is on screen.
   const keyboardInset = useKeyboardInset(isMobile && isEditing)
 
+  // Publish the toolbar's rendered height so keyboardAwareScroll can keep
+  // the caret above the toolbar, not just above the keyboard. Measured
+  // (rather than hardcoded) so it tracks button/padding/safe-area changes,
+  // and re-published via ResizeObserver; cleared to 0 on unmount.
+  const toolbarRef = useRef<HTMLDivElement | null>(null)
+  useLayoutEffect(() => {
+    const el = toolbarRef.current
+    if (!el) {
+      setEditingToolbarHeight(0)
+      return
+    }
+    const measure = () => setEditingToolbarHeight(el.getBoundingClientRect().height)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => {
+      observer.disconnect()
+      setEditingToolbarHeight(0)
+    }
+  }, [isMobile, isEditing])
+
   if (!isMobile || !isEditing) return null
 
   // Prevent the editor from blurring when a button is pressed — losing
@@ -252,6 +274,7 @@ export function MobileKeyboardToolbar() {
 
   return (
     <div
+      ref={toolbarRef}
       // `keyboardInset` is 0 on browsers where bottom:0 already lands
       // above the keyboard (Chrome on Android, iOS Safari) and equals
       // the keyboard's CSS-px height on browsers that anchor

--- a/src/utils/keyboardAwareScroll.ts
+++ b/src/utils/keyboardAwareScroll.ts
@@ -2,6 +2,7 @@ import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view'
 import type { Extension } from '@codemirror/state'
 import {
   getBottomEditingInset,
+  getEditingToolbarHeight,
   getKeyboardOverlap,
   subscribeKeyboardViewport,
 } from './keyboardViewport.js'
@@ -62,7 +63,17 @@ export const keyboardAwareScroll = (): Extension => [
       private subscribe(view: EditorView) {
         if (this.unsubscribe) return
         this.unsubscribe = subscribeKeyboardViewport(() => {
-          if (!view.hasFocus || getKeyboardOverlap() < MIN_KEYBOARD_OVERLAP) return
+          if (!view.hasFocus) return
+          // Re-scroll when there's a real keyboard OR the editing toolbar
+          // is present. The toolbar height is only ever nonzero while the
+          // toolbar is actually rendered (mobile + editing), so it's a
+          // reliable signal rather than viewport noise. This matters on
+          // Chrome Android's resizes-content path, where the keyboard
+          // overlap stays 0 (the layout viewport shrank with the keyboard)
+          // yet the toolbar still obscures the caret.
+          if (getKeyboardOverlap() < MIN_KEYBOARD_OVERLAP && getEditingToolbarHeight() === 0) {
+            return
+          }
           view.dispatch({
             effects: EditorView.scrollIntoView(view.state.selection.main.head),
           })

--- a/src/utils/keyboardAwareScroll.ts
+++ b/src/utils/keyboardAwareScroll.ts
@@ -1,6 +1,10 @@
 import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view'
 import type { Extension } from '@codemirror/state'
-import { getKeyboardOverlap, subscribeKeyboardViewport } from './keyboardViewport.js'
+import {
+  getBottomEditingInset,
+  getKeyboardOverlap,
+  subscribeKeyboardViewport,
+} from './keyboardViewport.js'
 
 // Below this many CSS px we treat the overlap as viewport noise (URL-bar
 // jitter, sub-pixel rounding) rather than a real on-screen keyboard, and
@@ -11,25 +15,28 @@ const MIN_KEYBOARD_OVERLAP = 60
 /** Keeps the caret visible above the on-screen keyboard while editing.
  *
  *  Two cooperating pieces:
- *  - `scrollMargins` reserves the keyboard's height at the bottom of the
+ *  - `scrollMargins` reserves the bottom editing inset (keyboard height
+ *    plus the editing toolbar floating above it) at the bottom of the
  *    editor's scroll target, so CodeMirror's own "scroll the cursor into
  *    view" (on edit-entry and as the user types near the bottom) lands
- *    the caret above the keyboard instead of behind it. CodeMirror
- *    measures the scroller in layout coordinates, which is exactly what
- *    `getKeyboardOverlap` reports.
+ *    the caret above that chrome instead of behind it. CodeMirror measures
+ *    the scroller in layout coordinates, which is exactly what
+ *    `getBottomEditingInset` reports.
  *  - a ViewPlugin re-asserts the caret when the keyboard *opens after*
  *    focus. Tapping a block focuses it, but the keyboard then animates up
  *    a few frames later — a visualViewport resize that the focus call
- *    can't wait for. BlockEditor's edit-entry scroll covers the inverse
- *    case (keyboard already up when you tap a second block), which fires
- *    no resize.
+ *    can't wait for. The same subscription also fires when the editing
+ *    toolbar mounts/resizes, so a late-arriving toolbar still lifts the
+ *    caret clear. BlockEditor's edit-entry scroll covers the inverse case
+ *    (keyboard already up when you tap a second block), which fires no
+ *    resize.
  *
- *  Inert on desktop: with no keyboard the overlap is 0, so the margin is
+ *  Inert on desktop: with no keyboard the inset is 0, so the margin is
  *  null and the re-assert is gated out. */
 export const keyboardAwareScroll = (): Extension => [
   EditorView.scrollMargins.of(() => {
-    const overlap = getKeyboardOverlap()
-    return overlap > 0 ? {bottom: overlap} : null
+    const inset = getBottomEditingInset()
+    return inset > 0 ? {bottom: inset} : null
   }),
   ViewPlugin.fromClass(
     class {

--- a/src/utils/keyboardViewport.ts
+++ b/src/utils/keyboardViewport.ts
@@ -61,9 +61,10 @@ const detach = () => {
 }
 
 /** Subscribe to visual-viewport geometry changes (keyboard open/close,
- *  URL-bar collapse, rotation). Listeners are attached lazily on the
- *  first subscription and torn down once the last one leaves, so an app
- *  with no active editors carries no global listeners. */
+ *  URL-bar collapse, rotation) *and* editing-toolbar height changes.
+ *  Listeners are attached lazily on the first subscription and torn down
+ *  once the last one leaves, so an app with no active editors carries no
+ *  global listeners. */
 export const subscribeKeyboardViewport = (listener: Listener): (() => void) => {
   listeners.add(listener)
   attach()
@@ -72,3 +73,30 @@ export const subscribeKeyboardViewport = (listener: Listener): (() => void) => {
     if (listeners.size === 0) detach()
   }
 }
+
+// The mobile editing toolbar floats just above the keyboard while a block
+// is being edited, so it obscures another strip of the otherwise-visible
+// area. The toolbar publishes its measured height here (0 when it isn't
+// shown) so scroll math can keep the caret above it too, not just above
+// the keyboard.
+let editingToolbarHeight = 0
+
+/** Height of the mobile editing toolbar currently on screen, in CSS px
+ *  (0 when none is shown). */
+export const getEditingToolbarHeight = (): number => editingToolbarHeight
+
+/** Publish the editing toolbar's measured height. Notifies viewport
+ *  subscribers on change so a focused editor can re-assert the caret when
+ *  the toolbar mounts/resizes after the keyboard is already up. */
+export const setEditingToolbarHeight = (height: number): void => {
+  const next = Math.max(0, Math.round(height))
+  if (next === editingToolbarHeight) return
+  editingToolbarHeight = next
+  notify()
+}
+
+/** Total height obscured at the bottom of the editing surface — the
+ *  on-screen keyboard plus the editing toolbar floating above it. This is
+ *  the bottom scroll margin needed to land the caret in the clear. */
+export const getBottomEditingInset = (): number =>
+  getKeyboardOverlap() + editingToolbarHeight

--- a/src/utils/test/keyboardViewport.test.ts
+++ b/src/utils/test/keyboardViewport.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getKeyboardOverlap, subscribeKeyboardViewport } from '@/utils/keyboardViewport'
+import {
+  getBottomEditingInset,
+  getKeyboardOverlap,
+  setEditingToolbarHeight,
+  subscribeKeyboardViewport,
+} from '@/utils/keyboardViewport'
 
 /** Minimal stand-in for window.visualViewport that lets tests drive the
  *  height/offsetTop the overlap formula reads, and records listeners so
@@ -26,6 +31,8 @@ const installViewport = (initial: {height: number; offsetTop?: number}) => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  // Module-level state — reset so it doesn't bleed between tests.
+  setEditingToolbarHeight(0)
 })
 
 describe('getKeyboardOverlap', () => {
@@ -83,5 +90,35 @@ describe('subscribeKeyboardViewport', () => {
     unsub()
     vv.emit('resize')
     expect(seen).toHaveBeenCalledTimes(2) // no longer notified
+  })
+
+  it('notifies subscribers when the editing toolbar height changes', () => {
+    installViewport({height: 500})
+    const seen = vi.fn()
+    const unsub = subscribeKeyboardViewport(seen)
+
+    setEditingToolbarHeight(48)
+    expect(seen).toHaveBeenCalledTimes(1)
+
+    setEditingToolbarHeight(48) // unchanged — no notification
+    expect(seen).toHaveBeenCalledTimes(1)
+
+    unsub()
+  })
+})
+
+describe('getBottomEditingInset', () => {
+  it('adds the editing toolbar height on top of the keyboard overlap', () => {
+    vi.stubGlobal('innerHeight', 800)
+    installViewport({height: 500}) // 300px keyboard overlap
+    setEditingToolbarHeight(48)
+    expect(getBottomEditingInset()).toBe(348)
+  })
+
+  it('is just the toolbar height when there is no keyboard', () => {
+    vi.stubGlobal('innerHeight', 500)
+    installViewport({height: 500}) // 0px overlap
+    setEditingToolbarHeight(48)
+    expect(getBottomEditingInset()).toBe(48)
   })
 })


### PR DESCRIPTION
## Problem

The keyboard-aware scroll from #129 lifts the caret above the on-screen keyboard, but the mobile editing toolbar floats in the strip *just above* the keyboard — so the block being edited ended up landing exactly behind the toolbar. The scroll "worked", but the block was still covered.

## Fix

Account for the toolbar's height in the scroll margin, not just the keyboard overlap.

- **`keyboardViewport`** — the toolbar publishes its measured height via `setEditingToolbarHeight` (0 when not shown); `getBottomEditingInset` sums it with the keyboard overlap. A height change notifies viewport subscribers, so a focused editor re-asserts the caret when the toolbar mounts/resizes *after* the keyboard is already up.
- **`keyboardAwareScroll`** — `scrollMargins` now reserves `getBottomEditingInset()` instead of the keyboard overlap alone.
- **`MobileKeyboardToolbar`** — measures its own rendered height with a `ResizeObserver` (so it tracks button / padding / safe-area changes rather than a hardcoded constant that could drift from the CSS) and clears to 0 on unmount.

Still inert on desktop: no keyboard and no toolbar means a 0 inset, so the margin is null and the re-assert is gated out.

## Testing

- `yarn run check` passes — compile clean, 0 lint errors, 3139 tests pass (incl. new coverage for the toolbar-height store and the combined `getBottomEditingInset`).
- The cross-browser formula and the inset sum are unit-tested; the actual keyboard+toolbar UX still wants a real-device / simulator pass (iOS Simulator with the software keyboard, or a real phone), which can't be exercised from CI.

https://claude.ai/code/session_01KbeEUVuTm5V6rkiCTFRAFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbeEUVuTm5V6rkiCTFRAFo)_