### PR TITLE
docs: correct stale UiState 'not synced' claims (#133)

### DIFF
--- a/docs/navigation-redesign.md
+++ b/docs/navigation-redesign.md
@@ -2,7 +2,12 @@
 
 Captures the design discussion from the navigation refactor up through step 3 (state preservation). This document is the working spec for step 4 and the post-step-4 extensibility roadmap. Written 2026-05-08.
 
-> **Correction (2026-06-15):** an earlier draft assumed `ChangeScope.UiState` writes stay device-local and out of PowerSync. They don't — UiState writes upload and sync through the normal queue like any other scope; the scope only opts out of the undo stack, not out of sync. Syncing UI state through ordinary block rows is a deliberate, affirmed decision: device-local ephemeral state was removed on purpose in favor of one uniform storage substrate, so focus/scroll/layout restore across devices. The inline notes below have been corrected to say "not undoable" rather than "not synced."
+> **Correction (2026-06-15):** an earlier draft described `ChangeScope.UiState` panel rows as "not synced." That conflates two layers:
+>
+> - **Scope / transport:** `ChangeScope.UiState` does *not* keep writes out of the upload queue. UiState rows upload and sync through PowerSync like any block row; the scope only opts them out of the *undo stack*, not out of sync. (Plugin ui-state blocks under the root ui-state subtree are keyed only by workspace + user, so they genuinely restore across devices — see `getPluginUIStateBlock`.)
+> - **Panel layout specifically:** panel rows live under `ui-state/layout-sessions/{layoutSessionId}`, and `layoutSessionId` is a *device-local* random id (per-tab `sessionStorage` / per-install `localStorage`, see `layoutSessionId.ts`). A second device generates a different layout-session subtree, so it never reads the first device's panel rows. Panel layout / focus / scroll are therefore effectively per-device — not because the rows are excluded from sync, but because the session key that addresses them is device-local. Restore happens on reload / PWA relaunch (same key), not across devices.
+>
+> The inline notes below have been corrected accordingly: UiState rows sync (so "not synced" was wrong), but panel layout stays per-device by virtue of the device-local layout-session key, not by opting out of the upload queue.
 
 ## Where we are now (committed up through 078e426)
 
@@ -12,7 +17,7 @@ Captures the design discussion from the navigation refactor up through step 3 (s
 
 ## Step 4 goal
 
-Make the URL a first-class projection of panel layout: open/close/reorder operations show up in the URL, browser back operates over panel layout, links share their layout. **Substrate stays in the workspace DB** — panel rows already use `ChangeScope.UiState` (synced, but not undoable). The URL is a bidirectional projection of those rows, not a replacement substrate.
+Make the URL a first-class projection of panel layout: open/close/reorder operations show up in the URL, browser back operates over panel layout, links share their layout. **Substrate stays in the workspace DB** — panel rows already use `ChangeScope.UiState` (rows sync, but are addressed per-device via the layout-session key; not undoable — see the correction note above). The URL is a bidirectional projection of those rows, not a replacement substrate.
 
 This honors Riffle's prelude (one reactive store; scope-as-metadata) while still getting URL-as-address-bar for the things that genuinely need it (browser interop, sharing, deep-linking).
 
@@ -351,7 +356,7 @@ The current navigation code grew before facet was the dominant idiom; once step 
 - No back-compat for the old `#wsId/blockId?panels=...` shape we never shipped. Old `#wsId/blockId` is a special case of the new shape, so it parses fine.
 - Per-panel back/forward block history surviving reload: not in step 4. Punt to a follow-up — promoting `panelHistory` stacks to UiState rows is straightforward but adds row churn we don't need yet.
 - Persistent named layouts: not in step 4. A future feature; URL would carry an opaque layout id (`#wsId/L7`) and the structure would live in a saved-layouts store. Coexists with the inline grammar — opt-in only when the user explicitly names a layout.
-- Per-device panel layout: not separately scoped. UiState rows sync through PowerSync like any block row, so panel layout (and focus/scroll restore) is shared across a user's devices by design — see the correction note at the top.
+- Cross-device sync of panel layout: not a goal, and not what happens. The rows upload (UiState doesn't opt out of sync), but panel layout is addressed by a device-local `layoutSessionId`, so each device builds its own layout-session subtree and restores only its own layout (on reload / PWA relaunch). See the correction note at the top.
 - GC of orphan layout-session subtrees: not in step 4. Add a heartbeat-based sweep if/when this becomes a real issue (one cascading delete per stale layout session).
 
 ## Relation to Riffle's prelude

--- a/docs/navigation-redesign.md
+++ b/docs/navigation-redesign.md
@@ -2,6 +2,8 @@
 
 Captures the design discussion from the navigation refactor up through step 3 (state preservation). This document is the working spec for step 4 and the post-step-4 extensibility roadmap. Written 2026-05-08.
 
+> **Correction (2026-06-15):** an earlier draft assumed `ChangeScope.UiState` writes stay device-local and out of PowerSync. They don't — UiState writes upload and sync through the normal queue like any other scope; the scope only opts out of the undo stack, not out of sync. Syncing UI state through ordinary block rows is a deliberate, affirmed decision: device-local ephemeral state was removed on purpose in favor of one uniform storage substrate, so focus/scroll/layout restore across devices. The inline notes below have been corrected to say "not undoable" rather than "not synced."
+
 ## Where we are now (committed up through 078e426)
 
 - **Step 1 (cf397f0)**: `navigate()` primitive — single entry point for "go to a block" / "open in new panel". Replaces scattered `writeAppHash` + `dispatchEvent('open-panel')` call sites.
@@ -10,7 +12,7 @@ Captures the design discussion from the navigation refactor up through step 3 (s
 
 ## Step 4 goal
 
-Make the URL a first-class projection of panel layout: open/close/reorder operations show up in the URL, browser back operates over panel layout, links share their layout. **Substrate stays in the workspace DB** — panel rows already use `ChangeScope.UiState` (not synced, not undoable). The URL is a bidirectional projection of those rows, not a replacement substrate.
+Make the URL a first-class projection of panel layout: open/close/reorder operations show up in the URL, browser back operates over panel layout, links share their layout. **Substrate stays in the workspace DB** — panel rows already use `ChangeScope.UiState` (synced, but not undoable). The URL is a bidirectional projection of those rows, not a replacement substrate.
 
 This honors Riffle's prelude (one reactive store; scope-as-metadata) while still getting URL-as-address-bar for the things that genuinely need it (browser interop, sharing, deep-linking).
 
@@ -18,7 +20,7 @@ This honors Riffle's prelude (one reactive store; scope-as-metadata) while still
 
 ### Substrate: workspace DB rows, UiState scope
 
-Panel rows stay in the workspace DB. UiState scope already gives "don't sync across devices, don't enter undo stack." Components keep using existing reactive hooks (`usePropertyValue`, `useChildren`, etc.) — no parallel store.
+Panel rows stay in the workspace DB. UiState scope already gives "don't enter undo stack" (it still syncs, like any scope). Components keep using existing reactive hooks (`usePropertyValue`, `useChildren`, etc.) — no parallel store.
 
 The only deviation we considered (a fresh in-memory `panelLayoutStore`) was redundant with what UiState scope already provides, and would have fragmented the substrate for no win.
 
@@ -324,7 +326,7 @@ Callers don't talk to the projection directly — they write panel rows. The pro
   - On `visibilitychange` to hidden: flush pending write.
   - On mount + `topLevelBlockId` change: read `scrollTopProp` from row and apply to scrollRef in a post-layout effect (same pattern as the existing `consumeRestore`).
 - Existing in-memory snapshotter / restore queue stays — it's still the right substrate for *intra-session* per-panel back/forward, where we don't want every nav writing to DB.
-- Tests: scroll persists across reload; doesn't sync across devices (UiState); doesn't pollute another layout session's row.
+- Tests: scroll persists across reload; stays out of the undo stack (UiState, not undoable); doesn't pollute another layout session's row.
 
 ### 4e. Cleanup
 
@@ -349,9 +351,9 @@ The current navigation code grew before facet was the dominant idiom; once step 
 - No back-compat for the old `#wsId/blockId?panels=...` shape we never shipped. Old `#wsId/blockId` is a special case of the new shape, so it parses fine.
 - Per-panel back/forward block history surviving reload: not in step 4. Punt to a follow-up — promoting `panelHistory` stacks to UiState rows is straightforward but adds row churn we don't need yet.
 - Persistent named layouts: not in step 4. A future feature; URL would carry an opaque layout id (`#wsId/L7`) and the structure would live in a saved-layouts store. Coexists with the inline grammar — opt-in only when the user explicitly names a layout.
-- Cross-device sync of any panel layout: explicitly NOT a goal. UiState scope keeps panel rows out of PowerSync.
+- Per-device panel layout: not separately scoped. UiState rows sync through PowerSync like any block row, so panel layout (and focus/scroll restore) is shared across a user's devices by design — see the correction note at the top.
 - GC of orphan layout-session subtrees: not in step 4. Add a heartbeat-based sweep if/when this becomes a real issue (one cascading delete per stale layout session).
 
 ## Relation to Riffle's prelude
 
-The previous draft of this plan introduced a parallel in-memory `panelLayoutStore`. That deviated from Riffle's substrate-uniformity principle for no real gain — `ChangeScope.UiState` already provides the "ephemeral, not synced, not undoable" scope Riffle's essay describes as the right way to handle this kind of state. The current plan stays inside the existing reactive substrate; URL and `sessionStorage` are projections, not separate state authorities.
+The previous draft of this plan introduced a parallel in-memory `panelLayoutStore`. That deviated from Riffle's substrate-uniformity principle for no real gain — `ChangeScope.UiState` already provides a dedicated, not-undoable scope for this kind of state (it still syncs through the normal substrate — see the correction note at the top). The current plan stays inside the existing reactive substrate; URL and `sessionStorage` are projections, not separate state authorities.

--- a/src/data/globalState.ts
+++ b/src/data/globalState.ts
@@ -151,8 +151,10 @@ export const usePluginPrefsProperty = <T>(
 
 /** Resolve the per-plugin ui-state sub-block for a given type
  *  contribution. The mirror of `usePluginPrefsBlock` for persistent
- *  per-device state — the block lives under the root ui-state subtree
- *  and never enters the upload queue. */
+ *  ui-state — the block lives under the root ui-state subtree. Like all
+ *  `ChangeScope.UiState` writes it is non-undoable but still uploads and
+ *  syncs through the normal queue, so the state is restored across
+ *  devices (a deliberate uniform-substrate decision). */
 export function usePluginUIStateBlock(type: TypeContribution): Block {
   const repo = useRepo()
   const user = useUser()
@@ -171,9 +173,9 @@ export function usePluginUIStateChildBlock(type: TypeContribution, key: string):
 
 /** Read/write a ui-state property on the plugin's own ui-state
  *  sub-block. The schema must declare `changeScope: ChangeScope.UiState`
- *  so writes route into the device-local ui-state subtree (and stay
- *  undo-segregated from document edits). They still upload through the
- *  normal queue. */
+ *  so writes route into the ui-state subtree (and stay undo-segregated
+ *  from document edits). They still upload and sync through the normal
+ *  queue. */
 export const usePluginUIStateProperty = <T>(
   type: TypeContribution,
   schema: PropertySchema<T>,

--- a/src/data/pluginStateExtensions.ts
+++ b/src/data/pluginStateExtensions.ts
@@ -53,7 +53,8 @@ export const pluginPrefsExtension = (
 ]
 
 /** Same as `pluginPrefsExtension`, for sub-blocks under the root
- *  ui-state subtree (device-local, scoped via ChangeScope.UiState). */
+ *  ui-state subtree (scoped via ChangeScope.UiState — non-undoable but
+ *  still synced). */
 export const pluginUIStateExtension = (
   type: TypeContribution,
   source: string,


### PR DESCRIPTION
UiState-scoped writes upload and sync through the normal queue like any
other scope; the scope only opts out of the undo stack, not out of sync.
Cross-device restore of focus/scroll/layout via the uniform block
substrate is a deliberate, affirmed decision.

Fixes the stale docs caught by audit finding A2:
- globalState.ts: drop "never enters the upload queue" / "device-local"
- pluginStateExtensions.ts: drop "device-local" from the UiState subtree
- navigation-redesign.md: replace "not synced" framing with "not
  undoable" and add a correction note

https://claude.ai/code/session_01Gxcb53UCwoB6kn4VuAA4E3