### PR TITLE
fix(sync): suppress the row_events burst from the user_updated_at backfill

### DIFF
--- a/src/data/blockSchema.test.ts
+++ b/src/data/blockSchema.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import {
   BLOCK_STORAGE_COLUMNS,
   blockToRowParams,
-  ensureBlockUserUpdatedAtColumn,
   parseBlockRow,
   type BlockRow,
 } from './blockSchema'
@@ -118,59 +117,5 @@ describe('blockToRowParams / parseBlockRow round-trip', () => {
       user_updated_at: null,
     }
     expect(parseBlockRow(row).userUpdatedAt).toBe(fixture.updatedAt)
-  })
-})
-
-/** Table-aware db stand-in: PRAGMA table_info(<t>) returns the columns
- *  declared for <t>, and every executed statement is recorded. */
-const fakeMigrationDb = (columnsByTable: Record<string, string[]>) => {
-  const executed: string[] = []
-  return {
-    executed,
-    execute: async (sql: string) => { executed.push(sql) },
-    getAll: async <T>(sql: string): Promise<T[]> => {
-      const table = sql.match(/table_info\((\w+)\)/)?.[1] ?? ''
-      return (columnsByTable[table] ?? []).map((name) => ({ name })) as unknown as T[]
-    },
-  }
-}
-
-const altersIn = (executed: string[]) => executed.filter((s) => s.includes('ADD COLUMN'))
-const ranBackfill = (executed: string[]) =>
-  executed.some((s) => /UPDATE blocks SET user_updated_at = updated_at WHERE user_updated_at IS NULL/.test(s))
-
-describe('ensureBlockUserUpdatedAtColumn — local migration', () => {
-  it('adds user_updated_at to BOTH blocks and blocks_synced on a pre-split device, then backfills', async () => {
-    const db = fakeMigrationDb({
-      blocks: ['id', 'updated_at'],
-      blocks_synced: ['id', 'updated_at'],
-    })
-    await ensureBlockUserUpdatedAtColumn(db)
-    const alters = altersIn(db.executed)
-    expect(alters).toHaveLength(2)
-    expect(alters[0]).toContain('ALTER TABLE blocks ADD COLUMN user_updated_at')
-    expect(alters[1]).toContain('ALTER TABLE blocks_synced ADD COLUMN user_updated_at')
-    expect(ranBackfill(db.executed)).toBe(true)
-  })
-
-  it('is ALTER-free on a fresh install (column already present) but still self-gates the backfill', async () => {
-    const db = fakeMigrationDb({
-      blocks: ['id', 'updated_at', 'user_updated_at'],
-      blocks_synced: ['id', 'updated_at', 'user_updated_at'],
-    })
-    await ensureBlockUserUpdatedAtColumn(db)
-    expect(altersIn(db.executed)).toHaveLength(0)
-    expect(ranBackfill(db.executed)).toBe(true) // idempotent: WHERE user_updated_at IS NULL no-ops
-  })
-
-  it('adds only the table that is missing the column', async () => {
-    const db = fakeMigrationDb({
-      blocks: ['id', 'updated_at', 'user_updated_at'],
-      blocks_synced: ['id', 'updated_at'],
-    })
-    await ensureBlockUserUpdatedAtColumn(db)
-    const alters = altersIn(db.executed)
-    expect(alters).toHaveLength(1)
-    expect(alters[0]).toContain('ALTER TABLE blocks_synced')
   })
 })

--- a/src/data/blockSchema.ts
+++ b/src/data/blockSchema.ts
@@ -106,33 +106,6 @@ export const CREATE_BLOCKS_WORKSPACE_ACTIVE_INDEX_SQL = `
   WHERE deleted = 0
 `
 
-/**
- * Idempotent local-schema migration for the `user_updated_at` split.
- * `blocks` / `blocks_synced` are created with CREATE TABLE IF NOT EXISTS, so
- * adding the column to `BLOCK_STORAGE_COLUMNS` does NOT add it to an existing
- * device's tables — yet it immediately appears in every generated statement
- * (INSERT_SQL, the observer's upsert, the raw-table put), so an un-migrated
- * device would fail "no such column" on the first write/sync. Mirrors
- * `ensureWorkspaceE2eeColumns`: PRAGMA table_info + ALTER TABLE ADD COLUMN,
- * guarded so a fresh install (column already present from CREATE) doesn't
- * throw "duplicate column name". Applies to BOTH tables. The one-shot backfill
- * mirrors `updated_at` into the app-visible `blocks` table; `parseBlockRow`
- * falls back to `updated_at` regardless, and `blocks_synced` is overwritten by
- * sync deliveries, so only `blocks` needs the stored value.
- */
-export const ensureBlockUserUpdatedAtColumn = async (db: {
-  execute: (sql: string) => Promise<unknown>
-  getAll: <T>(sql: string) => Promise<T[]>
-}): Promise<void> => {
-  for (const table of ['blocks', 'blocks_synced'] as const) {
-    const columns = await db.getAll<{ name: string }>(`PRAGMA table_info(${table})`)
-    if (!columns.some((c) => c.name === 'user_updated_at')) {
-      await db.execute(`ALTER TABLE ${table} ADD COLUMN user_updated_at INTEGER`)
-    }
-  }
-  await db.execute('UPDATE blocks SET user_updated_at = updated_at WHERE user_updated_at IS NULL')
-}
-
 const powerSyncParamForColumn = (columnName: BlockColumnName): PendingStatementParameter =>
   columnName === 'id' ? 'Id' : {Column: columnName}
 

--- a/src/data/internals/clientSchema.test.ts
+++ b/src/data/internals/clientSchema.test.ts
@@ -47,6 +47,7 @@ import {
   analyzeIsWarranted,
   backfillBlockAliasesIfEmpty,
   backfillBlocksFtsIfEmpty,
+  ensureBlockUserUpdatedAtColumn,
   getBlocksStatEstimate,
   runAnalyzeIfStale,
   runAnalyzeNow,
@@ -1138,5 +1139,69 @@ describe('block_types side-index triggers', () => {
     expect(types()).toHaveLength(2)
     h.deleteBlock('b1')
     expect(types()).toEqual([])
+  })
+})
+
+// Table-aware db stand-in: PRAGMA table_info(<t>) returns the columns declared
+// for <t>, and every executed statement is recorded in order.
+const fakeMigrationDb = (columnsByTable: Record<string, string[]>) => {
+  const executed: string[] = []
+  return {
+    executed,
+    execute: async (sql: string) => { executed.push(sql) },
+    getAll: async <T,>(sql: string): Promise<T[]> => {
+      const table = sql.match(/table_info\((\w+)\)/)?.[1] ?? ''
+      return (columnsByTable[table] ?? []).map((name) => ({name})) as unknown as T[]
+    },
+  }
+}
+
+describe('ensureBlockUserUpdatedAtColumn — local migration', () => {
+  it('adds the column to BOTH tables and backfills blocks with the audit trigger suspended', async () => {
+    const db = fakeMigrationDb({
+      blocks: ['id', 'updated_at'],
+      blocks_synced: ['id', 'updated_at'],
+    })
+    await ensureBlockUserUpdatedAtColumn(db)
+    const e = db.executed
+
+    expect(e.filter(s => s.includes('ADD COLUMN user_updated_at'))).toHaveLength(2)
+    expect(e.some(s => s.includes('ALTER TABLE blocks ADD COLUMN user_updated_at'))).toBe(true)
+    expect(e.some(s => s.includes('ALTER TABLE blocks_synced ADD COLUMN user_updated_at'))).toBe(true)
+
+    // The backfill is bracketed: drop the unconditional row_event trigger, run
+    // the UPDATE trigger-free, then recreate it — so it never writes one
+    // row_events row per block (the burst this fix exists to prevent).
+    const dropAt = e.findIndex(s => /DROP TRIGGER IF EXISTS blocks_row_event_update/.test(s))
+    const updateAt = e.findIndex(s => /UPDATE blocks SET user_updated_at = updated_at/.test(s))
+    const recreateAt = e.findIndex(s => /CREATE TRIGGER IF NOT EXISTS\s+blocks_row_event_update/.test(s))
+    expect(dropAt).toBeGreaterThanOrEqual(0)
+    expect(dropAt).toBeLessThan(updateAt)     // dropped before the backfill UPDATE
+    expect(updateAt).toBeLessThan(recreateAt) // recreated after it
+  })
+
+  it('does NOT backfill or touch the trigger when the column already exists (fresh install / steady state)', async () => {
+    const db = fakeMigrationDb({
+      blocks: ['id', 'updated_at', 'user_updated_at'],
+      blocks_synced: ['id', 'updated_at', 'user_updated_at'],
+    })
+    await ensureBlockUserUpdatedAtColumn(db)
+    expect(db.executed.some(s => s.includes('ADD COLUMN'))).toBe(false)
+    expect(db.executed.some(s => /UPDATE blocks SET user_updated_at/.test(s))).toBe(false)
+    expect(db.executed.some(s => /blocks_row_event_update/.test(s))).toBe(false)
+  })
+
+  it('adds only blocks_synced (no backfill) when only it is missing the column', async () => {
+    const db = fakeMigrationDb({
+      blocks: ['id', 'updated_at', 'user_updated_at'],
+      blocks_synced: ['id', 'updated_at'],
+    })
+    await ensureBlockUserUpdatedAtColumn(db)
+    const alters = db.executed.filter(s => s.includes('ADD COLUMN'))
+    expect(alters).toHaveLength(1)
+    expect(alters[0]).toContain('ALTER TABLE blocks_synced')
+    // blocks already had the column → no backfill, trigger untouched.
+    expect(db.executed.some(s => /UPDATE blocks SET user_updated_at/.test(s))).toBe(false)
+    expect(db.executed.some(s => /blocks_row_event_update/.test(s))).toBe(false)
   })
 })

--- a/src/data/internals/clientSchema.ts
+++ b/src/data/internals/clientSchema.ts
@@ -1126,6 +1126,31 @@ const withTriggerRecreate = (statements: readonly string[]): string[] =>
     return name ? [`DROP TRIGGER IF EXISTS ${name}`, stmt] : [stmt]
   })
 
+/** Run `fn` with `triggerName` temporarily dropped, then recreate it from
+ *  `createSql` (its canonical definition) — even if `fn` throws. For a bulk
+ *  maintenance write that must NOT fan out through an unconditional per-row
+ *  side-effect trigger (e.g. a column backfill that would otherwise write one
+ *  `row_events` row per block — hundreds of thousands of them). SQLite has no
+ *  `DISABLE TRIGGER`, so drop+recreate is the equivalent; pass the same
+ *  `CREATE` constant the bootstrap installs so the recreated trigger can't
+ *  drift. This is the client analog of the server backfill's `DISABLE TRIGGER`
+ *  bracketing, and the same drop-then-recreate move {@link withTriggerRecreate}
+ *  already does to every trigger on boot. Bootstrap-only: there is no
+ *  write-serving window in which the trigger is absent. */
+const withTriggerSuspended = async (
+  db: {execute: (sql: string) => Promise<unknown>},
+  triggerName: string,
+  createSql: string,
+  fn: () => Promise<void>,
+): Promise<void> => {
+  await db.execute(`DROP TRIGGER IF EXISTS ${triggerName}`)
+  try {
+    await fn()
+  } finally {
+    await db.execute(createSql)
+  }
+}
+
 export const CLIENT_SCHEMA_STATEMENTS: readonly string[] = withTriggerRecreate([
   // Tables
   CREATE_TX_CONTEXT_TABLE_SQL,
@@ -1247,6 +1272,56 @@ export const backfillBlocksFtsIfEmpty = async (
   await db.execute(BACKFILL_BLOCKS_FTS_ROWIDS_SQL)
   await db.execute(BACKFILL_BLOCKS_FTS_SQL)
   await db.execute(RECORD_BLOCKS_FTS_BACKFILL_DONE_SQL)
+}
+
+/**
+ * Idempotent local-schema migration for the `user_updated_at` split.
+ * `blocks` / `blocks_synced` are created with CREATE TABLE IF NOT EXISTS, so
+ * adding the column to `BLOCK_STORAGE_COLUMNS` does NOT add it to an existing
+ * device's tables — yet it immediately appears in every generated statement
+ * (INSERT_SQL, the observer's upsert, the raw-table put), so an un-migrated
+ * device would fail "no such column" on the first write/sync. PRAGMA
+ * table_info + ALTER TABLE ADD COLUMN on BOTH tables, guarded so a fresh
+ * install (column already present from CREATE) doesn't throw "duplicate column
+ * name".
+ *
+ * When the column is newly added, backfill `blocks` once so the stored value
+ * is fully populated (no lingering NULLs — `parseBlockRow` falls back to
+ * `updated_at` on read, but we keep the column honest). The backfill is
+ * bracketed by `withTriggerSuspended`: the only trigger that fires on a
+ * `user_updated_at`-only UPDATE is `blocks_row_event_update` (AFTER UPDATE ON
+ * blocks, no column scope), and a full-table backfill through it would write
+ * one `row_events` row per block. The FTS/alias/type triggers are column-scoped
+ * (content/properties_json/deleted/workspace_id) and the upload trigger is
+ * source-gated, so neither fires here. `blocks_synced` gets the column (the
+ * raw-table put binds it) but no backfill — it's a passive sync landing zone
+ * overwritten by deliveries.
+ */
+export const ensureBlockUserUpdatedAtColumn = async (db: {
+  execute: (sql: string) => Promise<unknown>
+  getAll: <T>(sql: string) => Promise<T[]>
+}): Promise<void> => {
+  let backfillBlocks = false
+  for (const table of ['blocks', 'blocks_synced'] as const) {
+    const columns = await db.getAll<{name: string}>(`PRAGMA table_info(${table})`)
+    if (!columns.some(c => c.name === 'user_updated_at')) {
+      await db.execute(`ALTER TABLE ${table} ADD COLUMN user_updated_at INTEGER`)
+      if (table === 'blocks') backfillBlocks = true
+    }
+  }
+  // Backfill only right after the ALTER — every existing `blocks` row is NULL
+  // then. On later boots the column already exists, so we skip the backfill
+  // (and its full-table scan) entirely.
+  if (backfillBlocks) {
+    await withTriggerSuspended(
+      db,
+      'blocks_row_event_update',
+      CREATE_BLOCKS_UPDATE_ROW_EVENT_TRIGGER_SQL,
+      async () => {
+        await db.execute('UPDATE blocks SET user_updated_at = updated_at')
+      },
+    )
+  }
 }
 
 /** Row count `sqlite_stat1` recorded for `blocks` at the last ANALYZE, or

--- a/src/data/repoProvider.ts
+++ b/src/data/repoProvider.ts
@@ -43,7 +43,6 @@ import {
   CREATE_BLOCKS_SYNCED_TABLE_SQL,
   CREATE_BLOCKS_TABLE_SQL,
   CREATE_BLOCKS_WORKSPACE_ACTIVE_INDEX_SQL,
-  ensureBlockUserUpdatedAtColumn,
 } from '@/data/blockSchema'
 import {
   CREATE_WORKSPACES_TABLE_SQL,
@@ -58,6 +57,7 @@ import {
   backfillBlockAliasesIfEmpty,
   backfillBlocksFtsIfEmpty,
   backfillBlockTypesIfEmpty,
+  ensureBlockUserUpdatedAtColumn,
   runAnalyzeIfStale,
 } from '@/data/internals/clientSchema'
 import { scheduleIdle } from '@/utils/scheduleIdle.js'


### PR DESCRIPTION
Follow-up to the `user_updated_at` split ([#143](https://github.com/Stvad/knowledge-medium/pull/143), already merged + deployed). Caught live on a dev client after the rollout.

## The problem

On the first boot of the new bundle, the local backfill in `ensureBlockUserUpdatedAtColumn` (`UPDATE blocks SET user_updated_at = updated_at`) rewrites **every** existing block. Each row-write fires `blocks_row_event_update` — which is `AFTER UPDATE ON blocks` with **no column scope** — so the backfill writes **one `row_events` row per block** (observed ~340k on the 340k-block workspace; `row_events` has no pruning yet, so it's permanent audit bloat). Devices that haven't upgraded yet would each repeat the burst.

It's functionally harmless — the FTS/alias/type triggers are column-scoped (`content`/`properties_json`/`deleted`/`workspace_id`) so they don't re-index, and the upload trigger is source-gated so nothing uploads — but it's a large one-time write burst + lasting bloat.

## The fix

- **`withTriggerSuspended` helper** (new, in `clientSchema.ts` next to `withTriggerRecreate`): drop a trigger, run a fn, recreate it from its canonical `CREATE` constant in a `finally`. The client analog of the server backfill's `DISABLE TRIGGER` bracketing — SQLite has no `DISABLE TRIGGER`, and it's the same drop+recreate move `withTriggerRecreate` already does to every trigger on boot. The recreated trigger is byte-identical (single source of truth); only that one trigger is touched; bootstrap-only, so no write-serving window misses its audit row.
- Backfill now runs **inside** `withTriggerSuspended('blocks_row_event_update', …)` → zero `row_events` written, column still fully populated (**no lingering NULLs**).
- **Gated** on the `ALTER` actually firing (column just added), so steady-state boots skip the backfill (and its full-table scan) entirely.
- Moved `ensureBlockUserUpdatedAtColumn` from `blockSchema.ts` → `clientSchema.ts` (home of the other `backfill*IfEmpty` helpers + the trigger SQL it needs; avoids a `blockSchema`→`internals` layering inversion). `blockSchema` keeps the column definition + `parseBlockRow` fallback.

## Tests

Rewrote the migration unit tests (moved to `clientSchema.test.ts`) to assert the contract: ALTER both tables, **gate the backfill on column-added**, and **drop-before-UPDATE → recreate-after** ordering (so the trigger can't fire during the backfill). `parseBlockRow` NULL-fallback test stays in `blockSchema.test.ts`.

`yarn run check` green (3181 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)