### PR TITLE
perf(sync): collapse redundant delete enqueue in blocks_synced_changes

### DIFF
--- a/src/data/internals/clientSchema.test.ts
+++ b/src/data/internals/clientSchema.test.ts
@@ -1205,3 +1205,22 @@ describe('ensureBlockUserUpdatedAtColumn — local migration', () => {
     expect(db.executed.some(s => /blocks_row_event_update/.test(s))).toBe(false)
   })
 })
+
+describe('blocks_synced_changes enqueue-collapse', () => {
+  it('serves the collapse delete from an index, not a full table scan', () => {
+    // The blocks_synced_changes_insert trigger runs
+    // `DELETE ... WHERE id = NEW.id AND op = 'delete'` on EVERY staging insert.
+    // Without an index that scans the whole pending queue, turning a bulk apply
+    // (the queue fills within one PowerSync apply tx before the observer drains)
+    // into O(n^2). Pin the load-bearing invariant — the lookup is index-backed —
+    // so dropping the index, or the trigger predicate drifting off it, fails
+    // loudly instead of silently regressing large syncs.
+    const plan = (h.db
+      .prepare("EXPLAIN QUERY PLAN DELETE FROM blocks_synced_changes WHERE id = ? AND op = 'delete'")
+      .all('b1') as Array<{ detail: string }>)
+      .map(r => r.detail)
+      .join(' | ')
+    expect(plan).toContain('USING INDEX')
+    expect(plan).not.toContain('SCAN')
+  })
+})

--- a/src/data/internals/clientSchema.ts
+++ b/src/data/internals/clientSchema.ts
@@ -325,6 +325,23 @@ export const CREATE_BLOCKS_SYNCED_CHANGES_TABLE_SQL = `
   )
 `
 
+/** Indexes the enqueue-collapse lookup in `blocks_synced_changes_insert`
+ *  (`DELETE … WHERE id = NEW.id AND op = 'delete'`). The table is otherwise
+ *  keyed only by the autoincrement `seq`, so without this index that per-insert
+ *  delete would SCAN the entire pending queue on every staging insert — even a
+ *  brand-new id with no matching 'delete'. During a bulk sync/backfill the queue
+ *  grows (within one PowerSync apply tx) far faster than the observer drains, so
+ *  an unindexed scan turns the apply into O(n²) — the exact large-download case
+ *  this queue exists to keep cheap (the ~310K-row backfill that motivated the
+ *  collapse). With the index the lookup is an O(log n) seek, including the common
+ *  no-match insert. The drain still reads/deletes by `seq` (PK), so this index
+ *  only serves the collapse delete; its maintenance cost on queue insert + the
+ *  drain's `DELETE … WHERE seq <= ?` is O(log n) per row. */
+export const CREATE_BLOCKS_SYNCED_CHANGES_ID_OP_INDEX_SQL = `
+  CREATE INDEX IF NOT EXISTS idx_blocks_synced_changes_id_op
+  ON blocks_synced_changes (id, op)
+`
+
 export const CREATE_BLOCKS_SYNCED_CHANGES_INSERT_TRIGGER_SQL = `
   CREATE TRIGGER IF NOT EXISTS blocks_synced_changes_insert
   AFTER INSERT ON blocks_synced
@@ -1184,6 +1201,7 @@ export const CLIENT_SCHEMA_STATEMENTS: readonly string[] = withTriggerRecreate([
   CREATE_PS_CRUD_REJECTED_REJECTED_AT_INDEX_SQL,
   CREATE_PS_CRUD_REJECTED_TX_ID_INDEX_SQL,
   CREATE_BLOCKS_SYNCED_CHANGES_TABLE_SQL,
+  CREATE_BLOCKS_SYNCED_CHANGES_ID_OP_INDEX_SQL,
   DROP_BLOCKS_WORKSPACE_TYPE_INDEX_SQL,
   // 3 row_events audit/history triggers
   CREATE_BLOCKS_INSERT_ROW_EVENT_TRIGGER_SQL,

--- a/src/data/internals/clientSchema.ts
+++ b/src/data/internals/clientSchema.ts
@@ -294,14 +294,23 @@ export const CREATE_PS_CRUD_REJECTED_TX_ID_INDEX_SQL = `
 // Coalescing still happens, in JS at drain time (latest op per id wins), so a
 // hot row is materialized once per batch, not once per delivery.
 //
-//   - INSERT trigger → 'upsert'. The raw put is `INSERT OR REPLACE`, so a
-//     re-delivery of an existing id fires DELETE then INSERT, appending a
-//     'delete' then a higher-seq 'upsert' that wins the dedup. (No UPDATE
-//     trigger: PowerSync never issues a bare UPDATE against the raw table.)
+//   - INSERT trigger → 'upsert'. The raw put is `INSERT OR REPLACE`, and
+//     PowerSync applies a *changed* synced row as this REPLACE (a DELETE then
+//     an INSERT), never a bare UPDATE. Left alone, every changed block would
+//     enqueue BOTH a 'delete' (the replace's implicit DELETE) and an 'upsert' —
+//     two rows for one logical upsert, inflating the pending count ~2× and
+//     wasting drain windows on no-op delete passes. So the INSERT trigger
+//     COLLAPSES at enqueue: it drops a pending same-id 'delete' before appending
+//     its 'upsert', netting a single 'upsert' per REPLACE. This is safe because
+//     the REPLACE's delete-then-insert is one atomic statement and the drain
+//     reads the queue only after the apply tx commits — it never sees a partial
+//     (delete-without-insert) REPLACE. (No UPDATE trigger: PowerSync never
+//     issues a bare UPDATE against the raw table.)
 //   - DELETE trigger → 'delete'. A real stream-exit (membership revoke /
-//     workspace delete) appends a higher-seq 'delete' that supersedes an
-//     un-drained 'upsert', and is captured DURABLY so a removal that lands
-//     while the observer is down is still drained on next startup.
+//     workspace delete) has no following INSERT, so its 'delete' survives the
+//     collapse and supersedes an un-drained 'upsert'; it is captured DURABLY so
+//     a removal that lands while the observer is down is still drained on next
+//     startup.
 //
 // No source-gating: these are not upload triggers, so they fire on both sync
 // and (the rare) local writes to the staging table. blocks_synced itself
@@ -320,6 +329,7 @@ export const CREATE_BLOCKS_SYNCED_CHANGES_INSERT_TRIGGER_SQL = `
   CREATE TRIGGER IF NOT EXISTS blocks_synced_changes_insert
   AFTER INSERT ON blocks_synced
   BEGIN
+    DELETE FROM blocks_synced_changes WHERE id = NEW.id AND op = 'delete';
     INSERT INTO blocks_synced_changes (id, op) VALUES (NEW.id, 'upsert');
   END
 `

--- a/src/data/internals/syncObserver/materialize.ts
+++ b/src/data/internals/syncObserver/materialize.ts
@@ -377,13 +377,18 @@ export const materializeStagingRows = async (
     const removedBeforeById = await readBlocksByIds(tx, change.removed, readChunkSize)
     // A 'delete' whose staging row still exists is an INSERT OR REPLACE
     // re-delivery artifact, not a stream-exit: SQLite's REPLACE fires the
-    // staging delete trigger then the insert trigger, enqueuing delete-then-
-    // upsert for one row. Drained in seq windows, that pair can split so the
-    // delete arrives alone here. Deleting the local row then would be wrong —
-    // the trailing upsert is gated (skip-stale on a pending local edit / newer
-    // local stamp), so the block would vanish and an unsent edit be lost. Only
-    // hard-delete ids whose staging row is truly gone; the upsert (this window
-    // or a later one) reconciles the rest through the gate.
+    // staging delete trigger then the insert trigger, which would enqueue
+    // delete-then-upsert for one row. The `blocks_synced_changes_insert` trigger
+    // now collapses that pair at enqueue (it drops a pending same-id 'delete'
+    // before appending its 'upsert'), so a REPLACE nets a single 'upsert' and a
+    // lone 'delete' with a still-present staging row should not normally reach
+    // here. This guard stays as defense-in-depth: if such a 'delete' ever
+    // arrives, deleting the local row would be wrong — its still-present staging
+    // row proves the row is alive, and any trailing upsert is gated (skip-stale
+    // on a pending local edit / newer local stamp), so the block would vanish
+    // and an unsent edit be lost. Only hard-delete ids whose staging row is
+    // truly gone; the upsert (this window or a later one) reconciles the rest
+    // through the gate.
     const removedStillStaged = await readExistingStagingIds(tx, change.removed, readChunkSize)
     for (const id of change.removed) {
       if (removedStillStaged.has(id)) continue

--- a/src/data/internals/syncObserver/observer.test.ts
+++ b/src/data/internals/syncObserver/observer.test.ts
@@ -348,13 +348,12 @@ describe('blocksSyncedObserver — robustness', () => {
     expect(errors.every(e => e instanceof Error && e.message === 'boom')).toBe(true)
   })
 
-  it('keeps a locally-edited block when a re-delivery\'s delete/upsert straddle a window boundary', async () => {
-    // `put` is INSERT OR REPLACE, so re-delivering an existing staged row
-    // enqueues a delete (the replace's implicit delete) THEN an upsert. With a
-    // small drain window the pair can split across windows: the delete lands
-    // alone in one window, the upsert in the next. A lone delete must NOT drop a
-    // block the user has an unsent local edit for — the trailing upsert is then
-    // skip-staled by the pending gate, so the row would vanish entirely.
+  it('keeps a locally-edited block when the server re-delivers it (collapse → single upsert, skip-staled)', async () => {
+    // `put` is INSERT OR REPLACE, so re-delivering an existing staged row fires
+    // DELETE then INSERT. The blocks_synced_changes_insert trigger collapses
+    // that to a single 'upsert' at enqueue, which the drain then skip-stales
+    // against the user's pending local edit (newer local stamp + pending
+    // upload). The unsent edit must survive the re-delivery.
     await put(data({ content: 'server v1', updatedAt: 1 }))
     const { observer } = start({ getMaterializability: constMat('copy'), drainChunkSize: 1 })
     await observer.flush()
@@ -369,13 +368,34 @@ describe('blocksSyncedObserver — robustness', () => {
       ['b1'],
     )
 
-    // Server re-delivers b1 → enqueues delete@N then upsert@N+1; chunk size 1
-    // puts them in separate windows.
+    // Server re-delivers b1 → REPLACE → collapsed to a single 'upsert'.
     await put(data({ content: 'server v2', updatedAt: 2 }))
     await observer.flush()
 
-    // The local edit survives, and the queue still fully drains.
+    // The local edit survives (skip-staled), and the queue still fully drains.
     expect(await blocks()).toEqual([{ id: 'b1', content: 'local edit' }])
+    expect(await queueLen()).toBe(0)
+  })
+
+  it('skip-if-staged: a lone delete whose staging row still exists does not drop the block (defense-in-depth)', async () => {
+    // The enqueue-collapse means a REPLACE nets a single 'upsert', so a lone
+    // 'delete' with the staging row still present no longer arises from the
+    // normal trigger path. The materialize guard (readExistingStagingIds) stays
+    // as defense-in-depth: if such a 'delete' ever reaches the drain, the
+    // still-present staging row proves the row is alive (a REPLACE artifact, not
+    // a stream-exit), so the block must survive.
+    await put(data({ content: 'server v1', updatedAt: 1 }))
+    const { observer } = start({ getMaterializability: constMat('copy') })
+    await observer.flush()
+    expect(await blocks()).toEqual([{ id: 'b1', content: 'server v1' }])
+
+    // The staging row for b1 is still present. Manually enqueue a lone 'delete'
+    // (the artifact the collapse would normally absorb) to exercise the guard.
+    await env.db.execute("INSERT INTO blocks_synced_changes (id, op) VALUES ('b1', 'delete')")
+    await observer.flush()
+
+    // The block survives because its staging row still exists; queue drains.
+    expect(await blocks()).toEqual([{ id: 'b1', content: 'server v1' }])
     expect(await queueLen()).toBe(0)
   })
 

--- a/src/data/test/blocksSyncedChanges.test.ts
+++ b/src/data/test/blocksSyncedChanges.test.ts
@@ -12,11 +12,14 @@
  *      sync-apply runs against the raw table (`BLOCKS_SYNCED_RAW_TABLE`) — the
  *      same mechanism the existing `row_events` triggers rely on for the live
  *      `blocks` table.
- *   2. It's an APPEND-ONLY log keyed by a monotonic `seq` (so the observer can
- *      drain race- and failure-safely with a watermark). Coalescing is a
- *      drain-time concern, not a storage one: the effective state of an id is
- *      its highest-seq op, so a re-delivery (`INSERT OR REPLACE` =
- *      DELETE+INSERT) appends 'delete' then a higher-seq 'upsert' that wins.
+ *   2. It's a seq-keyed log drained race- and failure-safely with a watermark.
+ *      It's append-only except for one targeted collapse: the insert trigger
+ *      drops a pending same-id 'delete' before appending its 'upsert', so a
+ *      re-delivery (`INSERT OR REPLACE` = DELETE+INSERT — how PowerSync applies
+ *      every *changed* synced row) nets a single 'upsert' instead of a redundant
+ *      delete+upsert pair (the ~2× pending-count inflation fix). The effective
+ *      state of an id is still its highest-seq op; drain-time coalescing (latest
+ *      op per id) handles the rest.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -64,21 +67,34 @@ describe('blocks_synced_changes capture queue', () => {
     expect(await latestOps()).toEqual([{ id: 'b1', op: 'delete' }])
   })
 
-  it('appends rather than coalescing in-table; a re-delivery leaves the latest op = upsert', async () => {
+  it('collapses a REPLACE re-delivery to a single upsert (drops the pending delete at enqueue)', async () => {
     await put(data({ id: 'b1', content: 'v1' }))
     await drain() // observer processed the first delivery
     // Re-deliver the SAME id (existing staging row). The raw put is INSERT OR
-    // REPLACE, which fires DELETE then INSERT — appending a 'delete' then a
-    // higher-seq 'upsert'. The log keeps BOTH rows (append-only); the drain's
-    // latest-op-per-id is 'upsert', never a stranded 'delete'.
+    // REPLACE, which fires DELETE then INSERT. The insert trigger drops the
+    // pending same-id 'delete' before appending its 'upsert', so the REPLACE
+    // nets a SINGLE 'upsert' row — not a delete+upsert pair. PowerSync applies
+    // every changed synced row as a REPLACE, so without the collapse each one
+    // would enqueue two rows (the ~2× pending-count inflation this fix removes).
     await put(data({ id: 'b1', content: 'v2' }))
-    expect(await rowCount()).toBe(2)
+    expect(await rowCount()).toBe(1)
     expect(await latestOps()).toEqual([{ id: 'b1', op: 'upsert' }])
   })
 
-  it('lets a later delete supersede an un-drained upsert for the same id', async () => {
+  it('collapses an un-drained delete-then-reinsert to a single upsert (final state present)', async () => {
+    await put(data({ id: 'b1' })) // upsert
+    await del('b1') // delete enqueued; observer never drained it
+    // The row comes back (a separate re-insert, not a REPLACE — the staging row
+    // is gone). The insert trigger still drops the pending 'delete' before
+    // appending its 'upsert', so the queue converges to 'upsert' (final staging
+    // state is present), which is what the materialize would converge to anyway.
     await put(data({ id: 'b1' }))
-    await del('b1') // observer never got to drain the upsert
+    expect(await latestOps()).toEqual([{ id: 'b1', op: 'upsert' }])
+  })
+
+  it('lets a genuine later delete (no following insert) supersede an un-drained upsert', async () => {
+    await put(data({ id: 'b1' }))
+    await del('b1') // observer never got to drain the upsert; no re-insert follows
     expect(await latestOps()).toEqual([{ id: 'b1', op: 'delete' }])
   })
 


### PR DESCRIPTION
## Problem

The client materialize observer drains a change queue `blocks_synced_changes` (the `blocks_synced → blocks` pipeline). Two triggers on `blocks_synced` populate it: an `AFTER INSERT` → `'upsert'` and an `AFTER DELETE` → `'delete'`. There is **no `AFTER UPDATE` trigger** because PowerSync applies a *changed* synced row as a **DELETE + INSERT (a REPLACE)**, not an in-place UPDATE.

The consequence: every changed block fires *both* triggers and enqueues **two rows (one `'delete'`, one `'upsert'`) for what is logically one upsert**. Observed concretely after a bulk backfill touching ~310K rows: `blocks_synced_changes` held 60,048 rows for 30,024 distinct ids — exactly 2×. This inflated the "pending application" count in the sync UI (looked like ~2× total blocks) and wasted drain windows on no-op delete passes.

## Fix

Collapse at enqueue: the `blocks_synced_changes_insert` trigger now drops a pending same-id `'delete'` before enqueuing the `'upsert'`, so a REPLACE nets a single `'upsert'` row.

```sql
CREATE TRIGGER IF NOT EXISTS blocks_synced_changes_insert
AFTER INSERT ON blocks_synced
BEGIN
  DELETE FROM blocks_synced_changes WHERE id = NEW.id AND op = 'delete';
  INSERT INTO blocks_synced_changes (id, op) VALUES (NEW.id, 'upsert');
END
```

**Why it's safe**
- The REPLACE's delete-then-insert is one atomic statement, and the drain reads the queue only after the PowerSync apply tx commits — so the drain never sees a partial (delete-without-insert) REPLACE.
- A genuine delete (no following insert) still enqueues `'delete'` and is unaffected.
- A genuine delete-then-reinsert (both pending) correctly collapses to `'upsert'` (final state present), which is what materialize would converge to anyway.

## Wiring confirmed
- **Existing clients pick it up.** Triggers are drop+recreated from their canonical constants on boot via `withTriggerRecreate` (`clientSchema.ts`), run by `repoProvider.ts`. The prepended `DROP TRIGGER IF EXISTS blocks_synced_changes_insert` ensures the stale `CREATE … IF NOT EXISTS` body is replaced on next startup.
- **Drain unchanged.** The observer still drains `ORDER BY seq LIMIT chunk`, dedupes by id, and `DELETE … WHERE seq <= maxSeq`. The collapse only reduces rows; a window with a real `'delete'` still removes the block.
- **Defense-in-depth kept.** The apply-time skip-if-staged guard in `materialize.ts` (`readExistingStagingIds`) is retained — a lone `'delete'` whose staging row still exists is never hard-deleted.

## Tests
- `blocks_synced_changes`: a REPLACE re-delivery now collapses to a single `'upsert'` row (was delete+upsert); an un-drained delete-then-reinsert converges to `'upsert'`; a genuine delete (no following insert) still enqueues `'delete'`.
- observer: a server re-delivery while a local edit is pending keeps the local edit (collapse → single upsert, skip-staled); added a direct defense-in-depth test that a lone `'delete'` with a still-present staging row does not drop the block.
- The genuine-delete hard-delete path and the sync-applied hard-delete invalidation test are unchanged and pass.

Verified locally: `tsc -b`, ESLint on the changed files, and the affected vitest suites (`blocksSyncedChanges`, `observer`, `clientSchema`, `invalidation`, `materialize`) all pass.

## Scope
Minor optimization, kept small and focused. It fixes the misleading ~2× pending count and removes wasted no-op delete windows. The dominant materialize-drain cost — `row_events` writing two full snapshots per block on the upsert side — is a separate, larger effort tracked in #132.

Related: #132

https://claude.ai/code/session_01QQLvAc8XFmFiEGQs1BznPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQLvAc8XFmFiEGQs1BznPZ)_