### PR TITLE
Unify AppExtension tree-walkers; fix disabled-plugin-steers-landing bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,18 +200,26 @@ const replaceHash = (hash: string): void => {
 // `workspaceLandingFacet` contributor) would still steer first paint.
 //
 // The cache keeps the cost down across re-entries via getInitialLayout's
-// promise cache; entries are keyed by `repo.instanceId` + workspace so a
-// fresh Repo (new login) or a workspace switch (different overrides)
-// builds a fresh runtime.
+// promise cache; entries are keyed by `repo.instanceId` + workspace +
+// the override state, so a fresh Repo (new login), a workspace switch,
+// or a mid-session toggle change (Settings dispatches
+// `refreshAppRuntime`) all build a fresh runtime instead of replaying a
+// stale one — otherwise a just-disabled daily-notes could still steer a
+// later empty-layout navigation until a full reload.
 const landingRuntimeCache = new Map<string, ReturnType<typeof resolveAppRuntimeSync>>()
 const getLandingRuntime = (repo: Repo) => {
   const workspaceId = repo.activeWorkspaceId
-  const cacheKey = `${repo.instanceId}:${workspaceId ?? ''}`
-  const cached = landingRuntimeCache.get(cacheKey)
-  if (cached) return cached
   const overrides = workspaceId
     ? readOverridesCache(workspaceId)
     : new Map<string, boolean>()
+  // Sparse map (only entries diverging from manifest defaults), sorted
+  // for a stable key regardless of insertion order.
+  const overridesFingerprint = JSON.stringify(
+    [...overrides.entries()].sort(([a], [b]) => a.localeCompare(b)),
+  )
+  const cacheKey = `${repo.instanceId}:${workspaceId ?? ''}:${overridesFingerprint}`
+  const cached = landingRuntimeCache.get(cacheKey)
+  if (cached) return cached
   const runtime = resolveAppRuntimeSync(staticAppExtensions({repo}), {
     overrides,
     context: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,8 @@ import { getOrCreateRecentsPage } from '@/data/recentsPage.js'
 import { useMyWorkspaceRoles } from '@/hooks/useWorkspaces.js'
 import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks.js'
 import { workspaceLandingFacet } from '@/extensions/core.js'
-import { resolveFacetRuntimeSync } from '@/extensions/facet.js'
+import { resolveAppRuntimeSync } from '@/extensions/resolveAppRuntime.js'
+import { readOverridesCache } from '@/extensions/overridesCache.js'
 import { staticAppExtensions } from '@/extensions/staticAppExtensions.js'
 import { getLayoutSessionId } from '@/utils/layoutSessionId.js'
 import {
@@ -190,20 +191,36 @@ const replaceHash = (hash: string): void => {
 // `workspaceLandingFacet` resolvers only need the kernel + static
 // plugin contributions — dynamic plugins haven't loaded yet at this
 // point in bootstrap, and we don't want to give them the power to
-// redirect a user's first paint. The cache keeps the cost down across
-// re-entries via getInitialLayout's promise cache; entries are bound
-// to `repo.instanceId` so a fresh Repo (new login) builds a fresh
-// runtime.
-const landingRuntimeCache = new Map<number, ReturnType<typeof resolveFacetRuntimeSync>>()
+// redirect a user's first paint.
+//
+// Resolution goes through `resolveAppRuntimeSync` with the workspace's
+// cached toggle overrides — NOT the bare collector — so a togglable
+// boundary the user has disabled is honoured here too. Without this, a
+// disabled non-essential plugin (e.g. `system:daily-notes`, the sole
+// `workspaceLandingFacet` contributor) would still steer first paint.
+//
+// The cache keeps the cost down across re-entries via getInitialLayout's
+// promise cache; entries are keyed by `repo.instanceId` + workspace so a
+// fresh Repo (new login) or a workspace switch (different overrides)
+// builds a fresh runtime.
+const landingRuntimeCache = new Map<string, ReturnType<typeof resolveAppRuntimeSync>>()
 const getLandingRuntime = (repo: Repo) => {
-  const cached = landingRuntimeCache.get(repo.instanceId)
+  const workspaceId = repo.activeWorkspaceId
+  const cacheKey = `${repo.instanceId}:${workspaceId ?? ''}`
+  const cached = landingRuntimeCache.get(cacheKey)
   if (cached) return cached
-  const runtime = resolveFacetRuntimeSync(staticAppExtensions({repo}), {
-    repo,
-    workspaceId: repo.activeWorkspaceId,
-    safeMode: false,
+  const overrides = workspaceId
+    ? readOverridesCache(workspaceId)
+    : new Map<string, boolean>()
+  const runtime = resolveAppRuntimeSync(staticAppExtensions({repo}), {
+    overrides,
+    context: {
+      repo,
+      workspaceId,
+      safeMode: false,
+    },
   })
-  landingRuntimeCache.set(repo.instanceId, runtime)
+  landingRuntimeCache.set(cacheKey, runtime)
   return runtime
 }
 

--- a/src/extensions/discoverToggleTree.ts
+++ b/src/extensions/discoverToggleTree.ts
@@ -16,10 +16,12 @@
  *     async awaits and recurses, logging + recovering on rejection
  */
 
-import type {
-  AppExtension,
-  FacetContribution,
-  FacetResolveContext,
+import {
+  walkAppExtension,
+  walkAppExtensionSync,
+  type AppExtension,
+  type AppExtensionVisitor,
+  type FacetResolveContext,
 } from '@/extensions/facet.js'
 import {getBoundary, type Togglable} from '@/extensions/togglable.js'
 
@@ -28,12 +30,27 @@ export interface ToggleNode {
   children: ToggleNode[]
 }
 
-const isFacetContribution = (
-  value: unknown,
-): value is FacetContribution<unknown> =>
-  typeof value === 'object' &&
-  value !== null &&
-  (value as {type?: unknown}).type === 'facet-contribution'
+/** Discovery's configuration of the shared walker. The threaded `sink`
+ *  is the `ToggleNode[]` we're filling:
+ *
+ *   - a boundary array produces a node and retargets descent into its
+ *     `children`; a non-boundary array descends into the current sink
+ *   - a contribution produces no row of its own, but `enables` descends
+ *     into the current sink (so any togglable inside a drag-along
+ *     surfaces as a sibling under the enclosing boundary, or at root)
+ *
+ *  No `isEnabled` filter — the settings tree must surface *every*
+ *  togglable so the user can re-enable a disabled one. No dedup. */
+const discoveryVisitor: AppExtensionVisitor<ToggleNode[]> = {
+  array: (node, sink) => {
+    const handle = getBoundary(node)
+    if (!handle) return sink
+    const child: ToggleNode = {handle, children: []}
+    sink.push(child)
+    return child.children
+  },
+  contribution: (_node, sink) => sink,
+}
 
 /** Sync discovery — usable on the static extension tree which has no
  *  function-valued nodes. Throws on a function (matches the resolver
@@ -43,36 +60,12 @@ export const discoverToggleTreeSync = (
   tree: AppExtension | readonly AppExtension[],
 ): ToggleNode[] => {
   const roots: ToggleNode[] = []
-  walkSync(tree, roots)
-  return roots
-}
-
-function walkSync(
-  node: AppExtension | readonly AppExtension[],
-  sink: ToggleNode[],
-): void {
-  if (!node) return
-
-  if (typeof node === 'function') {
-    throw new Error(
+  walkAppExtensionSync(tree, roots, discoveryVisitor, {
+    onFunction:
       'discoverToggleTreeSync: cannot resolve function-valued AppExtension. ' +
       'Use discoverToggleTree (async) for trees that contain dynamicExtensionsExtension.',
-    )
-  }
-
-  if (Array.isArray(node)) {
-    const handle = getBoundary(node)
-    if (handle) {
-      const child: ToggleNode = {handle, children: []}
-      sink.push(child)
-      for (const inner of node) walkSync(inner as AppExtension, child.children)
-    } else {
-      for (const inner of node) walkSync(inner as AppExtension, sink)
-    }
-    return
-  }
-
-  if (isFacetContribution(node) && node.enables) walkSync(node.enables, sink)
+  })
+  return roots
 }
 
 /** Async discovery — required when the tree contains
@@ -84,43 +77,6 @@ export const discoverToggleTree = async (
   context: FacetResolveContext,
 ): Promise<ToggleNode[]> => {
   const roots: ToggleNode[] = []
-  await walk(tree, context, roots)
+  await walkAppExtension(tree, roots, discoveryVisitor, {context})
   return roots
-}
-
-async function walk(
-  node: AppExtension | readonly AppExtension[],
-  context: FacetResolveContext,
-  sink: ToggleNode[],
-): Promise<void> {
-  if (!node) return
-
-  if (typeof node === 'function') {
-    try {
-      await walk(await node(context), context, sink)
-    } catch (error) {
-      console.error('discoverToggleTree: failed to resolve function', error)
-    }
-    return
-  }
-
-  if (Array.isArray(node)) {
-    const handle = getBoundary(node)
-    if (handle) {
-      const child: ToggleNode = {handle, children: []}
-      sink.push(child)
-      for (const inner of node) {
-        await walk(inner as AppExtension, context, child.children)
-      }
-    } else {
-      for (const inner of node) {
-        await walk(inner as AppExtension, context, sink)
-      }
-    }
-    return
-  }
-
-  if (isFacetContribution(node) && node.enables) {
-    await walk(node.enables, context, sink)
-  }
 }

--- a/src/extensions/dynamicExtensions.ts
+++ b/src/extensions/dynamicExtensions.ts
@@ -5,6 +5,7 @@ import {
 import {
   AppExtension,
   FacetContribution,
+  isFacetContribution,
 } from '@/extensions/facet.js'
 import {
   attachBoundary,
@@ -136,11 +137,6 @@ export const dynamicExtensionsExtension = (
 
   return collected
 }
-
-const isFacetContribution = (value: unknown): value is FacetContribution<unknown> =>
-  typeof value === 'object' &&
-  value !== null &&
-  (value as {type?: unknown}).type === 'facet-contribution'
 
 /**
  * Walks an AppExtension tree, validates shape, and force-prefixes every

--- a/src/extensions/facet.ts
+++ b/src/extensions/facet.ts
@@ -243,7 +243,7 @@ export async function resolveFacetRuntime(
   context: FacetResolveContext = {},
 ): Promise<FacetRuntime> {
   const contributions: FacetContribution<unknown>[] = []
-  await collectContributions(extensions, context, contributions)
+  await walkAppExtension(extensions, contributions, collectVisitor, {context})
   return new FacetRuntime(context, contributions)
 }
 
@@ -252,76 +252,176 @@ export function resolveFacetRuntimeSync(
   context: FacetResolveContext = {},
 ): FacetRuntime {
   const contributions: FacetContribution<unknown>[] = []
-  collectContributionsSync(extensions, contributions)
+  walkAppExtensionSync(extensions, contributions, collectVisitor, {
+    onFunction: 'Cannot resolve function app extensions synchronously',
+  })
   return new FacetRuntime(context, contributions)
 }
 
-const pushValidatedContribution = (
+/** Validate a contribution against its facet's `validate` guard and, if
+ *  it passes, append it to `output`. Returns whether it was accepted —
+ *  the boundary-aware resolver uses the result to decide whether to
+ *  recurse into the contribution's `enables` subtree. */
+export const pushValidatedContribution = (
   contribution: FacetContribution<unknown>,
   output: FacetContribution<unknown>[],
-): void => {
+): boolean => {
   const validate = contribution.facet.validate
   if (validate && !validate(contribution.value)) {
     console.error(
       `Dropping invalid contribution for facet "${contribution.facet.id}"`,
       {source: contribution.source, value: contribution.value},
     )
-    return
+    return false
   }
 
   output.push(contribution)
+  return true
 }
 
-async function collectContributions(
+/** Bare collector visitor: append every valid contribution and never
+ *  recurse into `enables`. This is the historical, togglable-blind
+ *  semantics of the facet.ts collectors — there's no `array` hook, so
+ *  togglable boundaries are walked like any other array. Callers that
+ *  need toggle boundaries go through `resolveAppRuntime` instead. */
+const collectVisitor: AppExtensionVisitor<FacetContribution<unknown>[]> = {
+  contribution: (node, output) => {
+    pushValidatedContribution(node, output)
+    return null
+  },
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Unified AppExtension walker
+// ──────────────────────────────────────────────────────────────────────
+
+/** Runtime type guard for a FacetContribution leaf. Shared by every
+ *  AppExtension walk (collector, boundary-aware resolver, toggle
+ *  discovery, dynamic loader) so the grammar's leaf shape is recognised
+ *  in exactly one place. */
+export const isFacetContribution = (
+  value: unknown,
+): value is FacetContribution<unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  (value as {type?: unknown}).type === 'facet-contribution'
+
+const isExtensionArray = (
   extension: AppExtension | readonly AppExtension[],
-  context: FacetResolveContext,
-  output: FacetContribution<unknown>[],
+): extension is readonly AppExtension[] => Array.isArray(extension)
+
+/**
+ * Per-site policy for `walkAppExtension` / `walkAppExtensionSync`.
+ *
+ * The grammar recursion (array, function, contribution, nullish) is
+ * fixed; only these two hooks vary across the bare collector, the
+ * boundary-aware resolver, and toggle-tree discovery. `C` is the
+ * threaded accumulator/target — an output array for the collectors and
+ * resolver, a `ToggleNode[]` sink for discovery.
+ */
+export interface AppExtensionVisitor<C> {
+  /** Visit an array node before descending. Return `null` to prune the
+   *  subtree, or the context to thread into its children. Omitted ⇒
+   *  descend with the parent context unchanged. The togglable-aware
+   *  walks read the boundary marker here — facet.ts stays ignorant of
+   *  togglable.ts; that policy is injected by the caller. */
+  array?: (node: readonly AppExtension[], ctx: C) => C | null
+  /** Visit a FacetContribution leaf. Return `null` to skip its
+   *  `enables` subtree, or the context to walk `enables` with. */
+  contribution: (node: FacetContribution<unknown>, ctx: C) => C | null
+}
+
+export interface WalkAppExtensionOptions {
+  context: FacetResolveContext
+  /** De-duplicate contributions by identity across the whole walk.
+   *  Needed when `enables` edges can reach the same contribution by
+   *  more than one path (the resolver). */
+  seen?: Set<FacetContribution<unknown>>
+}
+
+export interface WalkAppExtensionSyncOptions {
+  /** Error message thrown when a function-valued node is reached — sync
+   *  walks can't await. Call-site-specific so the thrown message names
+   *  the offending entry point. */
+  onFunction: string
+  seen?: Set<FacetContribution<unknown>>
+}
+
+/** Async walk over the AppExtension grammar — awaits function-valued
+ *  nodes (e.g. the dynamic-extensions loader) and logs + recovers if one
+ *  rejects, so a single bad subtree can't abort the whole resolution. */
+export async function walkAppExtension<C>(
+  node: AppExtension | readonly AppExtension[],
+  ctx: C,
+  visitor: AppExtensionVisitor<C>,
+  options: WalkAppExtensionOptions,
 ): Promise<void> {
-  if (!extension) return
+  if (!node) return
 
-  if (isExtensionArray(extension)) {
-    for (const child of extension) {
-      await collectContributions(child, context, output)
-    }
-    return
-  }
-
-  if (typeof extension === 'function') {
+  if (typeof node === 'function') {
     try {
-      await collectContributions(await extension(context), context, output)
+      await walkAppExtension(await node(options.context), ctx, visitor, options)
     } catch (error) {
       console.error('Failed to resolve app extension', error)
     }
     return
   }
 
-  if (extension.type === 'facet-contribution') {
-    pushValidatedContribution(extension, output)
-  }
-}
-
-function collectContributionsSync(
-  extension: AppExtension | readonly AppExtension[],
-  output: FacetContribution<unknown>[],
-): void {
-  if (!extension) return
-
-  if (isExtensionArray(extension)) {
-    for (const child of extension) {
-      collectContributionsSync(child, output)
+  if (isExtensionArray(node)) {
+    const childCtx = visitor.array ? visitor.array(node, ctx) : ctx
+    if (childCtx === null) return
+    for (const child of node) {
+      await walkAppExtension(child, childCtx, visitor, options)
     }
     return
   }
 
-  if (typeof extension === 'function') {
-    throw new Error('Cannot resolve function app extensions synchronously')
-  }
-
-  if (extension.type === 'facet-contribution') {
-    pushValidatedContribution(extension, output)
+  if (isFacetContribution(node)) {
+    const {seen} = options
+    if (seen) {
+      if (seen.has(node)) return
+      seen.add(node)
+    }
+    const enablesCtx = visitor.contribution(node, ctx)
+    if (enablesCtx !== null && node.enables) {
+      await walkAppExtension(node.enables, enablesCtx, visitor, options)
+    }
   }
 }
 
-const isExtensionArray = (
-  extension: AppExtension | readonly AppExtension[],
-): extension is readonly AppExtension[] => Array.isArray(extension)
+/** Sync walk over the AppExtension grammar — throws on function-valued
+ *  nodes (the static extension tree has none, and first-paint resolution
+ *  can't await). */
+export function walkAppExtensionSync<C>(
+  node: AppExtension | readonly AppExtension[],
+  ctx: C,
+  visitor: AppExtensionVisitor<C>,
+  options: WalkAppExtensionSyncOptions,
+): void {
+  if (!node) return
+
+  if (typeof node === 'function') {
+    throw new Error(options.onFunction)
+  }
+
+  if (isExtensionArray(node)) {
+    const childCtx = visitor.array ? visitor.array(node, ctx) : ctx
+    if (childCtx === null) return
+    for (const child of node) {
+      walkAppExtensionSync(child, childCtx, visitor, options)
+    }
+    return
+  }
+
+  if (isFacetContribution(node)) {
+    const {seen} = options
+    if (seen) {
+      if (seen.has(node)) return
+      seen.add(node)
+    }
+    const enablesCtx = visitor.contribution(node, ctx)
+    if (enablesCtx !== null && node.enables) {
+      walkAppExtensionSync(node.enables, enablesCtx, visitor, options)
+    }
+  }
+}

--- a/src/extensions/resolveAppRuntime.ts
+++ b/src/extensions/resolveAppRuntime.ts
@@ -1,8 +1,8 @@
 /**
  * Boundary-aware FacetRuntime resolver.
  *
- * Wraps the existing facet collector pattern (see `facet.ts:259/287`)
- * with two behaviours the bare collectors don't have:
+ * A thin configuration of the shared `walkAppExtension` skeleton (see
+ * `facet.ts`) adding two behaviours the bare collector visitor doesn't:
  *
  *   1. `getBoundary(node)` on an array → look up `isEnabled(handle,
  *      overrides)`; skip the whole subtree when the toggle resolves
@@ -14,10 +14,10 @@
  *      itself passed validation — dragged-along extensions exist to
  *      support their parent and are dropped when the parent is.
  *
- * Both behaviours apply identically across the sync and async walks
- * (mirroring the facet.ts pair). The async walk additionally awaits
+ * Both behaviours live in `resolverVisitor` and apply identically across
+ * the sync and async walks. The async walk additionally awaits
  * function-valued AppExtensions; the sync walk throws on them, matching
- * the existing `collectContributionsSync` policy.
+ * the shared walker's policy.
  *
  * facet.ts has no awareness of `@/extensions/togglable.ts`; this module
  * is the only place the two meet. Anyone calling `resolveFacetRuntime`
@@ -28,7 +28,11 @@
 
 import {
   FacetRuntime,
+  pushValidatedContribution,
+  walkAppExtension,
+  walkAppExtensionSync,
   type AppExtension,
+  type AppExtensionVisitor,
   type FacetContribution,
   type FacetResolveContext,
 } from '@/extensions/facet.js'
@@ -66,6 +70,24 @@ const shouldKeepBoundary = (
   return isEnabled(handle, overrides)
 }
 
+/** The only thing the resolver adds to the shared walker: a togglable
+ *  boundary array is pruned when its handle resolves to off, and a
+ *  contribution recurses into `enables` only if it survived validation
+ *  (dragged-along extensions exist to support their parent and are
+ *  dropped when the parent is). `output` is the threaded sink. */
+const resolverVisitor = (
+  overrides: Overrides,
+  safeMode: boolean,
+): AppExtensionVisitor<FacetContribution<unknown>[]> => ({
+  array: (node, output) => {
+    const handle = getBoundary(node)
+    if (handle && !shouldKeepBoundary(handle, overrides, safeMode)) return null
+    return output
+  },
+  contribution: (node, output) =>
+    pushValidatedContribution(node, output) ? output : null,
+})
+
 /** Build a FacetRuntime from an AppExtension tree, evaluating toggle
  *  boundaries with the supplied overrides. Async — awaits any
  *  function-valued nodes (e.g. `dynamicExtensionsExtension`). */
@@ -76,15 +98,17 @@ export async function resolveAppRuntime(
   const context = options.context ?? {}
   const safeMode = options.safeMode ?? false
   const collected: FacetContribution<unknown>[] = []
-  const seen = new Set<FacetContribution<unknown>>()
-  await walk(extensions, options.overrides, safeMode, context, collected, seen)
+  await walkAppExtension(extensions, collected, resolverVisitor(options.overrides, safeMode), {
+    context,
+    seen: new Set(),
+  })
   return new FacetRuntime(context, collected)
 }
 
-/** Sync variant. Throws if a function-valued AppExtension is reached,
- *  matching `collectContributionsSync` in facet.ts:300. The static
- *  extension tree contains no functions today; `AppRuntimeProvider`
- *  relies on that for first-paint resolution before React can await. */
+/** Sync variant. Throws if a function-valued AppExtension is reached.
+ *  The static extension tree contains no functions today;
+ *  `AppRuntimeProvider` relies on that for first-paint resolution before
+ *  React can await. */
 export function resolveAppRuntimeSync(
   extensions: AppExtension | readonly AppExtension[],
   options: ResolveAppRuntimeOptions,
@@ -92,108 +116,11 @@ export function resolveAppRuntimeSync(
   const context = options.context ?? {}
   const safeMode = options.safeMode ?? false
   const collected: FacetContribution<unknown>[] = []
-  const seen = new Set<FacetContribution<unknown>>()
-  walkSync(extensions, options.overrides, safeMode, collected, seen)
-  return new FacetRuntime(context, collected)
-}
-
-// ──────────────────────────────────────────────────────────────────────
-// Walk implementations
-// ──────────────────────────────────────────────────────────────────────
-
-/** Validation step mirrors `pushValidatedContribution` in facet.ts:243.
- *  Returns whether the contribution was accepted so the walk knows
- *  whether to recurse into its `enables`. */
-function pushValidatedContribution(
-  contribution: FacetContribution<unknown>,
-  output: FacetContribution<unknown>[],
-): boolean {
-  const validate = contribution.facet.validate
-  if (validate && !validate(contribution.value)) {
-    console.error(
-      `Dropping invalid contribution for facet "${contribution.facet.id}"`,
-      {source: contribution.source, value: contribution.value},
-    )
-    return false
-  }
-  output.push(contribution)
-  return true
-}
-
-const isFacetContribution = (
-  value: unknown,
-): value is FacetContribution<unknown> =>
-  typeof value === 'object' &&
-  value !== null &&
-  (value as {type?: unknown}).type === 'facet-contribution'
-
-async function walk(
-  node: AppExtension | readonly AppExtension[],
-  overrides: Overrides,
-  safeMode: boolean,
-  context: FacetResolveContext,
-  output: FacetContribution<unknown>[],
-  seen: Set<FacetContribution<unknown>>,
-): Promise<void> {
-  if (!node) return
-
-  if (typeof node === 'function') {
-    try {
-      await walk(await node(context), overrides, safeMode, context, output, seen)
-    } catch (error) {
-      console.error('Failed to resolve app extension', error)
-    }
-    return
-  }
-
-  if (Array.isArray(node)) {
-    const handle = getBoundary(node)
-    if (handle && !shouldKeepBoundary(handle, overrides, safeMode)) return
-    for (const child of node) {
-      await walk(child as AppExtension, overrides, safeMode, context, output, seen)
-    }
-    return
-  }
-
-  if (isFacetContribution(node)) {
-    if (seen.has(node)) return
-    seen.add(node)
-    const accepted = pushValidatedContribution(node, output)
-    if (accepted && node.enables) {
-      await walk(node.enables, overrides, safeMode, context, output, seen)
-    }
-  }
-}
-
-function walkSync(
-  node: AppExtension | readonly AppExtension[],
-  overrides: Overrides,
-  safeMode: boolean,
-  output: FacetContribution<unknown>[],
-  seen: Set<FacetContribution<unknown>>,
-): void {
-  if (!node) return
-
-  if (typeof node === 'function') {
-    throw new Error(
+  walkAppExtensionSync(extensions, collected, resolverVisitor(options.overrides, safeMode), {
+    onFunction:
       'resolveAppRuntimeSync: cannot resolve function-valued AppExtension. ' +
       'Use resolveAppRuntime (async) for trees that contain dynamic extensions.',
-    )
-  }
-
-  if (Array.isArray(node)) {
-    const handle = getBoundary(node)
-    if (handle && !shouldKeepBoundary(handle, overrides, safeMode)) return
-    for (const child of node) {
-      walkSync(child as AppExtension, overrides, safeMode, output, seen)
-    }
-    return
-  }
-
-  if (isFacetContribution(node)) {
-    if (seen.has(node)) return
-    seen.add(node)
-    const accepted = pushValidatedContribution(node, output)
-    if (accepted && node.enables) walkSync(node.enables, overrides, safeMode, output, seen)
-  }
+    seen: new Set(),
+  })
+  return new FacetRuntime(context, collected)
 }


### PR DESCRIPTION
The AppExtension grammar was walked by seven hand-rolled recursions with
three divergent semantics: `isFacetContribution` was copy-pasted across
three modules and `pushValidatedContribution` was duplicated, so a
grammar change (e.g. the `enables` edge) had to be applied in several
places and was already missed once.

Introduce a single parameterized skeleton in facet.ts —
`walkAppExtension` (async) / `walkAppExtensionSync` — driven by an
`AppExtensionVisitor` with `array` (boundary policy) and `contribution`
(leaf + `enables` policy) hooks plus an optional `seen` dedup set. The
collector, the boundary-aware resolver, and toggle-tree discovery are
now thin visitor configurations of it. facet.ts stays ignorant of
togglable.ts — the boundary policy is injected via the `array` hook.
`isFacetContribution` and `pushValidatedContribution` now live in
facet.ts and are shared.

Fix the live bug: App.tsx's landing resolution used the bare,
toggle-blind collector, so `system:daily-notes` — a non-essential,
user-disableable plugin and the sole `workspaceLandingFacet`
contributor — still steered first paint after the user disabled it.
Landing now resolves through `resolveAppRuntimeSync` with the
workspace's cached toggle overrides, so a disabled boundary is honoured.
The landing-runtime cache key gains the workspace id (overrides are
per-workspace).