### PR TITLE
refactor(data/extensions): remove setFacetRuntime compensation mechanisms (#136 B1)

### DIFF
--- a/src/data/facetBridge.ts
+++ b/src/data/facetBridge.ts
@@ -94,26 +94,6 @@ export class FacetBridge {
    *  Cleared when `setFacetRuntime` swaps to a fresh runtime — old
    *  listeners would fire against stale rebuild closures otherwise. */
   private runtimeFacetUnsubs: Array<() => void> = []
-  /** Durable runtime contribution buckets. Persisted across
-   *  `setFacetRuntime` swaps and replayed onto the fresh runtime so
-   *  user-data schemas (et al.) added via `setRuntimeContributions`
-   *  survive the dynamic-extension reload. Without this, a bucket would
-   *  live only on whichever FacetRuntime was current when it was set and
-   *  evaporate on the next swap.
-   *
-   *  Scope note: this mirrors only buckets written through *this* method
-   *  (durable owners — `UserSchemasService` / `UserTypesService`). App
-   *  effects that write directly to `runtime.setRuntimeContributions`
-   *  (e.g. the theme apply-actions / keybinding overrides) are NOT
-   *  mirrored here — they re-push on their own restart each swap, so
-   *  replaying them would strand stale contributions when their owning
-   *  plugin is toggled off. */
-  private readonly runtimeContributionBuckets = new Map<string, Map<string, readonly unknown[]>>()
-  /** Per-facet refs needed to replay buckets onto a fresh runtime —
-   *  `setRuntimeContributions` takes a `Facet` reference (not a string
-   *  id), so we cache it the first time the caller passes one. */
-  private readonly runtimeContributionFacets = new Map<string, Facet<unknown, unknown>>()
-
   /** Listeners for property-schema map changes (full rebuild OR
    *  runtime-bucket update). Used by `usePropertySchemas` to drive React
    *  reruns. */
@@ -153,20 +133,18 @@ export class FacetBridge {
     for (const dispose of this.runtimeFacetUnsubs) dispose()
     this.runtimeFacetUnsubs = []
 
+    const previous = this.runtime
     this.runtime = runtime
 
-    // Replay the persisted durable contribution buckets onto the fresh
-    // runtime so user-data schemas survive the swap. Doing this before
-    // running rebuild steps means the steps see the merged view on first
-    // read (no flicker through a state where user-data is missing and
-    // then re-added).
-    for (const [facetId, bucketsBySource] of this.runtimeContributionBuckets) {
-      const facet = this.runtimeContributionFacets.get(facetId)
-      if (!facet) continue
-      for (const [sourceId, contributions] of bucketsBySource) {
-        runtime.setRuntimeContributions(facet, sourceId, contributions)
-      }
-    }
+    // Carry the previous runtime's DURABLE runtime-contribution buckets
+    // (repo-owned user data — user property schemas / types) forward
+    // onto the fresh runtime. This is the runtime's own job now (B1(2)):
+    // the bridge no longer keeps a separate mirror. Only durable buckets
+    // are adopted, so transient effect-owned buckets can't strand.
+    // Doing this before running rebuild steps means the steps see the
+    // merged view on first read (no flicker through a state where
+    // user-data is missing and then re-added).
+    if (previous) runtime.adoptDurableContributionsFrom(previous)
 
     // Run every rebuild step on the fresh runtime.
     for (const step of this.rebuildSteps) step.run(runtime)
@@ -193,8 +171,10 @@ export class FacetBridge {
    *  `sourceId`. Triggers a re-run of every rebuild step whose declared
    *  inputs include this facet (via the `onFacetChange` listener wired in
    *  `setFacetRuntime`), plus per-facet listener fan-out for React
-   *  subscribers. The bucket is persisted here so it survives the next
-   *  `setFacetRuntime` swap. Throws if no runtime is installed. */
+   *  subscribers. Written as `{durable: true}` so the runtime carries the
+   *  bucket forward across the next `setFacetRuntime` swap
+   *  (`adoptDurableContributionsFrom`) — no separate bridge mirror.
+   *  Throws if no runtime is installed. */
   setRuntimeContributions<Input>(
     facet: Facet<Input, unknown>,
     sourceId: string,
@@ -203,25 +183,7 @@ export class FacetBridge {
     if (!this.runtime) {
       throw new Error('[FacetBridge.setRuntimeContributions] called before setFacetRuntime')
     }
-    // Persist the bucket so it survives `setFacetRuntime` swaps. We also
-    // cache the facet reference (the runtime's setRuntimeContributions
-    // takes a Facet, not just an id).
-    this.runtimeContributionFacets.set(facet.id, facet as Facet<unknown, unknown>)
-    let bucketsBySource = this.runtimeContributionBuckets.get(facet.id)
-    if (contributions.length === 0) {
-      bucketsBySource?.delete(sourceId)
-      if (bucketsBySource && bucketsBySource.size === 0) {
-        this.runtimeContributionBuckets.delete(facet.id)
-        this.runtimeContributionFacets.delete(facet.id)
-      }
-    } else {
-      if (!bucketsBySource) {
-        bucketsBySource = new Map<string, readonly unknown[]>()
-        this.runtimeContributionBuckets.set(facet.id, bucketsBySource)
-      }
-      bucketsBySource.set(sourceId, contributions as readonly unknown[])
-    }
-    this.runtime.setRuntimeContributions(facet, sourceId, contributions)
+    this.runtime.setRuntimeContributions(facet, sourceId, contributions, { durable: true })
   }
 
   onPropertySchemasChange(listener: () => void): () => void {

--- a/src/data/internals/facets.test.ts
+++ b/src/data/internals/facets.test.ts
@@ -76,8 +76,7 @@ beforeEach(async () => {
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
     // Start empty so setFacetRuntime is the only registration path.
-    registerKernelMutators: false,
-    registerKernelProcessors: false,
+    installKernelRuntime: false,
   })
 })
 afterEach(() => { repo.stopSyncObserver() })
@@ -134,7 +133,7 @@ describe('setFacetRuntime + mutatorsFacet', () => {
   })
 
   it('setFacetRuntime replaces the registry — kernel mutators are not implicitly retained', async () => {
-    // We started with registerKernelMutators: false, so the registry begins empty.
+    // We started with so the registry begins empty.
     // After setFacetRuntime with only a plugin mutator, kernel calls fail.
     let observed = false
     const plugin = defineMutator<{id: string}, void>({

--- a/src/data/internals/facets.test.ts
+++ b/src/data/internals/facets.test.ts
@@ -133,7 +133,7 @@ describe('setFacetRuntime + mutatorsFacet', () => {
   })
 
   it('setFacetRuntime replaces the registry — kernel mutators are not implicitly retained', async () => {
-    // We started with so the registry begins empty.
+    // We started with installKernelRuntime: false, so the registry begins empty.
     // After setFacetRuntime with only a plugin mutator, kernel calls fail.
     let observed = false
     const plugin = defineMutator<{id: string}, void>({

--- a/src/data/internals/kernelQueries.test.ts
+++ b/src/data/internals/kernelQueries.test.ts
@@ -51,7 +51,6 @@ const setup = async (): Promise<Harness> => {
     newId: () => `gen-${++idCursor}`,
     // Keep the processor registry empty; these query tests seed
     // `references` directly and should not depend on plugin processors.
-    registerKernelProcessors: false,
   })
   return {h, cache, repo}
 }

--- a/src/data/internals/kernelQueries.test.ts
+++ b/src/data/internals/kernelQueries.test.ts
@@ -108,9 +108,10 @@ const asBlockOrNull = (v: BlockData | null | undefined): BlockData | null => v ?
  * re-resolves to an equal value (or coalesces with a later control write) is
  * deduped and never reaches a subscriber. The synchronous count is complete the
  * moment `tx` resolves because these tests issue only local `repo.tx` writes to
- * `blocks`: the post-commit processor registry is empty (`registerKernelProcessors:
- * false`) AND the default sync observer only reacts to `blocks_synced` writes, so
- * neither re-invalidates a tick later.
+ * `blocks`: the post-commit processor registry is empty (`KERNEL_PROCESSORS` is
+ * `[]` and no plugin processors are registered here) AND the default sync
+ * observer only reacts to `blocks_synced` writes, so neither re-invalidates a
+ * tick later.
  */
 const invalidations = () => env.repo.handleStore.metrics.loaderInvalidations
 

--- a/src/data/internals/kernelQueries.ts
+++ b/src/data/internals/kernelQueries.ts
@@ -1220,9 +1220,10 @@ export const findExtensionBlocksQuery = defineQuery<{workspaceId: string}, Block
 
 // ──── Bundle ────
 
-/** All kernel queries — registered at construction time when
- *  `RepoOptions.registerKernelQueries` is true (default), and
- *  contributed to the FacetRuntime via `kernelDataExtension`. */
+/** All kernel queries — contributed to the FacetRuntime via
+ *  `kernelDataExtension`, which the Repo installs at construction
+ *  (`installKernelRuntime`, default true) and every `setFacetRuntime`
+ *  swap re-merges. */
 export const KERNEL_QUERIES: ReadonlyArray<AnyQuery> = [
   subtreeQuery,
   ancestorsQuery,

--- a/src/data/internals/phase3PluginExample.test.ts
+++ b/src/data/internals/phase3PluginExample.test.ts
@@ -122,7 +122,6 @@ beforeEach(async () => {
     // alongside core; setFacetRuntime below replaces the registry with
     // the merged kernel + plugin runtime (the same shape
     // AppRuntimeProvider produces).
-    registerKernelProcessors: false,
   })
   // Seed a row so setProperty has a target.
   await repo.tx(

--- a/src/data/internals/processorRunner.test.ts
+++ b/src/data/internals/processorRunner.test.ts
@@ -55,7 +55,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   return {h, repo}
 }

--- a/src/data/internals/sameTxRunner.test.ts
+++ b/src/data/internals/sameTxRunner.test.ts
@@ -53,7 +53,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   return {h, repo}
 }

--- a/src/data/internals/txEngine.test.ts
+++ b/src/data/internals/txEngine.test.ts
@@ -105,7 +105,6 @@ const setup = async (overrides?: {isReadOnly?: boolean}): Promise<Harness> => {
     // on content writes would add follow-up txs (parseReferences) the
     // engine assertions don't account for — keep the processor surface
     // empty and let the parseReferences integration tests cover it.
-    registerKernelProcessors: false,
   })
   // Register only the local test probe — afterCommit tests use it to
   // schedule explicit jobs. The rest of the engine tests don't call

--- a/src/data/internals/typeSystem.test.ts
+++ b/src/data/internals/typeSystem.test.ts
@@ -45,9 +45,8 @@ beforeEach(async () => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelMutators: false,
-    registerKernelProcessors: false,
-    registerKernelQueries: false,
+    // Start empty so setFacetRuntime is the only registration path.
+    installKernelRuntime: false,
   })
 })
 

--- a/src/data/internals/typedBlockQuery.test.ts
+++ b/src/data/internals/typedBlockQuery.test.ts
@@ -78,7 +78,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/data/kernelDataExtension.ts
+++ b/src/data/kernelDataExtension.ts
@@ -1,28 +1,22 @@
 /**
- * Kernel data-layer AppExtension — wraps the kernel mutators, queries,
- * property schemas, and any core-only post-commit processors as facet
- * contributions so the FacetRuntime carries them. The Repo bootstraps
- * with kernel registries directly, but `repo.setFacetRuntime(runtime)`
- * REPLACES those registries, so the runtime's data facets must include
- * the kernel contributions to keep `repo.mutate.<kernel>` and
- * `repo.query.<kernel>` working after that call.
+ * Kernel data-layer AppExtension — the single source of the kernel
+ * mutators, queries, post-commit / same-tx processors, invalidation
+ * rule, property schemas, and type contributions, expressed as facet
+ * contributions. This is the ONLY kernel registration path (audit
+ * B1(1)): the Repo constructor installs it as a kernel-only
+ * `FacetRuntime` (`installKernelRuntime`, default true) so
+ * `repo.mutate.<kernel>` / `repo.query.<kernel>` work immediately, and
+ * every later `repo.setFacetRuntime(runtime)` REPLACES that install with
+ * the merged kernel + plugin registry — so this extension must be
+ * present in every runtime (it is, via `staticDataExtensions`) to keep
+ * the kernel dispatch surfaces working after a swap.
  *
- * Property schemas (Phase 3 — chunk A): the kernel descriptors live
- * in `data/properties.ts` and are
- * exported as plain consts; this extension surfaces them through
+ * Property schemas: the kernel descriptors live in `data/properties.ts`
+ * (plain consts); this extension surfaces them through
  * `propertySchemasFacet` so non-React surfaces (the property panel's
- * schema lookup, future CLI / server-side audit) and plugin authors
- * can resolve names through the same registry that plugin schemas
- * register into.
- *
- * Queries (Phase 4 — chunk B): KERNEL_QUERIES are facet-contributed
- * here so `repo.setFacetRuntime(runtime)` includes them alongside
- * plugin queries. Repo also registers them at construction time
- * (RepoOptions.registerKernelQueries, default true) so `repo.query.X`
- * works pre-Stage-1 in the same way `repo.mutate.X` does — the
- * setFacetRuntime call replaces the registry with the merged
- * kernel + plugin set, so the kernel queries must be in the runtime
- * to keep `repo.query.<kernel>` working after that call.
+ * schema lookup, future CLI / server-side audit) and plugin authors can
+ * resolve names through the same registry that plugin schemas register
+ * into.
  *
  * No facet sources beyond the data layer here — UI facets
  * (renderers, actions, contexts) live in their own extensions.

--- a/src/data/mutators.test.ts
+++ b/src/data/mutators.test.ts
@@ -54,8 +54,9 @@ const setup = async (): Promise<Harness> => {
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
     // Mutator tests assert on user-facing tx side-effects (cache,
-    // command_events). Kernel processors firing add follow-up txs
-    // that aren't under test here; integration coverage lives in the
+    // command_events) against the kernel-only runtime the constructor
+    // installs — no plugin post-commit processors are registered here, so
+    // no follow-up txs run. Plugin-processor integration lives in the
     // backlinks plugin processor tests.
   })
   return {

--- a/src/data/mutators.test.ts
+++ b/src/data/mutators.test.ts
@@ -57,7 +57,6 @@ const setup = async (): Promise<Harness> => {
     // command_events). Kernel processors firing add follow-up txs
     // that aren't under test here; integration coverage lives in the
     // backlinks plugin processor tests.
-    registerKernelProcessors: false,
   })
   return {
     h,

--- a/src/data/queryRun.test.ts
+++ b/src/data/queryRun.test.ts
@@ -45,7 +45,6 @@ beforeEach(async () => {
     db: sharedDb.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
 })
 afterEach(() => { repo.stopSyncObserver() })

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -16,6 +16,7 @@
 
 import { v4 as uuidv4 } from 'uuid'
 import type { FacetRuntime, Facet } from '@/facets/facet'
+import { resolveFacetRuntimeSync } from '@/facets/facet'
 import type {
   AnyMutator,
   AnyPostCommitProcessor,
@@ -54,11 +55,7 @@ import {
 import { runTx, type PowerSyncDb } from './internals/commitPipeline'
 import type { BlockCache } from '@/data/blockCache'
 import { buildQualifiedBlockColumnsSql, parseBlockRow, type BlockRow } from '@/data/blockSchema'
-import { KERNEL_MUTATORS } from './mutators'
-import { KERNEL_PROCESSORS } from './internals/kernelProcessors'
-import { KERNEL_SAME_TX_PROCESSORS } from './internals/normalizeReferencesProcessor'
-import { KERNEL_QUERIES } from './internals/kernelQueries'
-import { kernelInvalidationRule } from './internals/kernelInvalidation'
+import { kernelDataExtension } from './kernelDataExtension'
 import {
   type WorkspaceBackfill,
   type WorkspaceBackfillContext,
@@ -225,34 +222,16 @@ export interface RepoOptions {
    *  never collide with anything from a prior run. Tests can inject a
    *  deterministic counter. */
   newTxSeq?: () => number
-  /** When true (default), kernel mutators are registered at
-   *  construction time so `repo.mutate.indent({...})` works
-   *  immediately. Set false when a test wants to populate the registry
-   *  explicitly (or when `setFacetRuntime` is the only registration
-   *  path). */
-  registerKernelMutators?: boolean
-  /** When true (default), kernel post-commit processors are registered
-   *  at construction time. The kernel set is currently empty; plugin
-   *  processors arrive through `setFacetRuntime`. Kept as a test/tooling
-   *  switch for any future core-only processors. */
-  registerKernelProcessors?: boolean
-  /** When true (default), kernel same-tx processors are registered at
-   *  construction time. Today that's `core.normalizeReferences`. Set
-   *  false in tests that need to exercise the engine without
-   *  reference normalization (e.g. asserting raw-shape round-trip). */
-  registerKernelSameTxProcessors?: boolean
-  /** When true (default), kernel queries are registered at construction
-   *  time so `repo.query.subtree({id})` etc. work immediately without a
-   *  `setFacetRuntime` call. Set false when a test wants to populate
-   *  the query registry explicitly. Mirrors `registerKernelMutators` /
-   *  `registerKernelProcessors`. */
-  registerKernelQueries?: boolean
-  /** When true (default), the kernel `kernelInvalidationRule` is
-   *  registered at construction time so `core.byType` / `core.typedBlocks`
-   *  / alias / content queries fire correctly without a `setFacetRuntime`
-   *  call. Tests that want to populate the invalidation-rules registry
-   *  explicitly can disable this. */
-  registerKernelInvalidationRules?: boolean
+  /** When false, skip the construction-time kernel-runtime install so
+   *  the Repo starts with empty registries. Default true: the
+   *  constructor installs a kernel-only `FacetRuntime`
+   *  (`kernelDataExtension`) so `repo.mutate.<kernel>` /
+   *  `repo.query.<kernel>` work immediately through the same facet path
+   *  a later `setFacetRuntime` uses — no separate per-facet registration
+   *  flags. Callers that want to control the registry explicitly either
+   *  pass `false` and call `setFacetRuntime` themselves, or just call
+   *  `setFacetRuntime` (it REPLACES the kernel install). */
+  installKernelRuntime?: boolean
   /** When true (default), the Layout B sync observer is started at
    *  construction time so sync-applied writes — staged into `blocks_synced`
    *  — materialize into the app-visible `blocks` table and invalidate
@@ -605,26 +584,10 @@ export class Repo {
       let seq = Date.now()
       this.newTxSeq = () => ++seq
     }
-    // Register kernel contributions by default. setFacetRuntime
-    // overrides with the merged kernel + plugin registry once a
-    // runtime is supplied; callers can pass `registerKernel*` flags as
-    // `false` to start empty for that facet (used by tests + tooling
-    // that want explicit registration semantics).
-    if (opts.registerKernelMutators ?? true) {
-      this.registerMutators(KERNEL_MUTATORS)
-    }
-    if (opts.registerKernelProcessors ?? true) {
-      for (const p of KERNEL_PROCESSORS) this.processors.set(p.name, p)
-    }
-    if (opts.registerKernelSameTxProcessors ?? true) {
-      for (const p of KERNEL_SAME_TX_PROCESSORS) this.sameTxProcessors.set(p.name, p)
-    }
-    if (opts.registerKernelQueries ?? true) {
-      for (const q of KERNEL_QUERIES) this.queries.set(q.name, q)
-    }
-    if (opts.registerKernelInvalidationRules ?? true) {
-      this.invalidationRules = [kernelInvalidationRule]
-    }
+    // Kernel contributions are installed via the facet runtime at the
+    // end of this constructor (see `installKernelRuntime` below) — one
+    // registration path shared with `setFacetRuntime`, no per-facet
+    // flags and no dual kernel registration (audit B1(1)).
     // Initialize the processor runner. The runner needs a Repo
     // reference for opening processor txs; passing `this` is safe
     // because runner methods only use it post-construction (during
@@ -679,6 +642,18 @@ export class Repo {
         return dispatchQ(prop)
       },
     }) as QueryProxy
+    // Install the kernel-only FacetRuntime so the kernel mutators,
+    // queries, same-tx processors, invalidation rule, property schemas,
+    // and type contributions are live before any `setFacetRuntime` swap
+    // (audit B1(1)). This is the SAME path a later swap takes — it
+    // REPLACES this install with the merged kernel + plugin registry —
+    // so there is exactly one kernel registration path. Reprojection
+    // scheduling is gated on an active workspace (none yet at
+    // construction), so this does no DB work. Tests/tooling that need
+    // empty registries pass `installKernelRuntime: false`.
+    if (opts.installKernelRuntime ?? true) {
+      this.setFacetRuntime(resolveFacetRuntimeSync([kernelDataExtension]))
+    }
     // Start the Layout B sync observer by default (design doc §9.2).
     // Tests that want deterministic timing pass startSyncObserver: false
     // and call repo.startSyncObserver() + flushSyncObserver() themselves
@@ -1883,16 +1858,10 @@ export class Repo {
     }
   }
 
-  /** Internal: register an array of mutators into the registry by name.
-   *  Used by the constructor's `registerKernel: true` path. */
-  private registerMutators(mutators: ReadonlyArray<AnyMutator>): void {
-    for (const m of mutators) this.mutators.set(m.name, m)
-  }
-
   /** Test-only escape hatch retained for stage 1.3 carryover tests
    *  that wired specific mutator sets without a FacetRuntime. New
-   *  tests should prefer `setFacetRuntime` or the
-   *  `registerKernel: false` constructor flag plus `setFacetRuntime`. */
+   *  tests should prefer `setFacetRuntime` (or `installKernelRuntime:
+   *  false` plus `setFacetRuntime`). */
   __setMutatorsForTesting(mutators: ReadonlyArray<AnyMutator>): void {
     this.mutators = new Map(mutators.map(m => [m.name, m]))
   }

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -1245,7 +1245,16 @@ export class Repo {
    *  `sourceId`. Triggers a re-run of every rebuild step whose declared
    *  inputs include this facet, plus per-facet listener fan-out for React
    *  subscribers (e.g. usePropertySchemas). Throws if no FacetRuntime has
-   *  been installed yet — callers must setFacetRuntime first. */
+   *  been installed yet — callers must setFacetRuntime first.
+   *
+   *  OWNERSHIP CONTRACT: the bucket is DURABLE — it survives `setFacetRuntime`
+   *  swaps via `FacetRuntime.adoptDurableContributionsFrom`, and the Repo is a
+   *  per-user singleton reused across workspace switches. A writer that owns a
+   *  workspace-scoped bucket (e.g. `UserSchemasService` / `UserTypesService`)
+   *  MUST clear it — `setRuntimeContributions(facet, sourceId, [])` — when it
+   *  tears down on a workspace switch, or the previous workspace's data is
+   *  adopted into the next workspace's runtime until the new bucket rebuilds.
+   *  (This is the leak fixed in `UserSchemasService.dispose`.) */
   setRuntimeContributions<Input>(
     facet: Facet<Input, unknown>,
     sourceId: string,

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -1430,11 +1430,14 @@ export class Repo {
       )
       this.reprojectionMetrics.rowsScanned += rows.length
       // Note: we do NOT bail when `this._propertySchemas !== propertySchemas`.
-      // `AppRuntimeProvider` calls `setFacetRuntime` twice during cold-start
-      // (kernel+static, then async with dynamic extensions), so a follow-up
-      // setFacetRuntime always lands while reprojection-1 is mid-SELECT —
-      // bailing here meant reprojection-1 never wrote markers and the same
-      // 1.4 s scan repeated on every reload. Dynamic extensions are additive
+      // On cold start `AppRuntimeProvider` calls `setFacetRuntime` twice
+      // (kernel+static, then async with dynamic extensions); a same-context
+      // reload calls it once (only the async swap — the sync base commit is
+      // gated to cold starts). On cold start that follow-up setFacetRuntime
+      // lands while reprojection-1 is mid-SELECT, so bailing here meant
+      // reprojection-1 never wrote markers and the same 1.4 s scan repeated
+      // on every reload; on a single-swap reload there's no racing follow-up
+      // to bail against anyway. Dynamic extensions are additive
       // (no codec redefinitions), so reprojection-1's snapshot is still
       // correct against the current state; per-block tx.get reads live
       // references and the JSON.stringify diff skips writes when nothing

--- a/src/data/targets.test.ts
+++ b/src/data/targets.test.ts
@@ -59,7 +59,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   return {h, repo}
 }

--- a/src/data/test/globalState.test.ts
+++ b/src/data/test/globalState.test.ts
@@ -77,7 +77,6 @@ const setup = async (types: readonly TypeContribution[] = []): Promise<Harness> 
     db: sharedDb.db,
     cache,
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   if (types.length > 0) {
@@ -195,7 +194,6 @@ describe('getUserPrefsBlock', () => {
       cache: new BlockCache(),
       user: USER,
       isReadOnly: true,
-      registerKernelProcessors: false,
     })
     repo.setActiveWorkspaceId(WS)
 

--- a/src/data/test/kernelPage.test.ts
+++ b/src/data/test/kernelPage.test.ts
@@ -31,7 +31,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   // Install a runtime that registers the synthetic marker type alongside

--- a/src/data/test/propertiesPage.test.ts
+++ b/src/data/test/propertiesPage.test.ts
@@ -23,7 +23,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/data/test/repoQueryDispatch.test.ts
+++ b/src/data/test/repoQueryDispatch.test.ts
@@ -48,11 +48,9 @@ beforeEach(() => {
     cache,
     user: {id: 'user-1'},
     // Empty registries — chunk A test surface is the dispatcher itself,
-    // not any registered query. Kernel mutators / processors stay off
-    // for the same reason.
-    registerKernelMutators: false,
-    registerKernelProcessors: false,
-    registerKernelQueries: false,
+    // not any registered query. Skip the kernel-runtime install so the
+    // registries start empty.
+    installKernelRuntime: false,
   })
 })
 

--- a/src/data/test/repoUndo.test.ts
+++ b/src/data/test/repoUndo.test.ts
@@ -49,7 +49,6 @@ const setup = async (): Promise<Harness> => {
     // Disable kernel processors so parseReferences doesn't fire and
     // add its own tx entries during these tests — keeps the audited
     // stack predictable.
-    registerKernelProcessors: false,
   })
   return {h, repo}
 }

--- a/src/data/test/resetTestDb.test.ts
+++ b/src/data/test/resetTestDb.test.ts
@@ -20,7 +20,6 @@ describe('resetTestDb', () => {
       db: h.db,
       cache: new BlockCache(),
       user: {id: 'u1'},
-      registerKernelProcessors: false,
       startSyncObserver: false,
     })
     repo.setActiveWorkspaceId(WS)

--- a/src/data/test/typesPage.test.ts
+++ b/src/data/test/typesPage.test.ts
@@ -22,7 +22,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -37,7 +37,6 @@ const setup = async (extraPresets: readonly AnyValuePreset[] = []): Promise<Harn
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
     startSyncObserver: false,
   })
   repo.setActiveWorkspaceId(WS)

--- a/src/data/userSchemasService.test.ts
+++ b/src/data/userSchemasService.test.ts
@@ -317,3 +317,28 @@ describe('Repo.setFacetRuntime — runtime contribution survival', () => {
     expect(env.repo.propertySchemas.get('siteUrl')).toBe(schema)
   })
 })
+
+describe('UserSchemasService workspace switch', () => {
+  // Regression: the Repo is a per-user singleton reused across workspace
+  // switches, and setFacetRuntime carries the durable user-data bucket
+  // forward (adoptDurableContributionsFrom). Before the fix, dispose() left
+  // the bucket in place, so the previous workspace's user-defined property
+  // schemas leaked into the next workspace until its subscription's first
+  // rebuild. Mirrors the hardening UserTypesService already had.
+  it('clears the user-data bucket on dispose so schemas do not leak into the next workspace', async () => {
+    env = await setup()
+    await env.service.addSchema({name: 'homepage', presetId: 'url'})
+    expect(env.repo.propertySchemas.get('homepage')?.codec.type).toBe('url')
+
+    // Workspace switch: dispose W1's service, switch the active workspace,
+    // bootstrap its properties page, restart. W1's schema must be gone.
+    env.service.dispose()
+    expect(env.repo.propertySchemas.get('homepage')).toBeUndefined()
+
+    const W2 = 'ws-user-schemas-2'
+    env.repo.setActiveWorkspaceId(W2)
+    await getOrCreatePropertiesPage(env.repo, W2)
+    env.service.start()
+    expect(env.repo.propertySchemas.get('homepage')).toBeUndefined()
+  })
+})

--- a/src/data/userSchemasService.ts
+++ b/src/data/userSchemasService.ts
@@ -151,6 +151,21 @@ export class UserSchemasService {
     this.subscriptionDisposer = null
     this.presetsListenerDisposer?.()
     this.presetsListenerDisposer = null
+    // Drop in-memory state AND clear the user-data bucket so the previous
+    // workspace's user-defined property schemas don't remain visible between
+    // dispose and the next subscription tick on a workspace switch. The Repo
+    // is a per-user singleton (reused across workspace switches) and
+    // `setFacetRuntime` carries the durable user-data bucket forward via
+    // `adoptDurableContributionsFrom`, so a stale bucket would leak into the
+    // next workspace until its subscription's first rebuild. Mirrors
+    // UserTypesService.dispose — that workspace-switch-race hardening was
+    // applied to types but never back-ported here, the service it was copied
+    // from.
+    this.latestBlocks = []
+    this.contributions = []
+    this.nameToBlockId = new Map()
+    this.blockIdToSchema = new Map()
+    this.repo.setRuntimeContributions(propertySchemasFacet, USER_DATA_SOURCE_ID, [])
   }
 
   /** Validates a schema block against the current presets and returns

--- a/src/data/userTypesService.test.ts
+++ b/src/data/userTypesService.test.ts
@@ -40,7 +40,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
     startSyncObserver: false,
   })
   repo.setActiveWorkspaceId(WS)

--- a/src/extensions/AppRuntimeProvider.tsx
+++ b/src/extensions/AppRuntimeProvider.tsx
@@ -135,7 +135,15 @@ export function AppRuntimeProvider({
   const effectReconciler = useMemo(() => new EffectReconciler(), [])
 
   useEffect(() => {
-    if (!workspaceId) return
+    if (!workspaceId) {
+      // Workspace cleared while still mounted: tear down running effects
+      // so their subscriptions / intervals / window hooks don't stay
+      // bound to the stale workspace. The previous single-effect
+      // lifecycle did this implicitly via its deps cleanup; the split
+      // reconcile/dispose effects otherwise only dispose on unmount.
+      effectReconciler.dispose()
+      return
+    }
     effectReconciler.reconcile(repo, runtime, workspaceId, safeMode)
   }, [effectReconciler, repo, runtime, safeMode, workspaceId])
 

--- a/src/extensions/AppRuntimeProvider.tsx
+++ b/src/extensions/AppRuntimeProvider.tsx
@@ -1,6 +1,5 @@
-import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { useRepo } from '@/context/repo.js'
-import type { Repo } from '@/data/repo'
 import { dynamicExtensionsExtension } from '@/extensions/dynamicExtensions.js'
 import {
   AppExtension,
@@ -63,6 +62,16 @@ export function AppRuntimeProvider({
 
   const [runtime, setRuntime] = useState(baseRuntime)
 
+  // App-effect lifecycle (audit B1(4)). The reconciler keeps unchanged
+  // effects running across a runtime swap (re-pointing them at the fresh
+  // runtime via a LiveRuntimeHandle) and starts/stops only the diff, so
+  // toggling one extension no longer restarts every plugin's effect /
+  // subscriptions. It restarts everything only when repo / workspaceId /
+  // safeMode change (values effects capture directly). It also owns the
+  // authoritative cold-vs-warm latch (`isColdFor`) the gated commit below
+  // consults — declared here so that effect can reference it.
+  const effectReconciler = useMemo(() => new EffectReconciler(), [])
+
   // Two-stage load is only worth its cost on a COLD start for a context —
   // initial mount and repo / workspace / safeMode switch. There we commit
   // the sync `baseRuntime` immediately so the kernel + static plugins (and
@@ -78,18 +87,16 @@ export function AppRuntimeProvider({
   // carries no dynamic extensions, so they'd read as "removed" then
   // "re-added"), and (b) momentarily downgrading the Repo to static-only
   // and dropping the live dynamic plugins' mutators during the compile gap.
-  const loadedCtx = useRef<{repo: Repo; workspaceId: string | null; safeMode: boolean} | null>(null)
+  //
+  // "Cold vs warm" is the reconciler's `isColdFor` — its capturedCtx is the
+  // single source of truth, so this commit and the reconcile below can't
+  // disagree about whether a change is a context switch or a reload.
   useEffect(() => {
-    const ctxChanged =
-      loadedCtx.current === null ||
-      loadedCtx.current.repo !== repo ||
-      loadedCtx.current.workspaceId !== workspaceId ||
-      loadedCtx.current.safeMode !== safeMode
-    if (!ctxChanged) return // same-context reload: keep current; async swaps once
-    loadedCtx.current = {repo, workspaceId, safeMode}
+    if (!effectReconciler.isColdFor(repo, workspaceId, safeMode)) return // warm reload: hold current; async swaps once
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync-state-from-prop: held runtime follows baseRuntime on cold start
     setRuntime(baseRuntime)
     repo.setFacetRuntime(baseRuntime)
-  }, [baseRuntime, repo, workspaceId, safeMode])
+  }, [baseRuntime, effectReconciler, repo, workspaceId, safeMode])
 
   useEffect(() => {
     let cancelled = false
@@ -142,14 +149,6 @@ export function AppRuntimeProvider({
       cancelled = true
     }
   }, [baseExtensions, errorStore, overrides, repo, runtimeContext, safeMode, workspaceId])
-
-  // App-effect lifecycle (audit B1(4)). The reconciler keeps unchanged
-  // effects running across a runtime swap (re-pointing them at the fresh
-  // runtime via a LiveRuntimeHandle) and starts/stops only the diff, so
-  // toggling one extension no longer restarts every plugin's effect /
-  // subscriptions. It restarts everything only when repo / workspaceId /
-  // safeMode change (values effects capture directly).
-  const effectReconciler = useMemo(() => new EffectReconciler(), [])
 
   useEffect(() => {
     if (!workspaceId) {

--- a/src/extensions/AppRuntimeProvider.tsx
+++ b/src/extensions/AppRuntimeProvider.tsx
@@ -12,7 +12,8 @@ import {
 } from '@/facets/resolveAppRuntime.js'
 import {useOverrides} from '@/extensions/useOverrides.js'
 import { AppRuntimeContextProvider } from '@/extensions/runtimeContext.js'
-import { appEffectsFacet, appMountsFacet, type AppEffectCleanup } from '@/extensions/core.js'
+import { appMountsFacet } from '@/extensions/core.js'
+import { EffectReconciler } from '@/extensions/liveRuntime.js'
 import { ActiveContextsProvider } from '@/shortcuts/ActiveContexts.js'
 import { HotkeyReconciler } from '@/shortcuts/HotkeyReconciler.js'
 import { staticAppExtensions } from '@/extensions/staticAppExtensions.js'
@@ -125,58 +126,23 @@ export function AppRuntimeProvider({
     }
   }, [baseExtensions, errorStore, overrides, repo, runtimeContext, safeMode, workspaceId])
 
+  // App-effect lifecycle (audit B1(4)). The reconciler keeps unchanged
+  // effects running across a runtime swap (re-pointing them at the fresh
+  // runtime via a LiveRuntimeHandle) and starts/stops only the diff, so
+  // toggling one extension no longer restarts every plugin's effect /
+  // subscriptions. It restarts everything only when repo / workspaceId /
+  // safeMode change (values effects capture directly).
+  const effectReconciler = useMemo(() => new EffectReconciler(), [])
+
   useEffect(() => {
     if (!workspaceId) return
+    effectReconciler.reconcile(repo, runtime, workspaceId, safeMode)
+  }, [effectReconciler, repo, runtime, safeMode, workspaceId])
 
-    let disposed = false
-    const cleanups: Array<{effectId: string; cleanup: AppEffectCleanup}> = []
-    const effects = runtime.read(appEffectsFacet)
-
-    const runCleanup = (cleanup: AppEffectCleanup, effectId: string) => {
-      try {
-        const result = cleanup()
-        if (result instanceof Promise) {
-          result.catch(error => {
-            console.error(`App effect cleanup failed for ${effectId}`, error)
-          })
-        }
-      } catch (error) {
-        console.error(`App effect cleanup failed for ${effectId}`, error)
-      }
-    }
-
-    for (const effect of effects) {
-      try {
-        const result = effect.start({
-          repo,
-          runtime,
-          workspaceId,
-          safeMode,
-        })
-
-        Promise.resolve(result).then(cleanup => {
-          if (typeof cleanup !== 'function') return
-          if (disposed) {
-            runCleanup(cleanup, effect.id)
-            return
-          }
-          cleanups.push({effectId: effect.id, cleanup})
-        }).catch(error => {
-          console.error(`App effect failed to start for ${effect.id}`, error)
-        })
-      } catch (error) {
-        console.error(`App effect failed to start for ${effect.id}`, error)
-      }
-    }
-
-    return () => {
-      disposed = true
-      for (const {effectId, cleanup} of cleanups.toReversed()) {
-        runCleanup(cleanup, effectId)
-      }
-      cleanups.length = 0
-    }
-  }, [repo, runtime, safeMode, workspaceId])
+  // Provider unmount: stop every running effect. Kept separate from the
+  // reconcile effect above so a deps change re-runs reconciliation
+  // (the diff) rather than tearing every effect down.
+  useEffect(() => () => effectReconciler.dispose(), [effectReconciler])
 
   // Reactive bridge between user-defined property-schema blocks and
   // propertySchemasFacet's user-data bucket (Phase 3b). The service

--- a/src/extensions/AppRuntimeProvider.tsx
+++ b/src/extensions/AppRuntimeProvider.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { useRepo } from '@/context/repo.js'
+import type { Repo } from '@/data/repo'
 import { dynamicExtensionsExtension } from '@/extensions/dynamicExtensions.js'
 import {
   AppExtension,
@@ -62,17 +63,33 @@ export function AppRuntimeProvider({
 
   const [runtime, setRuntime] = useState(baseRuntime)
 
-  // Sync state-from-prop pattern: when `baseRuntime` changes (rare —
-  // only on `repo` swap or generation reload) the held `runtime` must
-  // follow. The same effect also pushes that runtime into the Repo
-  // registries. The async effect below will replace it once dynamic
-  // plugins resolve, but the sync runtime keeps kernel + static plugin
-  // mutators / processors live during that gap.
+  // Two-stage load is only worth its cost on a COLD start for a context —
+  // initial mount and repo / workspace / safeMode switch. There we commit
+  // the sync `baseRuntime` immediately so the kernel + static plugins (and
+  // their mutators / processors) come up and the UI paints without waiting
+  // on the async dynamic-extension compile; the async effect below then
+  // swaps in the merged runtime.
+  //
+  // On a same-context RELOAD (extension toggle / `refreshAppRuntime` →
+  // generation bump, or an overrides change) we deliberately SKIP that
+  // intermediate. The current merged runtime is already live and valid for
+  // this context; holding it until the async resolve swaps it once avoids
+  // (a) churning every dynamic effect through a stop→start (baseRuntime
+  // carries no dynamic extensions, so they'd read as "removed" then
+  // "re-added"), and (b) momentarily downgrading the Repo to static-only
+  // and dropping the live dynamic plugins' mutators during the compile gap.
+  const loadedCtx = useRef<{repo: Repo; workspaceId: string | null; safeMode: boolean} | null>(null)
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    const ctxChanged =
+      loadedCtx.current === null ||
+      loadedCtx.current.repo !== repo ||
+      loadedCtx.current.workspaceId !== workspaceId ||
+      loadedCtx.current.safeMode !== safeMode
+    if (!ctxChanged) return // same-context reload: keep current; async swaps once
+    loadedCtx.current = {repo, workspaceId, safeMode}
     setRuntime(baseRuntime)
     repo.setFacetRuntime(baseRuntime)
-  }, [baseRuntime, repo])
+  }, [baseRuntime, repo, workspaceId, safeMode])
 
   useEffect(() => {
     let cancelled = false

--- a/src/extensions/core.ts
+++ b/src/extensions/core.ts
@@ -49,6 +49,32 @@ export type WorkspaceLandingResolver = (
 
 export type AppEffectCleanup = () => void | Promise<void>
 
+/**
+ * A long-lived side-effect (subscription, interval, window listener, the
+ * agent-runtime bridge) tied to the extension lifecycle. `start` runs once
+ * when the effect first appears and returns an optional cleanup.
+ *
+ * Lifecycle contract — the reconciler restarts (cleanup + re-`start`) an
+ * effect only when:
+ *   1. `repo` / `workspaceId` / `safeMode` change (values `start` captures
+ *      directly, not through the runtime), or
+ *   2. the effect's *contribution object identity* changes — i.e. a
+ *      different `AppEffect` reference is registered under the same `id`.
+ *
+ * Otherwise the effect keeps running across runtime swaps (extension
+ * toggles, dynamic-plugin loads); the `runtime` it received is a live
+ * handle that re-points itself at the fresh runtime, so `read` /
+ * `onFacetChange` / `setRuntimeContributions` stay valid without a restart.
+ *
+ * This means the AppEffect object MUST be a stable reference across
+ * resolves unless its code actually changed. Build it once at module scope
+ * (or memoize it); do NOT construct `{id, start}` inline inside a
+ * function-valued extension, and for dynamic extensions export an array,
+ * not a function — a fresh object every resolve reads as "identity
+ * changed" and silently restarts the effect on every unrelated swap.
+ * Duplicate `id`s are last-wins with a warn (per the facet convention).
+ * Cleanup must be idempotent and fast.
+ */
 export interface AppEffect {
   id: string
   start: (

--- a/src/extensions/liveRuntime.ts
+++ b/src/extensions/liveRuntime.ts
@@ -51,9 +51,11 @@ interface RememberedBucket {
 }
 
 /** A `FacetRuntime` facade effects capture so they survive runtime swaps.
- *  It owns no contribution state of its own (the empty `super` storage is
- *  never read — every public method is overridden to delegate to
- *  `current`); it just forwards to whichever runtime is installed and
+ *  It owns no contribution state of its own — the inherited `super`
+ *  storage is never read because every public method is overridden:
+ *  reads/writes/subscriptions delegate to `current`, and
+ *  `adoptDurableContributionsFrom` throws (the handle is never a swap
+ *  target). It just forwards to whichever runtime is installed and
  *  re-points the effect's subscriptions / transient buckets when that
  *  runtime swaps. */
 export class LiveRuntimeHandle extends FacetRuntime {
@@ -85,6 +87,18 @@ export class LiveRuntimeHandle extends FacetRuntime {
 
   override facetIds(): string[] {
     return this.current.facetIds()
+  }
+
+  /** Unsupported on the handle: it is a stable wrapper effects hold, never
+   *  a runtime a swap installs, so it is never the *target* of a durable
+   *  adoption. Overridden to fail loud rather than silently write into the
+   *  dead inherited `super` storage that the delegating reads never
+   *  consult (which would lose the durable data with no error). */
+  override adoptDurableContributionsFrom(): void {
+    throw new Error(
+      '[LiveRuntimeHandle] adoptDurableContributionsFrom is not supported — ' +
+      'the handle is a stable wrapper, never a swap target',
+    )
   }
 
   override onFacetChange(facetId: string, listener: () => void): () => void {
@@ -239,6 +253,9 @@ export class EffectReconciler {
       this.capturedCtx.workspaceId !== workspaceId ||
       this.capturedCtx.safeMode !== safeMode
 
+    const effects = runtime.read(appEffectsFacet)
+    const nextIds = new Set(effects.map(effect => effect.id))
+
     if (ctxChanged) {
       // Effects captured the previous repo/workspace/safeMode — restart
       // them all against a clean handle.
@@ -246,20 +263,20 @@ export class EffectReconciler {
       this.liveRuntime = new LiveRuntimeHandle(runtime)
       this.capturedCtx = { repo, workspaceId, safeMode }
     } else {
+      // Stop removed effects BEFORE re-pointing the handle: a removed
+      // transient owner's cleanup clears its bucket from the outgoing
+      // runtime + the handle, so `setCurrent` replays only the survivors
+      // onto the fresh runtime (no stale replay-then-clear window).
+      for (const [id, entry] of this.started) {
+        if (!nextIds.has(id)) {
+          stopEffect(entry)
+          this.started.delete(id)
+        }
+      }
       this.liveRuntime!.setCurrent(runtime)
     }
 
     const live = this.liveRuntime!
-    const effects = runtime.read(appEffectsFacet)
-    const nextIds = new Set(effects.map(effect => effect.id))
-
-    for (const [id, entry] of this.started) {
-      if (!nextIds.has(id)) {
-        stopEffect(entry)
-        this.started.delete(id)
-      }
-    }
-
     for (const effect of effects) {
       if (this.started.has(effect.id)) continue
       this.started.set(
@@ -277,7 +294,10 @@ export class EffectReconciler {
   }
 
   private stopAll(): void {
-    for (const entry of this.started.values()) stopEffect(entry)
+    // Tear down in reverse start order (LIFO), matching the previous
+    // provider's `cleanups.toReversed()` so any incidental ordering
+    // relationship between independent effects is preserved.
+    for (const entry of [...this.started.values()].reverse()) stopEffect(entry)
     this.started.clear()
   }
 }

--- a/src/extensions/liveRuntime.ts
+++ b/src/extensions/liveRuntime.ts
@@ -1,0 +1,283 @@
+/**
+ * Effect ↔ runtime-capture contract + effect lifecycle reconciliation
+ * (audit B1(4)).
+ *
+ * Problem: `AppRuntimeProvider` builds a fresh `FacetRuntime` on every
+ * swap (base → base+dynamic load, extension toggle). App effects capture
+ * the runtime they were started with — they `read` it, subscribe via
+ * `onFacetChange`, and write transient buckets via
+ * `setRuntimeContributions` (theme apply-actions, keybinding overrides),
+ * and the agent-runtime bridge captures it for command execution. So if
+ * we keep an unchanged effect running across a swap (the whole point of
+ * "restart only changed effects"), it strands on the dead runtime — the
+ * bug that reverted the #152 effect-diffing attempt.
+ *
+ * Fix: effects capture a stable `LiveRuntimeHandle` instead of a raw
+ * `FacetRuntime`. The handle is a `FacetRuntime` (so nothing downstream
+ * re-types) that delegates every read to a swappable `current`. On a
+ * swap, `setCurrent` migrates the kept effects' subscriptions and
+ * transient buckets onto the fresh runtime and re-fires subscribers so
+ * they re-sync — without restarting the effect. `EffectReconciler` then
+ * diffs `appEffectsFacet` by id and starts/stops only the delta.
+ */
+
+import {
+  FacetRuntime,
+  type Facet,
+  type FacetContribution,
+  type FacetResolveContext,
+  type RuntimeSourceId,
+} from '@/facets/facet.js'
+import {
+  appEffectsFacet,
+  type AppEffect,
+  type AppEffectCleanup,
+  type AppEffectContext,
+} from '@/extensions/core.js'
+import type { Repo } from '@/data/repo'
+
+interface ForwardedListener {
+  readonly facetId: string
+  readonly listener: () => void
+  /** Disposer for the subscription on the *current* runtime; replaced on
+   *  every `setCurrent`. */
+  unsub: () => void
+}
+
+interface RememberedBucket {
+  readonly facet: Facet<unknown, unknown>
+  readonly contributions: readonly unknown[]
+  readonly durable?: boolean
+}
+
+/** A `FacetRuntime` facade effects capture so they survive runtime swaps.
+ *  It owns no contribution state of its own (the empty `super` storage is
+ *  never read — every public method is overridden to delegate to
+ *  `current`); it just forwards to whichever runtime is installed and
+ *  re-points the effect's subscriptions / transient buckets when that
+ *  runtime swaps. */
+export class LiveRuntimeHandle extends FacetRuntime {
+  private current: FacetRuntime
+  private readonly forwarded = new Set<ForwardedListener>()
+  /** Transient (effect-owned) buckets written through this handle, keyed
+   *  facetId → sourceId. Replayed onto the fresh runtime on `setCurrent`
+   *  because the owning effect is NOT restarted across the swap, so it
+   *  won't re-push them itself. Cleared when the effect writes `[]`
+   *  (its cleanup) so a removed effect doesn't strand. */
+  private readonly buckets = new Map<string, Map<RuntimeSourceId, RememberedBucket>>()
+
+  constructor(initial: FacetRuntime) {
+    super(initial.context, [])
+    this.current = initial
+  }
+
+  override read<Input, Output>(facet: Facet<Input, Output>): Output {
+    return this.current.read(facet)
+  }
+
+  override contributions<Input>(facet: Facet<Input, unknown>): FacetContribution<Input>[] {
+    return this.current.contributions(facet)
+  }
+
+  override contributionsById(facetId: string): FacetContribution<unknown>[] {
+    return this.current.contributionsById(facetId)
+  }
+
+  override facetIds(): string[] {
+    return this.current.facetIds()
+  }
+
+  override onFacetChange(facetId: string, listener: () => void): () => void {
+    const reg: ForwardedListener = {
+      facetId,
+      listener,
+      unsub: this.current.onFacetChange(facetId, listener),
+    }
+    this.forwarded.add(reg)
+    return () => {
+      reg.unsub()
+      this.forwarded.delete(reg)
+    }
+  }
+
+  override setRuntimeContributions<Input>(
+    facet: Facet<Input, unknown>,
+    sourceId: RuntimeSourceId,
+    contributions: readonly Input[],
+    options?: { durable?: boolean },
+  ): void {
+    if (contributions.length === 0) {
+      const bySource = this.buckets.get(facet.id)
+      bySource?.delete(sourceId)
+      if (bySource && bySource.size === 0) this.buckets.delete(facet.id)
+    } else {
+      const bySource = this.buckets.get(facet.id) ?? new Map<RuntimeSourceId, RememberedBucket>()
+      bySource.set(sourceId, {
+        facet: facet as Facet<unknown, unknown>,
+        contributions: contributions as readonly unknown[],
+        durable: options?.durable,
+      })
+      this.buckets.set(facet.id, bySource)
+    }
+    this.current.setRuntimeContributions(facet, sourceId, contributions, options)
+  }
+
+  /** Point the handle at a freshly-installed runtime. Migrates the kept
+   *  effects' subscriptions and transient buckets, then re-fires the
+   *  subscribers so they re-read the new merged view (e.g. the theme
+   *  effect rebuilds its stylesheet + apply-actions for the new theme
+   *  set). No-op if `next` is already current. */
+  setCurrent(next: FacetRuntime): void {
+    if (next === this.current) return
+    this.current = next
+    // FacetRuntime.context is readonly at the type level, but the live
+    // handle must reflect the current runtime's context (e.g. generation
+    // bumps on toggle) for callers that read `runtime.context`.
+    ;(this as { context: FacetResolveContext }).context = next.context
+
+    // Replay transient buckets so a kept effect's contributions survive
+    // the swap (it won't re-push them — it isn't restarted).
+    for (const bySource of this.buckets.values()) {
+      for (const [sourceId, bucket] of bySource) {
+        next.setRuntimeContributions(bucket.facet, sourceId, bucket.contributions, { durable: bucket.durable })
+      }
+    }
+
+    // Re-subscribe forwarded listeners onto the new runtime.
+    for (const reg of this.forwarded) {
+      reg.unsub()
+      reg.unsub = next.onFacetChange(reg.facetId, reg.listener)
+    }
+
+    // Re-fire subscribers so they re-sync against `next` (the facet's
+    // contributions may have changed in the swap). Idempotent for the
+    // mirror-style effects that use onFacetChange (theme).
+    for (const reg of this.forwarded) {
+      try {
+        reg.listener()
+      } catch (error) {
+        console.error(`[LiveRuntimeHandle] forwarded listener for ${reg.facetId} threw`, error)
+      }
+    }
+  }
+}
+
+interface StartedEffect {
+  readonly id: string
+  stopped: boolean
+  cleanup?: AppEffectCleanup
+}
+
+const runCleanup = (cleanup: AppEffectCleanup, effectId: string): void => {
+  try {
+    const result = cleanup()
+    if (result instanceof Promise) {
+      result.catch(error => {
+        console.error(`App effect cleanup failed for ${effectId}`, error)
+      })
+    }
+  } catch (error) {
+    console.error(`App effect cleanup failed for ${effectId}`, error)
+  }
+}
+
+const startEffect = (effect: AppEffect, context: AppEffectContext): StartedEffect => {
+  const entry: StartedEffect = { id: effect.id, stopped: false }
+  try {
+    const result = effect.start(context)
+    // Capture a synchronous cleanup immediately so a same-tick stop
+    // (e.g. a removed effect, or unmount right after start) tears it
+    // down. Only the Promise-returning path is deferred.
+    if (typeof result === 'function') {
+      entry.cleanup = result
+    } else if (result instanceof Promise) {
+      result
+        .then(cleanup => {
+          if (typeof cleanup !== 'function') return
+          if (entry.stopped) {
+            runCleanup(cleanup, effect.id)
+            return
+          }
+          entry.cleanup = cleanup
+        })
+        .catch(error => {
+          console.error(`App effect failed to start for ${effect.id}`, error)
+        })
+    }
+  } catch (error) {
+    console.error(`App effect failed to start for ${effect.id}`, error)
+  }
+  return entry
+}
+
+const stopEffect = (entry: StartedEffect): void => {
+  entry.stopped = true
+  if (entry.cleanup) {
+    runCleanup(entry.cleanup, entry.id)
+    entry.cleanup = undefined
+  }
+}
+
+/** Drives the app-effect lifecycle across runtime swaps (B1(4)).
+ *
+ *  - When `repo` / `workspaceId` / `safeMode` change (values effects
+ *    capture directly, not through the runtime), every effect restarts —
+ *    keeping one alive would strand it on stale context.
+ *  - When only the runtime changes (the common toggle / dynamic-load
+ *    path), effects are diffed by id: newly-added ones start, removed
+ *    ones stop, and unchanged ones keep running on the `LiveRuntimeHandle`
+ *    (which `setCurrent` re-points at the fresh runtime). */
+export class EffectReconciler {
+  private liveRuntime: LiveRuntimeHandle | null = null
+  private readonly started = new Map<string, StartedEffect>()
+  private capturedCtx: { repo: Repo; workspaceId: string; safeMode: boolean } | null = null
+
+  reconcile(repo: Repo, runtime: FacetRuntime, workspaceId: string, safeMode: boolean): void {
+    const ctxChanged =
+      this.capturedCtx === null ||
+      this.capturedCtx.repo !== repo ||
+      this.capturedCtx.workspaceId !== workspaceId ||
+      this.capturedCtx.safeMode !== safeMode
+
+    if (ctxChanged) {
+      // Effects captured the previous repo/workspace/safeMode — restart
+      // them all against a clean handle.
+      this.stopAll()
+      this.liveRuntime = new LiveRuntimeHandle(runtime)
+      this.capturedCtx = { repo, workspaceId, safeMode }
+    } else {
+      this.liveRuntime!.setCurrent(runtime)
+    }
+
+    const live = this.liveRuntime!
+    const effects = runtime.read(appEffectsFacet)
+    const nextIds = new Set(effects.map(effect => effect.id))
+
+    for (const [id, entry] of this.started) {
+      if (!nextIds.has(id)) {
+        stopEffect(entry)
+        this.started.delete(id)
+      }
+    }
+
+    for (const effect of effects) {
+      if (this.started.has(effect.id)) continue
+      this.started.set(
+        effect.id,
+        startEffect(effect, { repo, runtime: live, workspaceId, safeMode }),
+      )
+    }
+  }
+
+  /** Stop every running effect (provider unmount). */
+  dispose(): void {
+    this.stopAll()
+    this.capturedCtx = null
+    this.liveRuntime = null
+  }
+
+  private stopAll(): void {
+    for (const entry of this.started.values()) stopEffect(entry)
+    this.started.clear()
+  }
+}

--- a/src/extensions/liveRuntime.ts
+++ b/src/extensions/liveRuntime.ts
@@ -178,6 +178,10 @@ export class LiveRuntimeHandle extends FacetRuntime {
 
 interface StartedEffect {
   readonly id: string
+  /** The contribution object this entry was started from. A later
+   *  reconcile compares by reference to detect a code change (same id,
+   *  new `start`) vs. the same effect re-resolved. */
+  readonly effect: AppEffect
   stopped: boolean
   cleanup?: AppEffectCleanup
 }
@@ -196,7 +200,7 @@ const runCleanup = (cleanup: AppEffectCleanup, effectId: string): void => {
 }
 
 const startEffect = (effect: AppEffect, context: AppEffectContext): StartedEffect => {
-  const entry: StartedEffect = { id: effect.id, stopped: false }
+  const entry: StartedEffect = { id: effect.id, effect, stopped: false }
   try {
     const result = effect.start(context)
     // Capture a synchronous cleanup immediately so a same-tick stop
@@ -254,7 +258,11 @@ export class EffectReconciler {
       this.capturedCtx.safeMode !== safeMode
 
     const effects = runtime.read(appEffectsFacet)
-    const nextIds = new Set(effects.map(effect => effect.id))
+    // First contribution wins per id (matches the start loop below).
+    const nextById = new Map<string, AppEffect>()
+    for (const effect of effects) {
+      if (!nextById.has(effect.id)) nextById.set(effect.id, effect)
+    }
 
     if (ctxChanged) {
       // Effects captured the previous repo/workspace/safeMode — restart
@@ -263,12 +271,18 @@ export class EffectReconciler {
       this.liveRuntime = new LiveRuntimeHandle(runtime)
       this.capturedCtx = { repo, workspaceId, safeMode }
     } else {
-      // Stop removed effects BEFORE re-pointing the handle: a removed
-      // transient owner's cleanup clears its bucket from the outgoing
-      // runtime + the handle, so `setCurrent` replays only the survivors
-      // onto the fresh runtime (no stale replay-then-clear window).
+      // Stop removed AND code-changed effects BEFORE re-pointing the
+      // handle. Removed = id no longer present; code-changed = same id
+      // but a different contribution object (e.g. a live-edited dynamic
+      // extension recompiled to a fresh module — the compile cache hands
+      // back a new reference only when the source changed, a stable one
+      // otherwise, so an unchanged effect keeps running). Stopping first
+      // lets the start loop launch the new implementation, and the
+      // cleanup clears any transient bucket before `setCurrent` replays
+      // the survivors onto the fresh runtime (no stale replay-then-clear).
       for (const [id, entry] of this.started) {
-        if (!nextIds.has(id)) {
+        const next = nextById.get(id)
+        if (next === undefined || next !== entry.effect) {
           stopEffect(entry)
           this.started.delete(id)
         }

--- a/src/extensions/liveRuntime.ts
+++ b/src/extensions/liveRuntime.ts
@@ -25,7 +25,6 @@ import {
   FacetRuntime,
   type Facet,
   type FacetContribution,
-  type FacetResolveContext,
   type RuntimeSourceId,
 } from '@/facets/facet.js'
 import {
@@ -71,6 +70,17 @@ export class LiveRuntimeHandle extends FacetRuntime {
   constructor(initial: FacetRuntime) {
     super(initial.context, [])
     this.current = initial
+    // Callers that consult `runtime.context` (e.g. generation bumps read
+    // off the context on toggle) must see the *current* runtime's context,
+    // not a snapshot frozen at construction. Replace the data property the
+    // super constructor set with an accessor that delegates to `current`,
+    // so the value stays live across swaps without `setCurrent` having to
+    // cast away `readonly` and repoint it.
+    Object.defineProperty(this, 'context', {
+      get: () => this.current.context,
+      enumerable: true,
+      configurable: true,
+    })
   }
 
   override read<Input, Output>(facet: Facet<Input, Output>): Output {
@@ -144,10 +154,8 @@ export class LiveRuntimeHandle extends FacetRuntime {
   setCurrent(next: FacetRuntime): void {
     if (next === this.current) return
     this.current = next
-    // FacetRuntime.context is readonly at the type level, but the live
-    // handle must reflect the current runtime's context (e.g. generation
-    // bumps on toggle) for callers that read `runtime.context`.
-    ;(this as { context: FacetResolveContext }).context = next.context
+    // `context` delegates to `current` via the constructor accessor, so it
+    // already reflects `next` — nothing to repoint here.
 
     // Replay transient buckets so a kept effect's contributions survive
     // the swap (it won't re-push them — it isn't restarted).
@@ -258,10 +266,20 @@ export class EffectReconciler {
       this.capturedCtx.safeMode !== safeMode
 
     const effects = runtime.read(appEffectsFacet)
-    // First contribution wins per id (matches the start loop below).
+    // Dedup by id, last-wins with a warn — matching the repo-wide facet
+    // convention (mutatorsFacet / typesFacet / … all warn + last-wins).
+    // The override idiom plugin authors are taught is "register after the
+    // kernel to replace it"; a silent first-wins here would drop their
+    // override with no signal. Duplicate effect ids are a misconfiguration
+    // either way, so we keep the last contribution and warn.
     const nextById = new Map<string, AppEffect>()
     for (const effect of effects) {
-      if (!nextById.has(effect.id)) nextById.set(effect.id, effect)
+      if (nextById.has(effect.id)) {
+        console.warn(
+          `[appEffectsFacet] duplicate effect id "${effect.id}"; last-wins per facet convention`,
+        )
+      }
+      nextById.set(effect.id, effect)
     }
 
     if (ctxChanged) {
@@ -291,7 +309,9 @@ export class EffectReconciler {
     }
 
     const live = this.liveRuntime!
-    for (const effect of effects) {
+    // Iterate the deduped winners (last-wins), not the raw array — starting
+    // the array's first occurrence would contradict the dedup above.
+    for (const effect of nextById.values()) {
       if (this.started.has(effect.id)) continue
       this.started.set(
         effect.id,

--- a/src/extensions/liveRuntime.ts
+++ b/src/extensions/liveRuntime.ts
@@ -258,12 +258,25 @@ export class EffectReconciler {
   private readonly started = new Map<string, StartedEffect>()
   private capturedCtx: { repo: Repo; workspaceId: string; safeMode: boolean } | null = null
 
-  reconcile(repo: Repo, runtime: FacetRuntime, workspaceId: string, safeMode: boolean): void {
-    const ctxChanged =
+  /** Whether `{repo, workspaceId, safeMode}` differs from the context the
+   *  reconciler last captured — i.e. the next `reconcile` would be a full
+   *  restart (cold) rather than a runtime-only diff (warm). This is the
+   *  single source of truth for "cold vs warm": `AppRuntimeProvider`
+   *  queries it to decide whether to commit the sync base runtime (cold
+   *  start) or hold the current one for a same-context reload, instead of
+   *  tracking the same latch separately. A never-reconciled or
+   *  just-disposed reconciler is cold. */
+  isColdFor(repo: Repo, workspaceId: string | null, safeMode: boolean): boolean {
+    return (
       this.capturedCtx === null ||
       this.capturedCtx.repo !== repo ||
       this.capturedCtx.workspaceId !== workspaceId ||
       this.capturedCtx.safeMode !== safeMode
+    )
+  }
+
+  reconcile(repo: Repo, runtime: FacetRuntime, workspaceId: string, safeMode: boolean): void {
+    const ctxChanged = this.isColdFor(repo, workspaceId, safeMode)
 
     const effects = runtime.read(appEffectsFacet)
     // Dedup by id, last-wins with a warn — matching the repo-wide facet

--- a/src/extensions/test/blockSelectionAction.test.ts
+++ b/src/extensions/test/blockSelectionAction.test.ts
@@ -20,7 +20,7 @@ afterAll(async () => { await sharedDb.cleanup() })
 
 beforeEach(async () => {
   await resetTestDb(sharedDb.db)
-  repo = new Repo({db: sharedDb.db, cache: new BlockCache(), user: USER, registerKernelProcessors: false})
+  repo = new Repo({db: sharedDb.db, cache: new BlockCache(), user: USER})
   repo.setActiveWorkspaceId(WS)
   await repo.tx(async tx => {
     await tx.create({id: 'panel', workspaceId: WS, parentId: null, orderKey: 'a0'})

--- a/src/extensions/test/liveRuntime.test.ts
+++ b/src/extensions/test/liveRuntime.test.ts
@@ -225,6 +225,21 @@ describe('EffectReconciler', () => {
     expect(start).toHaveBeenCalledTimes(2) // started fresh, not resumed
   })
 
+  // The cold-vs-warm latch AppRuntimeProvider consults to decide whether to
+  // commit the sync base runtime (cold) or hold the current one for a
+  // same-context reload (warm). Pinning the transition keeps the provider's
+  // gating and the reconciler's restart-vs-diff decision from drifting apart.
+  it('isColdFor: cold until a context is reconciled, warm on a same-context reload', () => {
+    const r = new EffectReconciler()
+    expect(r.isColdFor(repo, 'ws', false)).toBe(true) // never reconciled
+    r.reconcile(repo, runtimeWith([]), 'ws', false)
+    expect(r.isColdFor(repo, 'ws', false)).toBe(false) // same context → warm
+    expect(r.isColdFor(repo, 'ws', true)).toBe(true) // safeMode differs → cold
+    expect(r.isColdFor(repo, 'ws-2', false)).toBe(true) // workspace differs → cold
+    r.dispose()
+    expect(r.isColdFor(repo, 'ws', false)).toBe(true) // disposed → cold again
+  })
+
   it('duplicate effect id: the last contribution wins and warns', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const firstStart = vi.fn(() => () => {})

--- a/src/extensions/test/liveRuntime.test.ts
+++ b/src/extensions/test/liveRuntime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { defineFacet, resolveFacetRuntimeSync } from '@/facets/facet.js'
+import { defineFacet, FacetRuntime, resolveFacetRuntimeSync } from '@/facets/facet.js'
 import { appEffectsFacet, type AppEffect } from '@/extensions/core.js'
 import { EffectReconciler, LiveRuntimeHandle } from '@/extensions/liveRuntime.js'
 import type { Repo } from '@/data/repo'
@@ -76,6 +76,50 @@ describe('LiveRuntimeHandle', () => {
     const second = resolveFacetRuntimeSync([labels.of('b')])
     handle.setCurrent(second)
     expect(second.read(out)).toBe('b')
+  })
+
+  it('exposes the current runtime context, live across swaps', () => {
+    const first = resolveFacetRuntimeSync([])
+    const handle = new LiveRuntimeHandle(first)
+    expect(handle.context).toBe(first.context)
+
+    const second = resolveFacetRuntimeSync([])
+    handle.setCurrent(second)
+    expect(handle.context).toBe(second.context) // delegates, not frozen at construction
+  })
+
+  it('setCurrent is a no-op when passed the runtime already current', () => {
+    const rt = resolveFacetRuntimeSync([labels.of('a')])
+    const handle = new LiveRuntimeHandle(rt)
+    const fired = vi.fn()
+    handle.onFacetChange(labels.id, fired)
+
+    handle.setCurrent(rt) // same runtime already installed
+    expect(fired).not.toHaveBeenCalled() // no re-fire / re-subscribe churn
+  })
+
+  it('adoptDurableContributionsFrom throws — the handle is never a swap target', () => {
+    const handle = new LiveRuntimeHandle(resolveFacetRuntimeSync([]))
+    expect(() => handle.adoptDurableContributionsFrom()).toThrow(/not supported/)
+  })
+
+  // Guards the subclass seam: LiveRuntimeHandle owns no contribution state,
+  // so any *public* FacetRuntime method it forgets to override would
+  // silently serve dead inherited storage. FacetRuntime's `private` helpers
+  // (TS-private = runtime-visible) are only called by its own public
+  // methods; since the handle overrides every public method to delegate to
+  // `current`, those base methods — and thus these helpers — never run on
+  // the handle. They're listed as known-unreachable; anything else new must
+  // be overridden.
+  it('overrides every public FacetRuntime method', () => {
+    const internalHelpers = new Set([
+      'collectContributions', 'markDurable', 'unmarkDurable', 'notifyFacetListeners',
+    ])
+    const publicMethods = Object.getOwnPropertyNames(FacetRuntime.prototype)
+      .filter(name => name !== 'constructor' && !internalHelpers.has(name))
+    const handleOwn = new Set(Object.getOwnPropertyNames(LiveRuntimeHandle.prototype))
+    const notOverridden = publicMethods.filter(name => !handleOwn.has(name))
+    expect(notOverridden).toEqual([])
   })
 })
 
@@ -161,6 +205,70 @@ describe('EffectReconciler', () => {
     r.reconcile(repo, runtimeWith([{ id: 'e', start: () => cleanup }]), 'ws', false)
     r.dispose()
     expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  // Provider drives this on workspace → null → workspace: the cleared
+  // workspace disposes, then a restored one reconciles again. The second
+  // reconcile must restart against a fresh handle, not resume the disposed
+  // run (capturedCtx was nulled).
+  it('reconcile → dispose → reconcile restarts effects against a fresh handle', () => {
+    const cleanup = vi.fn()
+    const start = vi.fn(() => cleanup)
+    const effect: AppEffect = { id: 'e', start }
+    const r = new EffectReconciler()
+
+    r.reconcile(repo, runtimeWith([effect]), 'ws', false)
+    r.dispose() // workspace cleared
+    expect(cleanup).toHaveBeenCalledTimes(1)
+
+    r.reconcile(repo, runtimeWith([effect]), 'ws', false) // workspace restored
+    expect(start).toHaveBeenCalledTimes(2) // started fresh, not resumed
+  })
+
+  it('duplicate effect id: the last contribution wins and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const firstStart = vi.fn(() => () => {})
+    const lastStart = vi.fn()
+    const r = new EffectReconciler()
+
+    r.reconcile(repo, runtimeWith([
+      { id: 'dup', start: firstStart },
+      { id: 'dup', start: lastStart },
+    ]), 'ws', false)
+
+    expect(lastStart).toHaveBeenCalledTimes(1) // last-wins, per facet convention
+    expect(firstStart).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate effect id "dup"'))
+    warn.mockRestore()
+  })
+
+  it('runs a late async cleanup immediately when the effect was stopped before start resolved', async () => {
+    const cleanup = vi.fn()
+    let resolveStart!: (c: () => void) => void
+    const start = vi.fn(() => new Promise<() => void>(res => { resolveStart = res }))
+    const r = new EffectReconciler()
+
+    r.reconcile(repo, runtimeWith([{ id: 'async', start }]), 'ws', false)
+    r.reconcile(repo, runtimeWith([]), 'ws', false) // removed before start resolved → stopped
+
+    resolveStart(cleanup)
+    await new Promise(res => setTimeout(res, 0)) // flush the start promise's .then
+
+    expect(cleanup).toHaveBeenCalledTimes(1) // not stranded — torn down on resolve
+  })
+
+  it('a throwing cleanup does not prevent the rest of stopAll', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const order: string[] = []
+    const r = new EffectReconciler()
+    r.reconcile(repo, runtimeWith([
+      { id: 'a', start: () => () => { order.push('a') } },
+      { id: 'b', start: () => () => { order.push('b'); throw new Error('boom') } },
+    ]), 'ws', false)
+
+    expect(() => r.dispose()).not.toThrow()
+    expect(order).toEqual(['b', 'a']) // LIFO; b throwing didn't abort a's teardown
+    error.mockRestore()
   })
 
   // The reverted #152 regression: a kept effect that captured its

--- a/src/extensions/test/liveRuntime.test.ts
+++ b/src/extensions/test/liveRuntime.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineFacet, resolveFacetRuntimeSync } from '@/facets/facet.js'
+import { appEffectsFacet, type AppEffect } from '@/extensions/core.js'
+import { EffectReconciler, LiveRuntimeHandle } from '@/extensions/liveRuntime.js'
+import type { Repo } from '@/data/repo'
+
+const repo = {} as unknown as Repo
+
+const labels = defineFacet<string, string>({
+  id: 'test.live-labels',
+  combine: values => values.join(','),
+  empty: () => '',
+})
+const out = defineFacet<string, string>({
+  id: 'test.live-out',
+  combine: values => values.join(','),
+  empty: () => '',
+})
+
+describe('LiveRuntimeHandle', () => {
+  it('delegates reads to the current runtime', () => {
+    const rt = resolveFacetRuntimeSync([labels.of('a')])
+    const handle = new LiveRuntimeHandle(rt)
+    expect(handle.read(labels)).toBe('a')
+  })
+
+  it('re-points a forwarded onFacetChange subscription onto the new runtime', () => {
+    const first = resolveFacetRuntimeSync([])
+    const handle = new LiveRuntimeHandle(first)
+    const fired = vi.fn()
+    handle.onFacetChange(labels.id, fired)
+
+    const second = resolveFacetRuntimeSync([])
+    handle.setCurrent(second)
+    fired.mockClear() // ignore the re-sync fire from setCurrent itself
+
+    // A change on the OLD runtime must NOT reach the listener anymore.
+    first.setRuntimeContributions(labels, 'svc', ['stale'])
+    expect(fired).not.toHaveBeenCalled()
+    // A change on the NEW runtime must.
+    second.setRuntimeContributions(labels, 'svc', ['live'])
+    expect(fired).toHaveBeenCalledTimes(1)
+  })
+
+  it('replays transient buckets written through it onto the new runtime', () => {
+    const first = resolveFacetRuntimeSync([])
+    const handle = new LiveRuntimeHandle(first)
+    handle.setRuntimeContributions(out, 'effect', ['kept'])
+
+    const second = resolveFacetRuntimeSync([])
+    handle.setCurrent(second)
+    expect(second.read(out)).toBe('kept')
+  })
+
+  it('does not replay a bucket that was cleared before the swap', () => {
+    const first = resolveFacetRuntimeSync([])
+    const handle = new LiveRuntimeHandle(first)
+    handle.setRuntimeContributions(out, 'effect', ['gone'])
+    handle.setRuntimeContributions(out, 'effect', [])
+
+    const second = resolveFacetRuntimeSync([])
+    handle.setCurrent(second)
+    expect(second.read(out)).toBe('')
+  })
+
+  it('re-fires forwarded listeners on swap so subscribers re-sync', () => {
+    const first = resolveFacetRuntimeSync([labels.of('a')])
+    const handle = new LiveRuntimeHandle(first)
+    const apply = vi.fn(() => {
+      handle.setRuntimeContributions(out, 'mirror', [handle.read(labels)])
+    })
+    apply()
+    handle.onFacetChange(labels.id, apply)
+    expect(first.read(out)).toBe('a')
+
+    const second = resolveFacetRuntimeSync([labels.of('b')])
+    handle.setCurrent(second)
+    expect(second.read(out)).toBe('b')
+  })
+})
+
+/** Build a runtime carrying the given effects + an optional `labels`
+ *  static value, so the reconciler can `read(appEffectsFacet)`. */
+const runtimeWith = (effects: readonly AppEffect[], label?: string) =>
+  resolveFacetRuntimeSync([
+    ...(label === undefined ? [] : [labels.of(label)]),
+    ...effects.map(effect => appEffectsFacet.of(effect)),
+  ])
+
+describe('EffectReconciler', () => {
+  it('starts every effect on first reconcile', () => {
+    const start = vi.fn()
+    const r = new EffectReconciler()
+    r.reconcile(repo, runtimeWith([{ id: 'a', start }, { id: 'b', start }]), 'ws', false)
+    expect(start).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps unchanged effects running across a runtime-only swap', () => {
+    const start = vi.fn()
+    const cleanup = vi.fn()
+    start.mockReturnValue(cleanup)
+    const effect: AppEffect = { id: 'kept', start }
+    const r = new EffectReconciler()
+
+    r.reconcile(repo, runtimeWith([effect]), 'ws', false)
+    r.reconcile(repo, runtimeWith([effect]), 'ws', false) // new runtime, same ctx
+
+    expect(start).toHaveBeenCalledTimes(1) // NOT restarted
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+
+  it('starts added and stops removed effects on a runtime-only swap', () => {
+    const keptStart = vi.fn()
+    const removedCleanup = vi.fn()
+    const removedStart = vi.fn(() => removedCleanup)
+    const addedStart = vi.fn()
+    const kept: AppEffect = { id: 'kept', start: keptStart }
+
+    const r = new EffectReconciler()
+    r.reconcile(repo, runtimeWith([kept, { id: 'removed', start: removedStart }]), 'ws', false)
+    r.reconcile(repo, runtimeWith([kept, { id: 'added', start: addedStart }]), 'ws', false)
+
+    expect(keptStart).toHaveBeenCalledTimes(1) // survived
+    expect(removedCleanup).toHaveBeenCalledTimes(1) // torn down
+    expect(addedStart).toHaveBeenCalledTimes(1) // newly started
+  })
+
+  it('restarts all effects when the captured context changes', () => {
+    const start = vi.fn()
+    const cleanup = vi.fn()
+    start.mockReturnValue(cleanup)
+    const effect: AppEffect = { id: 'e', start }
+    const r = new EffectReconciler()
+
+    r.reconcile(repo, runtimeWith([effect]), 'ws-1', false)
+    r.reconcile(repo, runtimeWith([effect]), 'ws-2', false) // workspace switch
+
+    expect(start).toHaveBeenCalledTimes(2)
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispose stops every running effect', () => {
+    const cleanup = vi.fn()
+    const r = new EffectReconciler()
+    r.reconcile(repo, runtimeWith([{ id: 'e', start: () => cleanup }]), 'ws', false)
+    r.dispose()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  // The reverted #152 regression: a kept effect that captured its
+  // start-time runtime (reads a facet, subscribes, writes a derived
+  // bucket) must keep targeting the LIVE runtime after a swap — not
+  // strand its output on the dead one.
+  it('a kept mirror-style effect re-syncs to the new runtime instead of stranding', () => {
+    const start = vi.fn<AppEffect['start']>(({ runtime }) => {
+      const apply = () => runtime.setRuntimeContributions(out, 'mirror', [runtime.read(labels)])
+      apply()
+      return runtime.onFacetChange(labels.id, apply)
+    })
+    const mirror: AppEffect = { id: 'mirror', start }
+
+    const r = new EffectReconciler()
+    const first = runtimeWith([mirror], 'a')
+    r.reconcile(repo, first, 'ws', false)
+    expect(first.read(out)).toBe('a')
+
+    const second = runtimeWith([mirror], 'b')
+    r.reconcile(repo, second, 'ws', false)
+
+    expect(second.read(out)).toBe('b') // re-synced to the live runtime
+    expect(start).toHaveBeenCalledTimes(1) // and it was NOT restarted
+  })
+})

--- a/src/extensions/test/liveRuntime.test.ts
+++ b/src/extensions/test/liveRuntime.test.ts
@@ -109,6 +109,22 @@ describe('EffectReconciler', () => {
     expect(cleanup).not.toHaveBeenCalled()
   })
 
+  it('restarts an effect whose contribution object changed (same id, new start)', () => {
+    const oldCleanup = vi.fn()
+    const oldStart = vi.fn(() => oldCleanup)
+    const newStart = vi.fn()
+    const r = new EffectReconciler()
+
+    r.reconcile(repo, runtimeWith([{ id: 'e', start: oldStart }]), 'ws', false)
+    // Same id, different contribution object (e.g. a live-edited plugin
+    // recompiled to a new module): tear the old impl down and start the new.
+    r.reconcile(repo, runtimeWith([{ id: 'e', start: newStart }]), 'ws', false)
+
+    expect(oldStart).toHaveBeenCalledTimes(1)
+    expect(oldCleanup).toHaveBeenCalledTimes(1) // old impl torn down
+    expect(newStart).toHaveBeenCalledTimes(1) // new impl started
+  })
+
   it('starts added and stops removed effects on a runtime-only swap', () => {
     const keptStart = vi.fn()
     const removedCleanup = vi.fn()

--- a/src/facets/facet.ts
+++ b/src/facets/facet.ts
@@ -131,6 +131,12 @@ export type RuntimeSourceId = string
 
 type FacetChangeListener = () => void
 
+/** NOTE: `LiveRuntimeHandle` (src/extensions/liveRuntime.ts) subclasses
+ *  this and overrides EVERY public method to delegate to a swappable
+ *  `current` runtime — its inherited storage is intentionally dead. A new
+ *  public method added here that the handle doesn't override would
+ *  silently serve that empty inherited state for effect callers (no type
+ *  error). Add the override there too. */
 export class FacetRuntime {
   // Both maps are keyed by `facet.id` (a string), NOT by the Facet
   // object — so `.get(actionsFacet)` from outside this class will

--- a/src/facets/facet.ts
+++ b/src/facets/facet.ts
@@ -263,7 +263,12 @@ export class FacetRuntime {
    *  only durable buckets are carried forward, so transient effect-owned
    *  buckets can't strand. Caches for the touched facets are
    *  invalidated; no listeners fire (a fresh runtime has none yet — the
-   *  bridge runs its rebuild steps after this call). */
+   *  bridge runs its rebuild steps after this call).
+   *
+   *  Carry-forward is unconditional, so a writer that owns a workspace-scoped
+   *  durable bucket must clear it on teardown (see the ownership contract on
+   *  `Repo.setRuntimeContributions`) — otherwise its data is adopted into the
+   *  next workspace's runtime on the per-user Repo singleton. */
   adoptDurableContributionsFrom(previous: FacetRuntime): void {
     for (const [facetId, durableSources] of previous.durableRuntimeSources) {
       const prevBuckets = previous.runtimeContributionsByFacet.get(facetId)

--- a/src/facets/facet.ts
+++ b/src/facets/facet.ts
@@ -144,6 +144,17 @@ export class FacetRuntime {
     string,
     Map<RuntimeSourceId, FacetContribution<unknown>[]>
   >()
+  /** Per-facet set of runtime source ids marked **durable** — i.e.
+   *  written with `{durable: true}`. Durable buckets are repo-owned
+   *  user data (user property schemas / types) that must survive a
+   *  `setFacetRuntime` swap; `adoptDurableContributionsFrom` copies only
+   *  these forward onto the fresh runtime. Transient buckets (effect-
+   *  owned outputs such as the theme apply-actions or keybinding
+   *  overrides) are NOT tracked here — their owning effect re-pushes
+   *  them on restart, so replaying them would strand stale entries when
+   *  the effect's plugin is toggled off (the bug that reverted the
+   *  literal `withContributionsFrom` in #152). */
+  private readonly durableRuntimeSources = new Map<string, Set<RuntimeSourceId>>()
   private readonly cache = new Map<string, unknown>()
   private readonly facetListeners = new Map<string, Set<FacetChangeListener>>()
 
@@ -190,11 +201,17 @@ export class FacetRuntime {
 
   /** Replace the runtime contributions bucket for this facet under
    *  `sourceId`. Empty `contributions` removes the bucket. Notifies
-   *  per-facet subscribers after the cache is invalidated. */
+   *  per-facet subscribers after the cache is invalidated.
+   *
+   *  `options.durable` (default false) marks the bucket as repo-owned
+   *  user data that must survive `setFacetRuntime` swaps — see
+   *  `adoptDurableContributionsFrom` / `durableRuntimeSources`. Effect-
+   *  owned (transient) writers omit it. */
   setRuntimeContributions<Input>(
     facet: Facet<Input, unknown>,
     sourceId: RuntimeSourceId,
     contributions: readonly Input[],
+    options?: { durable?: boolean },
   ): void {
     const wrapped = contributions.map(value => ({
       type: 'facet-contribution' as const,
@@ -208,12 +225,54 @@ export class FacetRuntime {
       existing.delete(sourceId)
       if (existing.size === 0) this.runtimeContributionsByFacet.delete(facet.id)
       else this.runtimeContributionsByFacet.set(facet.id, existing)
+      this.unmarkDurable(facet.id, sourceId)
     } else {
       existing.set(sourceId, wrapped)
       this.runtimeContributionsByFacet.set(facet.id, existing)
+      if (options?.durable) this.markDurable(facet.id, sourceId)
+      else this.unmarkDurable(facet.id, sourceId)
     }
     this.cache.delete(facet.id)
     this.notifyFacetListeners(facet.id)
+  }
+
+  private markDurable(facetId: string, sourceId: RuntimeSourceId): void {
+    const set = this.durableRuntimeSources.get(facetId) ?? new Set<RuntimeSourceId>()
+    set.add(sourceId)
+    this.durableRuntimeSources.set(facetId, set)
+  }
+
+  private unmarkDurable(facetId: string, sourceId: RuntimeSourceId): void {
+    const set = this.durableRuntimeSources.get(facetId)
+    if (!set) return
+    set.delete(sourceId)
+    if (set.size === 0) this.durableRuntimeSources.delete(facetId)
+  }
+
+  /** Copy the **durable** runtime-contribution buckets from `previous`
+   *  onto this (fresh) runtime, preserving their durability marks, so
+   *  repo-owned user data (user property schemas / types) survives a
+   *  `setFacetRuntime` swap without a separate Repo-side mirror. This is
+   *  the sound realization of B1(2) "make replay the runtime's job":
+   *  only durable buckets are carried forward, so transient effect-owned
+   *  buckets can't strand. Caches for the touched facets are
+   *  invalidated; no listeners fire (a fresh runtime has none yet — the
+   *  bridge runs its rebuild steps after this call). */
+  adoptDurableContributionsFrom(previous: FacetRuntime): void {
+    for (const [facetId, durableSources] of previous.durableRuntimeSources) {
+      const prevBuckets = previous.runtimeContributionsByFacet.get(facetId)
+      if (!prevBuckets) continue
+      for (const sourceId of durableSources) {
+        const bucket = prevBuckets.get(sourceId)
+        if (!bucket || bucket.length === 0) continue
+        const buckets = this.runtimeContributionsByFacet.get(facetId)
+          ?? new Map<RuntimeSourceId, FacetContribution<unknown>[]>()
+        buckets.set(sourceId, bucket)
+        this.runtimeContributionsByFacet.set(facetId, buckets)
+        this.markDurable(facetId, sourceId)
+        this.cache.delete(facetId)
+      }
+    }
   }
 
   /** Subscribe to changes for one facet. Fires after every

--- a/src/facets/test/facet.test.ts
+++ b/src/facets/test/facet.test.ts
@@ -169,3 +169,54 @@ describe('FacetRuntime runtime contributions', () => {
     }
   })
 })
+
+// adoptDurableContributionsFrom is how a `setFacetRuntime` swap carries
+// repo-owned user data (durable buckets) forward without a separate
+// mirror (B1(2)). The durable/transient split is load-bearing: copying
+// transient effect-owned buckets forward is exactly what stranded stale
+// contributions and got reverted in #152, so it's covered directly.
+describe('FacetRuntime.adoptDurableContributionsFrom', () => {
+  const labelsFacet = defineFacet<string, string>({
+    id: 'test.adopt-labels',
+    combine: values => values.join(','),
+    empty: () => '',
+  })
+
+  it('carries durable buckets onto the fresh runtime', () => {
+    const previous = resolveFacetRuntimeSync([])
+    previous.setRuntimeContributions(labelsFacet, 'user-data', ['schema'], { durable: true })
+
+    const next = resolveFacetRuntimeSync([labelsFacet.of('static')])
+    next.adoptDurableContributionsFrom(previous)
+    expect(next.read(labelsFacet)).toBe('static,schema')
+  })
+
+  it('does NOT carry transient (non-durable) buckets — they would strand', () => {
+    const previous = resolveFacetRuntimeSync([])
+    previous.setRuntimeContributions(labelsFacet, 'effect-output', ['transient'])
+
+    const next = resolveFacetRuntimeSync([labelsFacet.of('static')])
+    next.adoptDurableContributionsFrom(previous)
+    expect(next.read(labelsFacet)).toBe('static')
+  })
+
+  it('drops a durable bucket once cleared on the source runtime', () => {
+    const previous = resolveFacetRuntimeSync([])
+    previous.setRuntimeContributions(labelsFacet, 'user-data', ['schema'], { durable: true })
+    previous.setRuntimeContributions(labelsFacet, 'user-data', [], { durable: true })
+
+    const next = resolveFacetRuntimeSync([])
+    next.adoptDurableContributionsFrom(previous)
+    expect(next.read(labelsFacet)).toBe('')
+  })
+
+  it('stops treating a bucket as durable when re-set as transient', () => {
+    const previous = resolveFacetRuntimeSync([])
+    previous.setRuntimeContributions(labelsFacet, 'src', ['v'], { durable: true })
+    previous.setRuntimeContributions(labelsFacet, 'src', ['v'])
+
+    const next = resolveFacetRuntimeSync([])
+    next.adoptDurableContributionsFrom(previous)
+    expect(next.read(labelsFacet)).toBe('')
+  })
+})

--- a/src/plugins/agent-runtime/authoringCatalog.ts
+++ b/src/plugins/agent-runtime/authoringCatalog.ts
@@ -535,7 +535,7 @@ const guides: AuthoringGuide[] = [
       'Add a manual sync action through `actionsFacet`. The handler reads the checkpoint from the prefs block, fetches incremental updates, and runs a single `repo.tx`. Wrap the body in `showProgress(...)` so the user sees per-page / per-book progress and a final summary.',
       'Anchor imported content under a plugin-owned root block whose id is `pluginBlockId(workspaceId, NAMESPACE, "library-root")` — see the `plugin-root-singleton` storage pattern.',
       'Upsert child records the same way: derive the block id from the external id, or look up by an external-id property. Never create a second block for the same external record.',
-      'For *background* sync (poll a webhook / poll on an interval) use `appEffectsFacet.of({id, start: ({repo}) => { ... return cleanup })`. Manual sync via an action is enough for most plugins — only reach for an effect when the data source itself pushes.',
+      'For *background* sync (poll a webhook / poll on an interval) use `appEffectsFacet.of({id, start: ({repo}) => { ... return cleanup })`. Manual sync via an action is enough for most plugins — only reach for an effect when the data source itself pushes. The effect object must be a STABLE reference: define it once at module scope (not inline in a function-valued extension), and export your extension as an array, not a function — a fresh `{id, start}` every resolve reads as "code changed" and silently restarts the effect (dropping its connection / interval) on every unrelated extension toggle.',
     ],
     preferredModules: [
       '@/extensions/api.js',

--- a/src/plugins/agent-runtime/test/commands.test.ts
+++ b/src/plugins/agent-runtime/test/commands.test.ts
@@ -31,7 +31,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   const runtime = resolveFacetRuntimeSync(staticDataExtensions, {

--- a/src/plugins/alias/test/collisionMerge.test.ts
+++ b/src/plugins/alias/test/collisionMerge.test.ts
@@ -31,7 +31,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/alias/test/collisionRejection.test.ts
+++ b/src/plugins/alias/test/collisionRejection.test.ts
@@ -51,7 +51,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/alias/test/syncProcessor.test.ts
+++ b/src/plugins/alias/test/syncProcessor.test.ts
@@ -44,7 +44,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/app-intents/test/appIntents.test.ts
+++ b/src/plugins/app-intents/test/appIntents.test.ts
@@ -51,7 +51,6 @@ const setup = async (): Promise<Harness> => {
     cache: new BlockCache(),
     user: USER,
     newId: () => `gen-${++id}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/backlinks/test/query.test.ts
+++ b/src/plugins/backlinks/test/query.test.ts
@@ -65,7 +65,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/block-tagging/test/appendTag.test.ts
+++ b/src/plugins/block-tagging/test/appendTag.test.ts
@@ -68,7 +68,6 @@ describe('appendTagToBlocks', () => {
       db: h.db,
       cache: new BlockCache(),
       user: {id: 'user-1'},
-      registerKernelProcessors: false,
     })
     repo.setFacetRuntime(resolveFacetRuntimeSync([kernelDataExtension]))
   })

--- a/src/plugins/daily-notes/test/actions.test.ts
+++ b/src/plugins/daily-notes/test/actions.test.ts
@@ -50,7 +50,6 @@ const setup = async (): Promise<Harness> => {
     cache: new BlockCache(),
     user: USER,
     newId: () => `gen-${++id}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/daily-notes/test/backfill.test.ts
+++ b/src/plugins/daily-notes/test/backfill.test.ts
@@ -32,7 +32,6 @@ const setup = async (): Promise<Harness> => {
     cache: new BlockCache(),
     user: USER,
     newId: () => `gen-${++id}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([kernelDataExtension, dailyNotesDataExtension]))
   repo.setActiveWorkspaceId(WS)

--- a/src/plugins/daily-notes/test/blockDateAdapter.test.ts
+++ b/src/plugins/daily-notes/test/blockDateAdapter.test.ts
@@ -65,7 +65,6 @@ const makeRepo = () =>
     db: sharedDb.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
     startSyncObserver: false,
   })
 

--- a/src/plugins/daily-notes/test/spreadBlockDates.test.ts
+++ b/src/plugins/daily-notes/test/spreadBlockDates.test.ts
@@ -40,7 +40,6 @@ beforeEach(async () => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   runtime = resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/daily-notes/test/targetIntegration.test.ts
+++ b/src/plugins/daily-notes/test/targetIntegration.test.ts
@@ -52,7 +52,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/find-replace/test/dataExtension.test.ts
+++ b/src/plugins/find-replace/test/dataExtension.test.ts
@@ -36,7 +36,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/geo/test/createOrFindPlace.test.ts
+++ b/src/plugins/geo/test/createOrFindPlace.test.ts
@@ -44,7 +44,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   repo.setFacetRuntime(resolveFacetRuntimeSync([kernelDataExtension, geoDataExtension]))

--- a/src/plugins/geo/test/locationsPage.test.ts
+++ b/src/plugins/geo/test/locationsPage.test.ts
@@ -27,7 +27,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   repo.setFacetRuntime(resolveFacetRuntimeSync([

--- a/src/plugins/geo/test/query.test.ts
+++ b/src/plugins/geo/test/query.test.ts
@@ -26,7 +26,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   repo.setFacetRuntime(resolveFacetRuntimeSync([kernelDataExtension, geoDataExtension]))

--- a/src/plugins/grouped-backlinks/test/query.test.ts
+++ b/src/plugins/grouped-backlinks/test/query.test.ts
@@ -56,7 +56,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/left-sidebar/test/actions.test.ts
+++ b/src/plugins/left-sidebar/test/actions.test.ts
@@ -28,7 +28,6 @@ const setup = async (): Promise<Harness> => {
     cache: new BlockCache(),
     user: USER,
     newId: () => `gen-${++id}`,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/plugins/left-sidebar/test/shortcuts.test.ts
+++ b/src/plugins/left-sidebar/test/shortcuts.test.ts
@@ -26,7 +26,6 @@ const createRepo = (h: TestDb): Repo => {
     db: h.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return repo

--- a/src/plugins/references/test/inlineDeletedBlockRefsProcessor.test.ts
+++ b/src/plugins/references/test/inlineDeletedBlockRefsProcessor.test.ts
@@ -44,8 +44,9 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
+  // The constructor installs a kernel-only runtime; this swap REPLACES it
+  // with the kernel + references + alias registry these tests exercise.
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,
     referencesDataExtension,

--- a/src/plugins/references/test/mergeRetargetProcessor.test.ts
+++ b/src/plugins/references/test/mergeRetargetProcessor.test.ts
@@ -32,7 +32,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/references/test/referencesProcessor.test.ts
+++ b/src/plugins/references/test/referencesProcessor.test.ts
@@ -62,7 +62,6 @@ const setup = async (
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   // Reprojection is workspace-scoped: it only scans + marks the active
   // workspace. All fixtures here live in WS, so make it active or every
@@ -855,7 +854,6 @@ describe('parseReferences — schema-swap reprojection', () => {
       db: env.h.db,
       cache: cache2,
       user: {id: 'user-1'},
-      registerKernelProcessors: false,
     })
     repo2.setActiveWorkspaceId(WS)
     repo2.setFacetRuntime(runtimeWithReviewer())

--- a/src/plugins/references/test/renameProcessor.test.ts
+++ b/src/plugins/references/test/renameProcessor.test.ts
@@ -43,7 +43,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/roam-import/test/import.test.ts
+++ b/src/plugins/roam-import/test/import.test.ts
@@ -80,7 +80,6 @@ const setup = async (): Promise<Harness> => {
     // The importer pre-populates references[] explicitly; running
     // parseReferences on top would re-parse content + clobber. The
     // importer also calls processors itself for alias resolution.
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WORKSPACE)
   repo.setFacetRuntime(resolveFacetRuntimeSync([

--- a/src/plugins/roam-import/test/schemaReconciliation.test.ts
+++ b/src/plugins/roam-import/test/schemaReconciliation.test.ts
@@ -37,7 +37,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
     startSyncObserver: false,
   })
   repo.setActiveWorkspaceId(WS)

--- a/src/plugins/spatial-navigation/test/PanelFocusRecovery.test.tsx
+++ b/src/plugins/spatial-navigation/test/PanelFocusRecovery.test.tsx
@@ -34,7 +34,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/plugins/spatial-navigation/test/actions.test.ts
+++ b/src/plugins/spatial-navigation/test/actions.test.ts
@@ -38,7 +38,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/plugins/srs-rescheduling/test/actions.test.ts
+++ b/src/plugins/srs-rescheduling/test/actions.test.ts
@@ -46,7 +46,6 @@ beforeEach(async () => {
     user: {id: USER},
     now: () => ++now,
     newId: () => `generated-${++id}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/srs-rescheduling/test/moveSrsState.test.ts
+++ b/src/plugins/srs-rescheduling/test/moveSrsState.test.ts
@@ -106,7 +106,6 @@ describe('moveSrsState', () => {
       cache: new BlockCache(),
       user: {id: 'user-1'},
       newTxSeq: () => ++txSeq,
-      registerKernelProcessors: false,
       startSyncObserver: false,
     })
     const runtime = resolveFacetRuntimeSync([

--- a/src/plugins/srs-rescheduling/test/plugin.test.ts
+++ b/src/plugins/srs-rescheduling/test/plugin.test.ts
@@ -81,7 +81,6 @@ describe('srsReschedulingPlugin', () => {
       db: sharedDb.db,
       cache: new BlockCache(),
       user: {id: 'user-1'},
-      registerKernelProcessors: false,
       startSyncObserver: false,
     })
     repo.setFacetRuntime(resolveFacetRuntimeSync([
@@ -381,7 +380,6 @@ describe('srsReschedulingPlugin', () => {
       cache: new BlockCache(),
       user: {id: 'user-1'},
       newTxSeq: () => ++txSeq,
-      registerKernelProcessors: false,
       startSyncObserver: false,
     })
     const runtime = resolveFacetRuntimeSync([
@@ -480,7 +478,6 @@ describe('srsReschedulingPlugin', () => {
         cache: new BlockCache(),
         user: {id: 'user-1'},
         newTxSeq: () => ++txSeq,
-        registerKernelProcessors: false,
         startSyncObserver: false,
       })
       const runtime = resolveFacetRuntimeSync([
@@ -619,7 +616,6 @@ describe('srsReschedulingPlugin', () => {
       user: {id: 'user-1'},
       now: () => ++now,
       newId: () => `generated-${++id}`,
-      registerKernelProcessors: false,
       startSyncObserver: false,
     })
     const runtime = resolveFacetRuntimeSync([

--- a/src/plugins/srs-rescheduling/test/rescheduleDecorator.test.ts
+++ b/src/plugins/srs-rescheduling/test/rescheduleDecorator.test.ts
@@ -52,7 +52,6 @@ beforeEach(async () => {
   h = sharedDb
   repo = new Repo({
     db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
 })
 

--- a/src/plugins/srs-rescheduling/test/srsBlockDateAdapter.test.ts
+++ b/src/plugins/srs-rescheduling/test/srsBlockDateAdapter.test.ts
@@ -47,7 +47,6 @@ beforeEach(async () => {
   h = sharedDb
   repo = new Repo({
     db: h.db, cache: new BlockCache(), user: {id: 'user-1'},
-    registerKernelProcessors: false,
   })
   setupRuntime()
 })

--- a/src/plugins/srs-review/test/dueCards.integration.test.ts
+++ b/src/plugins/srs-review/test/dueCards.integration.test.ts
@@ -40,7 +40,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
     // No live sync observer (the sanctioned deterministic-timing pattern).
     // This suite does explicit local writes + queries and never needs
     // materialization. With it on, a prior test's async observer write — whose

--- a/src/plugins/todo/test/actions.test.ts
+++ b/src/plugins/todo/test/actions.test.ts
@@ -31,7 +31,6 @@ beforeEach(async () => {
     user: {id: 'user-1'},
     now: () => ++now,
     newId: () => `generated-${++id}`,
-    registerKernelProcessors: false,
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,

--- a/src/plugins/update-indicator/test/loadTimes.test.ts
+++ b/src/plugins/update-indicator/test/loadTimes.test.ts
@@ -29,7 +29,6 @@ const makeRepo = (h: TestDb): Repo => {
     cache: new BlockCache(),
     user: USER,
     newTxSeq: () => ++txSeq,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return repo

--- a/src/plugins/vim-normal-mode/test/jumpVisibleBlocks.test.ts
+++ b/src/plugins/vim-normal-mode/test/jumpVisibleBlocks.test.ts
@@ -31,7 +31,6 @@ beforeEach(async () => {
     db: sharedDb.db,
     cache: new BlockCache(),
     user: {id: 'user-1'},
-    registerKernelProcessors: false,
     startSyncObserver: false,
   })
   repo.setActiveWorkspaceId(WS)

--- a/src/shortcuts/defaultShortcuts.test.ts
+++ b/src/shortcuts/defaultShortcuts.test.ts
@@ -58,7 +58,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache,
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/test/initData.test.ts
+++ b/src/test/initData.test.ts
@@ -49,7 +49,6 @@ const setup = async (): Promise<Harness> => {
     // links (`[[Tutorial]]`, `[[Tutorial (no vim)]]`) which would
     // otherwise create alias-target side effects we'd then have to
     // count around. Tests focus on what seedTutorial writes.
-    registerKernelProcessors: false,
   })
   return { h, repo }
 }

--- a/src/test/initData.test.ts
+++ b/src/test/initData.test.ts
@@ -45,10 +45,6 @@ const setup = async (): Promise<Harness> => {
     user: { id: 'user-1' },
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    // Don't run parseReferences — the seeded outlines contain wiki
-    // links (`[[Tutorial]]`, `[[Tutorial (no vim)]]`) which would
-    // otherwise create alias-target side effects we'd then have to
-    // count around. Tests focus on what seedTutorial writes.
   })
   return { h, repo }
 }

--- a/src/utils/test/linkTargetAutocomplete.test.ts
+++ b/src/utils/test/linkTargetAutocomplete.test.ts
@@ -34,7 +34,6 @@ const setup = async (): Promise<Harness> => {
     user: {id: 'user-1'},
     now: () => ++timeCursor,
     newId: () => `gen-${++idCursor}`,
-    registerKernelProcessors: false,
   })
   return {h, repo}
 }

--- a/src/utils/test/navigation.test.ts
+++ b/src/utils/test/navigation.test.ts
@@ -43,7 +43,6 @@ const setup = async (): Promise<Harness> => {
     db: sharedDb.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}

--- a/src/utils/test/panelLayoutProjection.test.ts
+++ b/src/utils/test/panelLayoutProjection.test.ts
@@ -40,7 +40,6 @@ const setup = async (): Promise<Harness> => {
     db: h.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   const uiState = await getUIStateBlock(repo, WS, USER, {})

--- a/src/utils/test/selection.test.ts
+++ b/src/utils/test/selection.test.ts
@@ -27,7 +27,6 @@ const setup = async (): Promise<Harness> => {
     db: sharedDb.db,
     cache: new BlockCache(),
     user: USER,
-    registerKernelProcessors: false,
   })
   repo.setActiveWorkspaceId(WS)
   return {h, repo}


### PR DESCRIPTION
Follow-up to #152 (audit D1), addressing **#136 (audit B1)** — the compensation mechanisms `setFacetRuntime`'s wholesale-REPLACE spawned. Learning from #152's two reverted attempts (the literal `withContributionsFrom` over-copied transient buckets; effect-diffing stranded effects on the dead runtime), this PR fixes the underlying contracts first.

Scope agreed with @Stvad: **a + b + d** in this PR; **c** under design discussion (see below). All commits are behavior-preserving except the deliberate effect-lifecycle change in (d). `tsc` + full vitest (3224 tests) + eslint all green locally.

### (a) — empty Repo + kernel-only runtime, drop the five flags ✅
- The Repo constructor no longer registers kernel mutators/queries/processors/invalidation directly via `registerKernel*` options. It installs a kernel-only `FacetRuntime` (`resolveFacetRuntimeSync([kernelDataExtension])`) through the **same** `setFacetRuntime` path a later swap uses → one kernel registration path, no dual-registration contract.
- `RepoOptions`: five `registerKernel*` flags → one `installKernelRuntime` (default true) escape hatch.
- Reprojection is gated on an active workspace (none at construction), so the install does no DB work.
- Migrated ~60 test call sites (the no-op `registerKernelProcessors: false` dropped; the 3 suites that wanted empty registries use `installKernelRuntime: false`).

### (b) — make durable replay the runtime's job; delete the FacetBridge mirror ✅
D1(c) had only *relocated* the durable-bucket mirror (Repo → `FacetBridge`). This realizes the original B1(2) idea: `FacetRuntime.setRuntimeContributions(..., {durable})` + `adoptDurableContributionsFrom(prev)` carry **only durable** repo-owned buckets (user schemas/types) forward; transient effect-owned buckets are deliberately not — exactly the distinction that reverted the literal `withContributionsFrom`. The bridge's mirror maps + replay loop are deleted.

### (d) — restart only changed effects ✅
Effects now capture a stable `LiveRuntimeHandle` (a `FacetRuntime` delegating to a swappable `current`) instead of the raw runtime, so a kept effect isn't stranded on the dead runtime after a swap (the #152 bug). On `setCurrent` the handle migrates the effect's `onFacetChange` subscriptions + transient buckets and re-fires subscribers so mirror-style effects (theme) re-sync. `EffectReconciler` diffs `appEffectsFacet` by id — starts added, stops removed, keeps unchanged — and restarts everything only when repo/workspaceId/safeMode change. Subclassing `FacetRuntime` keeps `AppEffectContext.runtime` typed `FacetRuntime`, so theme / keybindings / agent-runtime-bridge code is untouched.

### (c) — one per-plugin record ⏳ design discussion
Pre-existing duplication: each plugin lists its data extension both inside its toggle (`.of([dataExtension, …])`) and in `staticDataExtensions.ts`. A single-source registry must choose:
- **C-1**: `{app, data}[]` registry, data extensions become **always-on siblings** — no plugin API change, but disabling a plugin would no longer drop its data layer post-mount (e.g. srs-rescheduling's processor would keep running).
- **C-2**: a `definePlugin({toggle, app, data})` helper that preserves toggle-gating — a ~40-plugin refactor (plugin-authoring API change), recommended as its own focused PR.

Held pending @Stvad's call; leaning toward C-2-as-separate-PR so this PR stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)