### PR TITLE
refactor(bootstrap): lift App.tsx's module-level bootstrap pipeline out of the render path (#141)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,57 +9,16 @@ import type { Repo } from './data/repo'
 import { hasRemoteSyncConfig } from '@/services/powersync.js'
 import { useIsLocalOnly } from '@/components/Login.js'
 import { AppRuntimeProvider } from '@/extensions/AppRuntimeProvider.js'
-import {
-  canAccessRemoteWorkspace,
-  ensureLocalPersonalWorkspace,
-  ensurePersonalWorkspace,
-  getLocalMemberRole,
-  getLocalWorkspace,
-  listLocalWorkspaces,
-  primeLocalWorkspaceAndMember,
-} from '@/data/workspaces.js'
-import {
-  buildLayout,
-  layoutWorkspaceChanged,
-  parseLayout,
-  preserveHashQueryParams,
-} from '@/utils/routing.js'
-import { recallRememberedWorkspace, rememberWorkspace } from '@/utils/lastWorkspace.js'
-import { seedTutorial } from '@/initData.js'
-import { getOrCreatePropertiesPage } from '@/data/propertiesPage.js'
-import { getOrCreateTypesPage } from '@/data/typesPage.js'
-import { getOrCreateRecentsPage } from '@/data/recentsPage.js'
+import { getLocalMemberRole, getLocalWorkspace } from '@/data/workspaces.js'
+import { layoutWorkspaceChanged, parseLayout } from '@/utils/routing.js'
 import { useMyWorkspaceRoles } from '@/hooks/useWorkspaces.js'
-import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks.js'
-import { workspaceLandingFacet } from '@/extensions/core.js'
-import { resolveAppRuntimeSync } from '@/facets/resolveAppRuntime.js'
-import { readOverridesCache } from '@/extensions/overridesCache.js'
-import { staticAppExtensions } from '@/extensions/staticAppExtensions.js'
-import { getLayoutSessionId } from '@/utils/layoutSessionId.js'
-import {
-  PanelLayoutProjection,
-  applyCurrentLayoutUrl,
-  createPanelRowInTx,
-} from '@/utils/panelLayoutProjection.js'
-import { keyAtEnd } from '@/data/orderKey.js'
-import { ChangeScope } from '@/data/api'
 import { hasSafeModeSearchParam } from '@/utils/safeMode.js'
-import { getModePin, setModePin } from '@/sync/keys/modePin.js'
 import { onWipeReload } from '@/sync/keys/flows/lockAndWipe.js'
-import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
-import { decideWorkspaceEntry } from '@/sync/keys/workspaceAccess.js'
+import { PanelLayoutProjection } from '@/utils/panelLayoutProjection.js'
+import { resolveWorkspaceEntry } from '@/sync/keys/resolveWorkspaceEntry.js'
 import { WorkspaceKeyGate } from '@/components/workspace/WorkspaceKeyGate.js'
-
-// Resolved-workspace bundle. `freshlyCreated` is true only when this run
-// inserted a brand-new personal workspace via ensure_personal_workspace;
-// the caller uses it to install the starter tutorial alongside today's
-// daily note. Any path that returned an existing workspace (URL nav,
-// remembered, RPC returned an already-existing row) leaves it false —
-// those workspaces already have whatever pages the user has built up.
-interface ResolvedWorkspace {
-  id: string
-  freshlyCreated: boolean
-}
+import { resolveWorkspace } from '@/bootstrap/resolveWorkspace.js'
+import { bootstrapWorkspace } from '@/bootstrap/workspaceBootstrap.js'
 
 // `ready`: the workspace materialized and bootstrapped normally. `locked`: the
 // §6 gate intercepted before any bootstrap write — the workspace is e2ee
@@ -89,178 +48,22 @@ const initialLayoutCache = new Map<string, Promise<InitialLayout>>()
 const getCurrentHash = (): string =>
   typeof window === 'undefined' ? '' : window.location.hash
 
-// Pin a workspace plaintext, best-effort: a blocked/quota localStorage write
-// must not abort bootstrap (the create dialog catches the same failure). Worst
-// case the workspace shows the quarantine gate once on next load.
-const pinPlaintextBestEffort = (userId: string, workspaceId: string): void => {
-  try {
-    setModePin(userId, workspaceId, 'plaintext')
-  } catch (err) {
-    console.warn(`[App] plaintext pin failed for ${workspaceId} (will quarantine on next load)`, err)
-  }
-}
-
-const resolveWorkspace = async (
-  repo: Repo,
-  requestedWorkspaceId: string | undefined,
-  useRemoteSync: boolean,
-): Promise<ResolvedWorkspace> => {
-  if (requestedWorkspaceId) {
-    // Fast path: if PowerSync has already replicated this workspace into
-    // our local DB, RLS allowed it — we have access, trust the URL.
-    const localWs = await getLocalWorkspace(repo, requestedWorkspaceId)
-    if (localWs) return {id: localWs.id, freshlyCreated: false}
-
-    // Slow path: not local. This could be either "we don't have access"
-    // or "we have access but sync hasn't replicated yet". Ask the server
-    // (RLS-gated) to disambiguate. We can't poll local sqlite for this:
-    // `db.waitForFirstSync` resolves instantly on subsequent sessions
-    // (persistent IndexedDB), and a missing row could legitimately mean
-    // either case.
-    if (useRemoteSync) {
-      const access = await canAccessRemoteWorkspace(requestedWorkspaceId)
-      if (access.kind === 'allowed') {
-        // Server confirms access; getInitialLayout will poll for the blocks
-        // to land via sync.
-        return {id: requestedWorkspaceId, freshlyCreated: false}
-      }
-      if (access.kind === 'unknown') {
-        // Transport-level failure (offline, 5xx, JWT mid-refresh). We don't
-        // know if the user has access. Trust the URL hash rather than
-        // silently bumping them to a different workspace — the misroute is
-        // worse UX than a momentary "no blocks yet" page (which the user
-        // can fix with a reload once back online). If they really lack
-        // access, the next online bootstrap re-runs this check and falls
-        // through cleanly.
-        console.warn(
-          `canAccessRemoteWorkspace failed for ${requestedWorkspaceId}; trusting URL workspace and proceeding`,
-          access.error,
-        )
-        return {id: requestedWorkspaceId, freshlyCreated: false}
-      }
-      console.warn(
-        `Workspace ${requestedWorkspaceId} from URL is not accessible; falling back to default workspace.`,
-      )
-    }
-    // Confirmed-denied (or no remote sync) — fall through to default flow.
-    // The eventual layout normalization will overwrite the bad hash.
-  }
-
-  const remembered = recallRememberedWorkspace()
-  if (remembered) {
-    const ws = await getLocalWorkspace(repo, remembered)
-    if (ws) return {id: ws.id, freshlyCreated: false}
-  }
-
-  if (useRemoteSync) {
-    const result = await ensurePersonalWorkspace()
-    // Prime with the canonical member row from the RPC. Priming with a
-    // synthetic id (and waiting for sync to deliver the real one) would
-    // leave two membership rows in local sqlite, since the raw table has
-    // no (workspace_id, user_id) UNIQUE constraint.
-    await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
-    // A workspace WE just created is plaintext-confirmed (§8.1) — pin it so the
-    // §6 gate never quarantines it. An already-existing personal workspace
-    // (inserted=false) is left for the seed/gate to resolve.
-    if (result.inserted) pinPlaintextBestEffort(repo.user.id, result.workspace.id)
-    return {id: result.workspace.id, freshlyCreated: result.inserted}
-  }
-
-  const locals = await listLocalWorkspaces(repo)
-  if (locals.length > 0) return {id: locals[0].id, freshlyCreated: false}
-
-  // Remote sync disabled (e.g. dev mode without VITE_SUPABASE_*) and
-  // nothing local yet: synthesize a deterministic per-user personal
-  // workspace + owner membership locally so the rest of bootstrap
-  // (seedTutorial, daily note, Tutorial bullet) can run unchanged.
-  const local = await ensureLocalPersonalWorkspace(repo)
-  // Same plaintext-confirm as the remote path (§8.1) so the gate stays out of
-  // the way in local-only mode.
-  if (local.inserted) pinPlaintextBestEffort(repo.user.id, local.workspace.id)
-  return {id: local.workspace.id, freshlyCreated: local.inserted}
-}
-
-const replaceHash = (hash: string): void => {
-  if (typeof window === 'undefined') return
-  const nextHash = preserveHashQueryParams(hash, window.location.hash)
-  if (window.location.hash === nextHash) return
-  window.history.replaceState(null, '', nextHash)
-}
-
-// Resolve the static-extension runtime once per (repo, workspace).
-// `workspaceLandingFacet` resolvers only need the kernel + static
-// plugin contributions — dynamic plugins haven't loaded yet at this
-// point in bootstrap, and we don't want to give them the power to
-// redirect a user's first paint.
-//
-// Resolution goes through `resolveAppRuntimeSync` with the workspace's
-// cached toggle overrides — NOT the bare collector — so a togglable
-// boundary the user has disabled is honoured here too. Without this, a
-// disabled non-essential plugin (e.g. `system:daily-notes`, the sole
-// `workspaceLandingFacet` contributor) would still steer first paint.
-//
-// The cache keeps the cost down across re-entries via getInitialLayout's
-// promise cache; entries are keyed by `repo.instanceId` + workspace +
-// the override state, so a fresh Repo (new login), a workspace switch,
-// or a mid-session toggle change (Settings dispatches
-// `refreshAppRuntime`) all build a fresh runtime instead of replaying a
-// stale one — otherwise a just-disabled daily-notes could still steer a
-// later empty-layout navigation until a full reload.
-const landingRuntimeCache = new Map<string, ReturnType<typeof resolveAppRuntimeSync>>()
-const getLandingRuntime = (repo: Repo) => {
-  const workspaceId = repo.activeWorkspaceId
-  const overrides = workspaceId
-    ? readOverridesCache(workspaceId)
-    : new Map<string, boolean>()
-  // Sparse map (only entries diverging from manifest defaults), sorted
-  // for a stable key regardless of insertion order.
-  const overridesFingerprint = JSON.stringify(
-    [...overrides.entries()].sort(([a], [b]) => a.localeCompare(b)),
-  )
-  const cacheKey = `${repo.instanceId}:${workspaceId ?? ''}:${overridesFingerprint}`
-  const cached = landingRuntimeCache.get(cacheKey)
-  if (cached) return cached
-  const runtime = resolveAppRuntimeSync(staticAppExtensions({repo}), {
-    overrides,
-    context: {
-      repo,
-      workspaceId,
-      safeMode: false,
-    },
-  })
-  landingRuntimeCache.set(cacheKey, runtime)
-  return runtime
-}
-
-// Walk landing resolvers in reverse (highest precedence last in the
-// array — see `workspaceLandingFacet` docstring). Return the first
-// non-null id, or null if every resolver punts. A throwing resolver
-// is logged and skipped so a misbehaving plugin can't permanently
-// block the user from booting the app.
-const resolveLandingBlockId = async (
-  repo: Repo,
-  workspaceId: string,
-  freshlyCreated: boolean,
-): Promise<string | null> => {
-  const runtime = getLandingRuntime(repo)
-  const resolvers = runtime.read(workspaceLandingFacet)
-  for (let i = resolvers.length - 1; i >= 0; i -= 1) {
-    try {
-      const id = await resolvers[i]({repo, workspaceId, freshlyCreated})
-      if (id) return id
-    } catch (error) {
-      console.error('[App] workspace landing resolver threw', error)
-    }
-  }
-  return null
-}
-
+// The bootstrap pipeline's composing function: it owns the phase ORDERING that
+// was previously encoded only in comments. Three extracted phases run in a fixed
+// sequence — resolve the workspace, clear the §6 access gate, then run the
+// bootstrap writes — because each depends on the last: the gate must decide
+// BEFORE any write (those writes would otherwise land plaintext into an
+// encrypted-but-locked workspace), and `bootstrapWorkspace` keeps
+// seedTutorial-before-parseReferences inside itself.
 const resolveInitialLayout = async (
   repo: Repo,
   requestedHash: string,
   useRemoteSync: boolean,
 ): Promise<InitialLayout> => {
   const route = parseLayout(requestedHash)
+
+  // Phase 1 — resolve which workspace this run lands on (URL / remembered /
+  // ensure-personal / local-only). Pure async; see bootstrap/resolveWorkspace.
   const {id: workspaceId, freshlyCreated} = await resolveWorkspace(
     repo,
     route.workspaceId,
@@ -278,29 +81,16 @@ const resolveInitialLayout = async (
   const role = await getLocalMemberRole(repo, workspaceId, repo.user.id)
   repo.setReadOnly(role === 'viewer')
 
-  // §6 rule 3 access gate. Resolve whether this workspace can be materialized
-  // for us right now BEFORE any bootstrap write below — those writes (daily
-  // note, properties/types/recents pages, ui-state) would otherwise write
-  // plaintext into an encrypted-but-locked workspace. If it can't, return a
-  // `locked` layout and App renders the WorkspaceKeyGate. Safe because the
-  // rollout seed has already pinned pre-existing plaintext workspaces, so only
-  // genuinely locked/never-pinned workspaces land here.
-  const pin = getModePin(repo.user.id, workspaceId)
-  // Only an e2ee pin actually uses the workspace key. Reading the key store for
-  // plaintext/unpinned workspaces is unnecessary and — if IndexedDB is
-  // unavailable (private mode, disabled/corrupt storage) — would block an
-  // otherwise-plaintext user from loading the app. A read failure is treated as
-  // "no key" (→ locked, key-required) rather than aborting the bootstrap.
-  let hasKey = false
-  if (pin === 'e2ee') {
-    try {
-      hasKey = (await getWorkspaceKeyStore().get(repo.user.id, workspaceId)) !== null
-    } catch (err) {
-      console.warn(`[App] workspace key read failed for ${workspaceId}; treating as locked`, err)
-    }
-  }
-  const gateWorkspace = await getLocalWorkspace(repo, workspaceId)
-  const entry = decideWorkspaceEntry(pin, hasKey, gateWorkspace)
+  // Phase 2 — §6 rule 3 access gate. Resolve whether this workspace can be
+  // materialized for us right now BEFORE any bootstrap write below — those
+  // writes (daily note, properties/types/recents pages, ui-state) would
+  // otherwise write plaintext into an encrypted-but-locked workspace. If it
+  // can't, return a `locked`/`waiting` layout and App renders the gate/loader.
+  // The read-inputs + decide halves live together in resolveWorkspaceEntry; the
+  // local workspace row read is injected to keep that module within sync/keys.
+  const entry = await resolveWorkspaceEntry(repo.user.id, workspaceId, id =>
+    getLocalWorkspace(repo, id),
+  )
   if (entry.kind === 'waiting') {
     // The workspaces row hasn't replicated yet and the pin can't settle access
     // without it. Don't bootstrap (would write plaintext into a possibly-e2ee
@@ -313,99 +103,22 @@ const resolveInitialLayout = async (
     return {
       kind: 'locked',
       workspaceId,
-      workspaceName: gateWorkspace?.name ?? null,
+      workspaceName: entry.workspaceName,
       reason: entry.reason,
-      canary: gateWorkspace?.wkCanary ?? null,
+      canary: entry.canary,
     }
   }
 
-  // Ready — only NOW remember it as the default. Remembering a locked/waiting
-  // workspace would make the next empty-hash visit re-select it and render only
-  // the key gate (no switcher), trapping the user away from accessible spaces.
-  rememberWorkspace(workspaceId)
-
-  // Workspace-scoped one-shot data backfills (workspaceBackfillsFacet) — e.g.
-  // daily-notes deriving daily-note:date for pre-existing rows. Fire-and-forget:
-  // the repo defers it off this critical path and gates it to run once per
-  // workspace. Placed AFTER the access gate (above) so we never write into a
-  // locked / read-only workspace; routed through repo.tx so the derived rows
-  // upload — a raw write would stay local, which is exactly how the original
-  // daily-note:date backfill silently never synced.
-  repo.scheduleWorkspaceBackfills(workspaceId)
-
-  // One-time post-upgrade recovery for the deterministic-id shadow: clients that
-  // skip-staled the server's authoritative row under the old reconcile gate
-  // consumed its change-queue entry, so a normal startup never re-evaluates it.
-  // Re-scan the workspace's staged rows once (marker-gated, deferred) so those
-  // shadows heal on disk; visible on the next reload (the live cache LWW still
-  // holds the default this session).
-  repo.scheduleReconcileRescan(workspaceId)
-
-  // Freshly inserted personal workspace: install the starter tutorial
-  // as its own parent-less page. The [[Tutorial]] bullet on today's
-  // daily note (added below) makes it discoverable from the landing
-  // page without hijacking it. AWAIT the seed tx so the Tutorial
-  // alias row exists before parseReferences (post-commit processor)
-  // runs against the wiki-link bullet — otherwise parseReferences
-  // creates a fresh empty alias target for "Tutorial" and the
-  // bullet points at that orphan instead of the real seeded page.
-  if (freshlyCreated) {
-    await seedTutorial(repo, workspaceId)
-  }
-
-  // Ensure the Properties page exists (idempotent, deterministic id).
-  // User-defined property-schema blocks live under it.
-  await getOrCreatePropertiesPage(repo, workspaceId)
-
-  // Ensure the Types page exists (idempotent, deterministic id).
-  // User-defined block-type blocks live under it.
-  await getOrCreateTypesPage(repo, workspaceId)
-
-  // Ensure the Recents page exists. The recents plugin renders a
-  // recently-edited list on it via `repo.query.recentBlocks`.
-  await getOrCreateRecentsPage(repo, workspaceId)
-
-  const uiState = await getUIStateBlock(repo, workspaceId, repo.user, {})
-  const layoutSessionBlock = await getLayoutSessionBlock(uiState, getLayoutSessionId())
-  const hashForResolvedWorkspace = route.workspaceId && route.workspaceId !== workspaceId
-    ? buildLayout(workspaceId)
-    : requestedHash
-
-  const applyResult = await applyCurrentLayoutUrl({
+  // Phase 3 — bootstrap writes (remember-as-default, backfills, tutorial, the
+  // Properties/Types/Recents pages, ui-state) + URL→layout application. Runs
+  // only past the gate; see bootstrap/workspaceBootstrap.
+  const layoutSessionBlock = await bootstrapWorkspace({
     repo,
     workspaceId,
-    layoutSessionBlock,
-    hash: hashForResolvedWorkspace,
-    replaceHash,
+    freshlyCreated,
+    requestedHash,
+    requestedWorkspaceId: route.workspaceId,
   })
-
-  if (applyResult.kind === 'empty') {
-    // Empty layout — ask plugins via `workspaceLandingFacet` what block
-    // to land on. The daily-notes plugin contributes the historical
-    // "open today's note (and seed a [[Tutorial]] bullet on first
-    // run)" behavior; other plugins (or none) can override. We resolve
-    // the static-extension runtime here SYNCHRONOUSLY rather than
-    // waiting for AppRuntimeProvider's full async resolution because
-    // the landing decision blocks the first paint — dynamic
-    // user-defined plugins shouldn't be able to redirect the bootstrap
-    // before we've even built a layout, and the sync runtime carries
-    // the same kernel + static plugin contributions
-    // AppRuntimeProvider's initial render uses.
-    const landingId = await resolveLandingBlockId(repo, workspaceId, freshlyCreated)
-    if (landingId) {
-      replaceHash(buildLayout(workspaceId, [landingId]))
-      await repo.tx(async tx => {
-        const parent = await tx.get(layoutSessionBlock.id)
-        if (!parent) throw new Error(`getInitialLayout: layout session block ${layoutSessionBlock.id} not found`)
-        await createPanelRowInTx(repo, tx, {
-          workspaceId,
-          parentId: layoutSessionBlock.id,
-          orderKey: keyAtEnd(null),
-          blockId: landingId,
-        })
-      }, {scope: ChangeScope.UiState, description: 'bootstrap landing panel'})
-    }
-  }
 
   return {kind: 'ready', workspaceId, layoutSessionBlock}
 }

--- a/src/bootstrap/resolveWorkspace.ts
+++ b/src/bootstrap/resolveWorkspace.ts
@@ -1,0 +1,113 @@
+import type { Repo } from '@/data/repo.js'
+import {
+  canAccessRemoteWorkspace,
+  ensureLocalPersonalWorkspace,
+  ensurePersonalWorkspace,
+  getLocalWorkspace,
+  listLocalWorkspaces,
+  primeLocalWorkspaceAndMember,
+} from '@/data/workspaces.js'
+import { recallRememberedWorkspace } from '@/utils/lastWorkspace.js'
+import { setModePin } from '@/sync/keys/modePin.js'
+
+// Resolved-workspace bundle. `freshlyCreated` is true only when this run
+// inserted a brand-new personal workspace via ensure_personal_workspace;
+// the caller uses it to install the starter tutorial alongside today's
+// daily note. Any path that returned an existing workspace (URL nav,
+// remembered, RPC returned an already-existing row) leaves it false —
+// those workspaces already have whatever pages the user has built up.
+export interface ResolvedWorkspace {
+  id: string
+  freshlyCreated: boolean
+}
+
+// Pin a workspace plaintext, best-effort: a blocked/quota localStorage write
+// must not abort bootstrap (the create dialog catches the same failure). Worst
+// case the workspace shows the quarantine gate once on next load.
+const pinPlaintextBestEffort = (userId: string, workspaceId: string): void => {
+  try {
+    setModePin(userId, workspaceId, 'plaintext')
+  } catch (err) {
+    console.warn(`[App] plaintext pin failed for ${workspaceId} (will quarantine on next load)`, err)
+  }
+}
+
+export const resolveWorkspace = async (
+  repo: Repo,
+  requestedWorkspaceId: string | undefined,
+  useRemoteSync: boolean,
+): Promise<ResolvedWorkspace> => {
+  if (requestedWorkspaceId) {
+    // Fast path: if PowerSync has already replicated this workspace into
+    // our local DB, RLS allowed it — we have access, trust the URL.
+    const localWs = await getLocalWorkspace(repo, requestedWorkspaceId)
+    if (localWs) return {id: localWs.id, freshlyCreated: false}
+
+    // Slow path: not local. This could be either "we don't have access"
+    // or "we have access but sync hasn't replicated yet". Ask the server
+    // (RLS-gated) to disambiguate. We can't poll local sqlite for this:
+    // `db.waitForFirstSync` resolves instantly on subsequent sessions
+    // (persistent IndexedDB), and a missing row could legitimately mean
+    // either case.
+    if (useRemoteSync) {
+      const access = await canAccessRemoteWorkspace(requestedWorkspaceId)
+      if (access.kind === 'allowed') {
+        // Server confirms access; getInitialLayout will poll for the blocks
+        // to land via sync.
+        return {id: requestedWorkspaceId, freshlyCreated: false}
+      }
+      if (access.kind === 'unknown') {
+        // Transport-level failure (offline, 5xx, JWT mid-refresh). We don't
+        // know if the user has access. Trust the URL hash rather than
+        // silently bumping them to a different workspace — the misroute is
+        // worse UX than a momentary "no blocks yet" page (which the user
+        // can fix with a reload once back online). If they really lack
+        // access, the next online bootstrap re-runs this check and falls
+        // through cleanly.
+        console.warn(
+          `canAccessRemoteWorkspace failed for ${requestedWorkspaceId}; trusting URL workspace and proceeding`,
+          access.error,
+        )
+        return {id: requestedWorkspaceId, freshlyCreated: false}
+      }
+      console.warn(
+        `Workspace ${requestedWorkspaceId} from URL is not accessible; falling back to default workspace.`,
+      )
+    }
+    // Confirmed-denied (or no remote sync) — fall through to default flow.
+    // The eventual layout normalization will overwrite the bad hash.
+  }
+
+  const remembered = recallRememberedWorkspace()
+  if (remembered) {
+    const ws = await getLocalWorkspace(repo, remembered)
+    if (ws) return {id: ws.id, freshlyCreated: false}
+  }
+
+  if (useRemoteSync) {
+    const result = await ensurePersonalWorkspace()
+    // Prime with the canonical member row from the RPC. Priming with a
+    // synthetic id (and waiting for sync to deliver the real one) would
+    // leave two membership rows in local sqlite, since the raw table has
+    // no (workspace_id, user_id) UNIQUE constraint.
+    await primeLocalWorkspaceAndMember(repo, result.workspace, result.member)
+    // A workspace WE just created is plaintext-confirmed (§8.1) — pin it so the
+    // §6 gate never quarantines it. An already-existing personal workspace
+    // (inserted=false) is left for the seed/gate to resolve.
+    if (result.inserted) pinPlaintextBestEffort(repo.user.id, result.workspace.id)
+    return {id: result.workspace.id, freshlyCreated: result.inserted}
+  }
+
+  const locals = await listLocalWorkspaces(repo)
+  if (locals.length > 0) return {id: locals[0].id, freshlyCreated: false}
+
+  // Remote sync disabled (e.g. dev mode without VITE_SUPABASE_*) and
+  // nothing local yet: synthesize a deterministic per-user personal
+  // workspace + owner membership locally so the rest of bootstrap
+  // (seedTutorial, daily note, Tutorial bullet) can run unchanged.
+  const local = await ensureLocalPersonalWorkspace(repo)
+  // Same plaintext-confirm as the remote path (§8.1) so the gate stays out of
+  // the way in local-only mode.
+  if (local.inserted) pinPlaintextBestEffort(repo.user.id, local.workspace.id)
+  return {id: local.workspace.id, freshlyCreated: local.inserted}
+}

--- a/src/bootstrap/workspaceBootstrap.ts
+++ b/src/bootstrap/workspaceBootstrap.ts
@@ -1,0 +1,209 @@
+import type { Block } from '@/data/block.js'
+import type { Repo } from '@/data/repo.js'
+import { buildLayout, preserveHashQueryParams } from '@/utils/routing.js'
+import { rememberWorkspace } from '@/utils/lastWorkspace.js'
+import { seedTutorial } from '@/initData.js'
+import { getOrCreatePropertiesPage } from '@/data/propertiesPage.js'
+import { getOrCreateTypesPage } from '@/data/typesPage.js'
+import { getOrCreateRecentsPage } from '@/data/recentsPage.js'
+import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks.js'
+import { workspaceLandingFacet } from '@/extensions/core.js'
+import { resolveAppRuntimeSync } from '@/facets/resolveAppRuntime.js'
+import { readOverridesCache } from '@/extensions/overridesCache.js'
+import { staticAppExtensions } from '@/extensions/staticAppExtensions.js'
+import { getLayoutSessionId } from '@/utils/layoutSessionId.js'
+import { applyCurrentLayoutUrl, createPanelRowInTx } from '@/utils/panelLayoutProjection.js'
+import { keyAtEnd } from '@/data/orderKey.js'
+import { ChangeScope } from '@/data/api'
+
+const replaceHash = (hash: string): void => {
+  if (typeof window === 'undefined') return
+  const nextHash = preserveHashQueryParams(hash, window.location.hash)
+  if (window.location.hash === nextHash) return
+  window.history.replaceState(null, '', nextHash)
+}
+
+// Resolve the static-extension runtime once per (repo, workspace).
+// `workspaceLandingFacet` resolvers only need the kernel + static
+// plugin contributions — dynamic plugins haven't loaded yet at this
+// point in bootstrap, and we don't want to give them the power to
+// redirect a user's first paint.
+//
+// Resolution goes through `resolveAppRuntimeSync` with the workspace's
+// cached toggle overrides — NOT the bare collector — so a togglable
+// boundary the user has disabled is honoured here too. Without this, a
+// disabled non-essential plugin (e.g. `system:daily-notes`, the sole
+// `workspaceLandingFacet` contributor) would still steer first paint.
+//
+// The cache keeps the cost down across re-entries via getInitialLayout's
+// promise cache; entries are keyed by `repo.instanceId` + workspace +
+// the override state, so a fresh Repo (new login), a workspace switch,
+// or a mid-session toggle change (Settings dispatches
+// `refreshAppRuntime`) all build a fresh runtime instead of replaying a
+// stale one — otherwise a just-disabled daily-notes could still steer a
+// later empty-layout navigation until a full reload.
+const landingRuntimeCache = new Map<string, ReturnType<typeof resolveAppRuntimeSync>>()
+const getLandingRuntime = (repo: Repo) => {
+  const workspaceId = repo.activeWorkspaceId
+  const overrides = workspaceId
+    ? readOverridesCache(workspaceId)
+    : new Map<string, boolean>()
+  // Sparse map (only entries diverging from manifest defaults), sorted
+  // for a stable key regardless of insertion order.
+  const overridesFingerprint = JSON.stringify(
+    [...overrides.entries()].sort(([a], [b]) => a.localeCompare(b)),
+  )
+  const cacheKey = `${repo.instanceId}:${workspaceId ?? ''}:${overridesFingerprint}`
+  const cached = landingRuntimeCache.get(cacheKey)
+  if (cached) return cached
+  const runtime = resolveAppRuntimeSync(staticAppExtensions({repo}), {
+    overrides,
+    context: {
+      repo,
+      workspaceId,
+      safeMode: false,
+    },
+  })
+  landingRuntimeCache.set(cacheKey, runtime)
+  return runtime
+}
+
+// Walk landing resolvers in reverse (highest precedence last in the
+// array — see `workspaceLandingFacet` docstring). Return the first
+// non-null id, or null if every resolver punts. A throwing resolver
+// is logged and skipped so a misbehaving plugin can't permanently
+// block the user from booting the app.
+const resolveLandingBlockId = async (
+  repo: Repo,
+  workspaceId: string,
+  freshlyCreated: boolean,
+): Promise<string | null> => {
+  const runtime = getLandingRuntime(repo)
+  const resolvers = runtime.read(workspaceLandingFacet)
+  for (let i = resolvers.length - 1; i >= 0; i -= 1) {
+    try {
+      const id = await resolvers[i]({repo, workspaceId, freshlyCreated})
+      if (id) return id
+    } catch (error) {
+      console.error('[App] workspace landing resolver threw', error)
+    }
+  }
+  return null
+}
+
+export interface WorkspaceBootstrapArgs {
+  repo: Repo
+  workspaceId: string
+  freshlyCreated: boolean
+  requestedHash: string
+  /** The workspace id parsed from the requested hash (if any) — used to detect
+   *  a URL pointing at a different workspace than the one we resolved. */
+  requestedWorkspaceId: string | undefined
+}
+
+/**
+ * The bootstrap *write* phase (§6 gate already cleared by the caller). Performs
+ * the workspace-scoped writes — remember-as-default, one-shot backfills, the
+ * starter tutorial, the Properties/Types/Recents pages, the ui-state block — and
+ * applies the URL→layout projection (landing on a plugin-resolved block when the
+ * layout is empty). Returns the layout-session block the app renders.
+ *
+ * Testable without rendering: it takes a repo and plain args and returns a Block.
+ */
+export const bootstrapWorkspace = async ({
+  repo,
+  workspaceId,
+  freshlyCreated,
+  requestedHash,
+  requestedWorkspaceId,
+}: WorkspaceBootstrapArgs): Promise<Block> => {
+  // Only NOW remember it as the default. Remembering a locked/waiting workspace
+  // would make the next empty-hash visit re-select it and render only the key
+  // gate (no switcher), trapping the user away from accessible spaces.
+  rememberWorkspace(workspaceId)
+
+  // Workspace-scoped one-shot data backfills (workspaceBackfillsFacet) — e.g.
+  // daily-notes deriving daily-note:date for pre-existing rows. Fire-and-forget:
+  // the repo defers it off this critical path and gates it to run once per
+  // workspace. Placed AFTER the access gate (in the caller) so we never write
+  // into a locked / read-only workspace; routed through repo.tx so the derived
+  // rows upload — a raw write would stay local, which is exactly how the
+  // original daily-note:date backfill silently never synced.
+  repo.scheduleWorkspaceBackfills(workspaceId)
+
+  // One-time post-upgrade recovery for the deterministic-id shadow: clients that
+  // skip-staled the server's authoritative row under the old reconcile gate
+  // consumed its change-queue entry, so a normal startup never re-evaluates it.
+  // Re-scan the workspace's staged rows once (marker-gated, deferred) so those
+  // shadows heal on disk; visible on the next reload (the live cache LWW still
+  // holds the default this session).
+  repo.scheduleReconcileRescan(workspaceId)
+
+  // Freshly inserted personal workspace: install the starter tutorial
+  // as its own parent-less page. The [[Tutorial]] bullet on today's
+  // daily note (added below) makes it discoverable from the landing
+  // page without hijacking it. AWAIT the seed tx so the Tutorial
+  // alias row exists before parseReferences (post-commit processor)
+  // runs against the wiki-link bullet — otherwise parseReferences
+  // creates a fresh empty alias target for "Tutorial" and the
+  // bullet points at that orphan instead of the real seeded page.
+  if (freshlyCreated) {
+    await seedTutorial(repo, workspaceId)
+  }
+
+  // Ensure the Properties page exists (idempotent, deterministic id).
+  // User-defined property-schema blocks live under it.
+  await getOrCreatePropertiesPage(repo, workspaceId)
+
+  // Ensure the Types page exists (idempotent, deterministic id).
+  // User-defined block-type blocks live under it.
+  await getOrCreateTypesPage(repo, workspaceId)
+
+  // Ensure the Recents page exists. The recents plugin renders a
+  // recently-edited list on it via `repo.query.recentBlocks`.
+  await getOrCreateRecentsPage(repo, workspaceId)
+
+  const uiState = await getUIStateBlock(repo, workspaceId, repo.user, {})
+  const layoutSessionBlock = await getLayoutSessionBlock(uiState, getLayoutSessionId())
+  const hashForResolvedWorkspace = requestedWorkspaceId && requestedWorkspaceId !== workspaceId
+    ? buildLayout(workspaceId)
+    : requestedHash
+
+  const applyResult = await applyCurrentLayoutUrl({
+    repo,
+    workspaceId,
+    layoutSessionBlock,
+    hash: hashForResolvedWorkspace,
+    replaceHash,
+  })
+
+  if (applyResult.kind === 'empty') {
+    // Empty layout — ask plugins via `workspaceLandingFacet` what block
+    // to land on. The daily-notes plugin contributes the historical
+    // "open today's note (and seed a [[Tutorial]] bullet on first
+    // run)" behavior; other plugins (or none) can override. We resolve
+    // the static-extension runtime here SYNCHRONOUSLY rather than
+    // waiting for AppRuntimeProvider's full async resolution because
+    // the landing decision blocks the first paint — dynamic
+    // user-defined plugins shouldn't be able to redirect the bootstrap
+    // before we've even built a layout, and the sync runtime carries
+    // the same kernel + static plugin contributions
+    // AppRuntimeProvider's initial render uses.
+    const landingId = await resolveLandingBlockId(repo, workspaceId, freshlyCreated)
+    if (landingId) {
+      replaceHash(buildLayout(workspaceId, [landingId]))
+      await repo.tx(async tx => {
+        const parent = await tx.get(layoutSessionBlock.id)
+        if (!parent) throw new Error(`getInitialLayout: layout session block ${layoutSessionBlock.id} not found`)
+        await createPanelRowInTx(repo, tx, {
+          workspaceId,
+          parentId: layoutSessionBlock.id,
+          orderKey: keyAtEnd(null),
+          blockId: landingId,
+        })
+      }, {scope: ChangeScope.UiState, description: 'bootstrap landing panel'})
+    }
+  }
+
+  return layoutSessionBlock
+}

--- a/src/sync/keys/resolveWorkspaceEntry.test.ts
+++ b/src/sync/keys/resolveWorkspaceEntry.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ModePin } from './modePin.js'
+import type { GateWorkspace } from './resolveWorkspaceEntry.js'
+
+// The read-half wraps two side-effecting reads (the local pin and the
+// per-device key store); mock them so the test drives the orchestration the
+// pure decideWorkspaceEntry can't see (key lookup, its failure handling, and
+// the name/canary enrichment for the lock prompt).
+const getModePin = vi.fn<(userId: string, workspaceId: string) => ModePin | null>()
+const keyGet = vi.fn<(userId: string, workspaceId: string) => Promise<CryptoKey | null>>()
+
+vi.mock('./modePin.js', () => ({getModePin: (u: string, w: string) => getModePin(u, w)}))
+vi.mock('./keyStore.js', () => ({getWorkspaceKeyStore: () => ({get: keyGet})}))
+
+const { resolveWorkspaceEntry } = await import('./resolveWorkspaceEntry.js')
+
+const workspace = (over: Partial<GateWorkspace> = {}): GateWorkspace => ({
+  encryptionMode: 'none',
+  name: 'My space',
+  wkCanary: null,
+  ...over,
+})
+
+beforeEach(() => {
+  getModePin.mockReset()
+  keyGet.mockReset()
+  keyGet.mockResolvedValue(null)
+})
+
+describe('resolveWorkspaceEntry (read-inputs half of the §6 gate)', () => {
+  it('plaintext pin → ready without reading the key store or the row', async () => {
+    getModePin.mockReturnValue('plaintext')
+    const loadWorkspace = vi.fn()
+    expect(await resolveWorkspaceEntry('u', 'w', loadWorkspace)).toEqual({kind: 'ready'})
+    expect(keyGet).not.toHaveBeenCalled()
+  })
+
+  it('e2ee pin reads the key store; key present → ready', async () => {
+    getModePin.mockReturnValue('e2ee')
+    keyGet.mockResolvedValue({} as CryptoKey)
+    expect(await resolveWorkspaceEntry('u', 'w', async () => null)).toEqual({kind: 'ready'})
+    expect(keyGet).toHaveBeenCalledWith('u', 'w')
+  })
+
+  it('a thrown key-store read is treated as locked, not fatal', async () => {
+    getModePin.mockReturnValue('e2ee')
+    keyGet.mockRejectedValue(new Error('IndexedDB unavailable'))
+    const entry = await resolveWorkspaceEntry('u', 'w', async () => workspace({encryptionMode: 'e2ee'}))
+    expect(entry).toMatchObject({kind: 'locked', reason: 'key-required'})
+  })
+
+  it('locked entries carry the row name and canary for the prompt', async () => {
+    getModePin.mockReturnValue(null)
+    const entry = await resolveWorkspaceEntry('u', 'w', async () =>
+      workspace({encryptionMode: 'e2ee', name: 'Vault', wkCanary: 'canary-1'}),
+    )
+    expect(entry).toEqual({
+      kind: 'locked',
+      reason: 'key-required',
+      workspaceName: 'Vault',
+      canary: 'canary-1',
+    })
+  })
+
+  it('waits when the row needed to decide has not synced yet', async () => {
+    getModePin.mockReturnValue(null)
+    expect(await resolveWorkspaceEntry('u', 'w', async () => null)).toEqual({kind: 'waiting'})
+  })
+})

--- a/src/sync/keys/resolveWorkspaceEntry.ts
+++ b/src/sync/keys/resolveWorkspaceEntry.ts
@@ -1,0 +1,73 @@
+/**
+ * §6 rule 3 access gate — the *read-inputs* half, reunited with the *decide*
+ * half ({@link decideWorkspaceEntry}) it feeds.
+ *
+ * The bootstrap pipeline must know, BEFORE any plaintext write, whether the
+ * active workspace can be materialized for us right now. That needs three live
+ * reads — the local mode pin, the per-device workspace key, and the local
+ * `workspaces` row — gathered here and handed to the pure policy in
+ * `workspaceAccess.ts`. The workspace-row read is the one cross-layer dependency
+ * (the data layer), so it is injected via {@link loadWorkspace} rather than
+ * imported, keeping this module within `sync/keys`.
+ */
+
+import { getModePin } from './modePin.js'
+import { getWorkspaceKeyStore } from './keyStore.js'
+import { decideWorkspaceEntry } from './workspaceAccess.js'
+
+/** The local `workspaces` row fields the gate reads. `encryptionMode` decides
+ *  access (branch a/b); `name`/`wkCanary` populate the lock prompt. */
+export interface GateWorkspace {
+  readonly encryptionMode: string
+  readonly name: string | null
+  readonly wkCanary: string | null
+}
+
+export type WorkspaceEntryResolution =
+  | { readonly kind: 'ready' }
+  /** The synced `workspaces` row isn't local yet and access can't be decided
+   *  safely without it — wait for it to replicate, then re-resolve. */
+  | { readonly kind: 'waiting' }
+  | {
+      readonly kind: 'locked'
+      readonly reason: 'key-required' | 'quarantine'
+      readonly workspaceName: string | null
+      readonly canary: string | null
+    }
+
+/**
+ * Resolve how to enter `workspaceId` for `userId`: gather the pin, key, and
+ * (injected) local workspace row, then defer to {@link decideWorkspaceEntry}.
+ *
+ * Only an e2ee pin actually uses the workspace key. Reading the key store for
+ * plaintext/unpinned workspaces is unnecessary and — if IndexedDB is
+ * unavailable (private mode, disabled/corrupt storage) — would block an
+ * otherwise-plaintext user from loading the app. A read failure is treated as
+ * "no key" (→ locked, key-required) rather than aborting the bootstrap.
+ */
+export const resolveWorkspaceEntry = async (
+  userId: string,
+  workspaceId: string,
+  loadWorkspace: (workspaceId: string) => Promise<GateWorkspace | null>,
+): Promise<WorkspaceEntryResolution> => {
+  const pin = getModePin(userId, workspaceId)
+  let hasKey = false
+  if (pin === 'e2ee') {
+    try {
+      hasKey = (await getWorkspaceKeyStore().get(userId, workspaceId)) !== null
+    } catch (err) {
+      console.warn(`[App] workspace key read failed for ${workspaceId}; treating as locked`, err)
+    }
+  }
+  const workspace = await loadWorkspace(workspaceId)
+  const entry = decideWorkspaceEntry(pin, hasKey, workspace)
+  if (entry.kind === 'locked') {
+    return {
+      kind: 'locked',
+      reason: entry.reason,
+      workspaceName: workspace?.name ?? null,
+      canary: workspace?.wkCanary ?? null,
+    }
+  }
+  return entry
+}


### PR DESCRIPTION
Closes #141 (Audit D2).

## Problem
430 of `App.tsx`'s 594 lines were a module-level bootstrap pipeline spanning five layers, executed straight from the React render path via `use()`: six-way workspace resolution (incl. a Supabase RLS probe), the §6 E2EE entry-gate with its *read-inputs* half split from the *decide* half in `sync/keys/workspaceAccess.ts`, bootstrap writes, the landing-runtime cache, and URL→layout application — all welded into one opaque promise.

## Change
Split at the three comment-fenced phase boundaries into independently testable units, leaving App with a small composing function that owns the phase **ordering**:

1. **`src/bootstrap/resolveWorkspace.ts`** — the six-way workspace resolution (pure async), moved verbatim with its `pinPlaintextBestEffort` helper.
2. **`src/sync/keys/resolveWorkspaceEntry.ts`** — reunites the §6 gate's *read-inputs* half (pin + key-store + local workspace-row reads, incl. the key-read failure handling) with the *decide* half (`decideWorkspaceEntry`) it feeds. The one cross-layer read (the workspace row) is **injected** so the module stays within `sync/keys` (no new dependency on the data layer).
3. **`src/bootstrap/workspaceBootstrap.ts`** — the bootstrap write phase (remember-as-default, backfills, tutorial seed, Properties/Types/Recents pages, ui-state) plus the landing-runtime cache and URL→layout application. Testable without rendering.

`resolveInitialLayout` is now just the composer — **resolve → gate → write** — with the gate-before-writes ordering enforced by control flow rather than comments, and `seedTutorial`-before-`parseReferences` kept inside `bootstrapWorkspace`.

## Notes
- Behavior unchanged; this is a pure boundary move. App.tsx drops from 619 → 332 lines.
- The LRU / `navigationVersion` machinery is left in place — its shrink is the downstream payoff the issue flags as a follow-up, not part of this split.

## Verification
- `tsc -b` clean; eslint clean on all touched files.
- Full suite: **297 files / 3218 tests pass**.
- Added a focused unit test for `resolveWorkspaceEntry` covering the key-store read, its thrown-read→locked fallback, the waiting case, and the lock-prompt name/canary enrichment — the IO orchestration the pure `decideWorkspaceEntry` test can't reach.

https://claude.ai/code/session_01SjWCwJS9yCMyZFprYZQgQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjWCwJS9yCMyZFprYZQgQk)_