### PR TITLE
Guard self-merge in mergeBlocksInTx (no-op when intoId === fromId)

### DIFF
--- a/src/data/blockMerge.ts
+++ b/src/data/blockMerge.ts
@@ -46,6 +46,11 @@ export const mergeBlocksInTx = async (
     aliasRewrites = [],
   }: MergeBlocksInTxArgs,
 ): Promise<void> => {
+  // Merging a block into itself would tombstone it (delete), double its
+  // content (read-after-delete via requireExisting), and orphan its children
+  // under the tombstone. Treat self-merge as a no-op.
+  if (into.id === from.id) return
+
   const intoChildren = await tx.childrenOf(into.id)
   const fromChildren = await tx.childrenOf(from.id)
   if (fromChildren.length > 0) {

--- a/src/data/mutators.test.ts
+++ b/src/data/mutators.test.ts
@@ -812,6 +812,22 @@ describe('core.merge', () => {
     expect(await env.childIds('p')).toEqual(['a'])
   })
 
+  it('treats self-merge (intoId === fromId) as a no-op', async () => {
+    await env.repo.tx(
+      tx => tx.create({id: 'p', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'}),
+      {scope: ChangeScope.BlockDefault},
+    )
+    await env.repo.mutate.createChild({parentId: 'p', id: 'x', content: 'foo'})
+    await env.repo.mutate.createChild({parentId: 'x', id: 'c', content: 'child'})
+    await env.repo.mutate.merge({intoId: 'x', fromId: 'x'})
+    // Block intact: not deleted, content not doubled, child still parented.
+    expect(env.read('x')!.deleted).toBe(false)
+    expect(env.read('x')!.content).toBe('foo')
+    expect(env.read('c')!.parentId).toBe('x')
+    expect(env.read('c')!.deleted).toBe(false)
+    expect(await env.childIds('x')).toEqual(['c'])
+  })
+
   it("re-parents source's children under the target so they aren't stranded", async () => {
     await env.repo.tx(
       tx => tx.create({id: 'p', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'}),


### PR DESCRIPTION
## Summary
Fixes #184.

`core.merge({intoId: x, fromId: x})` (a block merged into itself) would silently:
- soft-delete the block (`tx.delete(x)` writes an `after=tombstone` snapshot),
- double its content (`tx.update` reads the tombstone back via `requireExisting` — no `deleted` filter — and writes `content = x.content + x.content`),
- orphan its children under the tombstone.

No UI caller hits this today (`MergePicker` excludes the source, the alias path self-excludes, backspace `previousVisibleBlock` never returns current), but `core.merge` is a **public mutator** (agent bridge / macros / plugins) with no guard — so this is defense-in-depth.

## Change
- `src/data/blockMerge.ts`: one-line guard — `if (into.id === from.id) return` at the top of `mergeBlocksInTx`, treating self-merge as a no-op.
- `src/data/mutators.test.ts`: test that `core.merge` with `intoId === fromId` on a block with children + content leaves the block intact (not deleted, content not doubled, children not orphaned).

## Verification
- `yarn run check` green (3273 tests passed, 0 lint errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdmNvKiWeTMX3U7SK4BmXb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdmNvKiWeTMX3U7SK4BmXb)_