### PR TITLE
fix(references): drop only the bad refList element, never strip the whole field (#189)

### DIFF
--- a/src/data/api/codecs.test.ts
+++ b/src/data/api/codecs.test.ts
@@ -190,6 +190,22 @@ describe('codecs.refList', () => {
     expect(() => codecs.refList().decode('target-1')).toThrow(CodecError)
     expect(() => codecs.refList().decode(['target-1', 42])).toThrow(CodecError)
   })
+
+  it('decodeValid keeps well-formed ids and drops only the malformed elements (#189)', () => {
+    const inner = codecs.refList()
+    // The historical whole-field strip: one bad element must NOT discard the
+    // valid backlinks alongside it.
+    expect(inner.decodeValid(['valid-1', 'valid-2', 42])).toEqual(['valid-1', 'valid-2'])
+    expect(inner.decodeValid(['a', null, 'b', {}, 'c'])).toEqual(['a', 'b', 'c'])
+    expect(inner.decodeValid([])).toEqual([])
+    expect(inner.decodeValid(['a', 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('decodeValid returns [] for non-array input (nothing recoverable)', () => {
+    expect(codecs.refList().decodeValid('target-1')).toEqual([])
+    expect(codecs.refList().decodeValid(42)).toEqual([])
+    expect(codecs.refList().decodeValid(null)).toEqual([])
+  })
 })
 
 describe('CodecError', () => {

--- a/src/data/api/codecs.test.ts
+++ b/src/data/api/codecs.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   codecs,
   CodecError,
+  decodeRefListIds,
   isRefCodec,
   isRefListCodec,
+  type RefListCodec,
 } from './codecs'
 
 describe('codec type metadata', () => {
@@ -195,16 +197,46 @@ describe('codecs.refList', () => {
     const inner = codecs.refList()
     // The historical whole-field strip: one bad element must NOT discard the
     // valid backlinks alongside it.
-    expect(inner.decodeValid(['valid-1', 'valid-2', 42])).toEqual(['valid-1', 'valid-2'])
-    expect(inner.decodeValid(['a', null, 'b', {}, 'c'])).toEqual(['a', 'b', 'c'])
-    expect(inner.decodeValid([])).toEqual([])
-    expect(inner.decodeValid(['a', 'b'])).toEqual(['a', 'b'])
+    expect(inner.decodeValid!(['valid-1', 'valid-2', 42])).toEqual(['valid-1', 'valid-2'])
+    expect(inner.decodeValid!(['a', null, 'b', {}, 'c'])).toEqual(['a', 'b', 'c'])
+    expect(inner.decodeValid!([])).toEqual([])
+    expect(inner.decodeValid!(['a', 'b'])).toEqual(['a', 'b'])
   })
 
   it('decodeValid returns [] for non-array input (nothing recoverable)', () => {
-    expect(codecs.refList().decodeValid('target-1')).toEqual([])
-    expect(codecs.refList().decodeValid(42)).toEqual([])
-    expect(codecs.refList().decodeValid(null)).toEqual([])
+    expect(codecs.refList().decodeValid!('target-1')).toEqual([])
+    expect(codecs.refList().decodeValid!(42)).toEqual([])
+    expect(codecs.refList().decodeValid!(null)).toEqual([])
+  })
+})
+
+describe('decodeRefListIds', () => {
+  it('uses the codec decodeValid when present (lenient element-wise, #189)', () => {
+    expect(decodeRefListIds(codecs.refList(), ['valid-1', 42, 'valid-2'])).toEqual(['valid-1', 'valid-2'])
+    expect(decodeRefListIds(codecs.refList(), 'not-an-array')).toEqual([])
+  })
+
+  it('falls back to a method-free string filter for a codec lacking decodeValid', () => {
+    // Models a RefListCodec authored against the pre-decodeValid public
+    // interface (RefListCodec is exported, so external/older plugins may
+    // implement only the original shape). It must not throw
+    // `decodeValid is not a function` and abort the block's whole projection
+    // — it recovers the well-formed ids the same way.
+    const legacy: RefListCodec = {
+      type: 'refList',
+      targetTypes: [],
+      encode: v => v.map(item => item),
+      decode: j => {
+        if (!Array.isArray(j)) throw new CodecError('array', j)
+        return j.map(item => {
+          if (typeof item !== 'string') throw new CodecError('string', item)
+          return item
+        })
+      },
+    }
+    expect(legacy.decodeValid).toBeUndefined()
+    expect(decodeRefListIds(legacy, ['valid-1', 42, 'valid-2'])).toEqual(['valid-1', 'valid-2'])
+    expect(decodeRefListIds(legacy, 'not-an-array')).toEqual([])
   })
 })
 

--- a/src/data/api/codecs.ts
+++ b/src/data/api/codecs.ts
@@ -63,8 +63,16 @@ export interface RefListCodec extends Codec<readonly string[]> {
    *  yields `[]`. This is the projection-safe counterpart to `decode`:
    *  one malformed element must not strip the whole field's backlinks to
    *  `[]` (issue #189). `decode` stays strict for the write/read boundary
-   *  call sites that want shape errors surfaced. */
-  decodeValid(json: unknown): string[]
+   *  call sites that want shape errors surfaced.
+   *
+   *  Optional because `RefListCodec` is a public, exported boundary that
+   *  predates this method: a third-party or older plugin may implement
+   *  only the original shape. Reference projection must reach it through
+   *  `decodeRefListIds`, which feature-detects this method so a legacy
+   *  codec can't throw `decodeValid is not a function` and abort the
+   *  block's whole projection. Codecs built by `codecs.refList()` always
+   *  provide it. */
+  decodeValid?(json: unknown): string[]
 }
 
 const stringCodec: Codec<string> = {
@@ -202,6 +210,22 @@ export const isRefCodec = (codec: unknown): codec is RefCodec =>
 
 export const isRefListCodec = (codec: unknown): codec is RefListCodec =>
   typeof codec === 'object' && codec !== null && (codec as Codec<unknown>).type === 'refList'
+
+/** Project a refList codec's value to its well-formed ref ids — the
+ *  reference-projection-safe entry point. Prefers the codec's own lenient
+ *  `decodeValid`; falls back to a method-free string filter for a
+ *  `RefListCodec` authored against the pre-`decodeValid` public interface
+ *  (`isRefListCodec` narrows on the discriminator alone, so such a codec
+ *  reaches here). `RefListCodec` is `Codec<readonly string[]>`, so
+ *  well-formed elements are strings — keep those, drop the rest. Total by
+ *  construction: never throws, so one malformed element OR a missing
+ *  method drops only what it must and never aborts the block's projection
+ *  (issue #189 + its follow-up). */
+export const decodeRefListIds = (codec: RefListCodec, value: unknown): string[] => {
+  if (typeof codec.decodeValid === 'function') return codec.decodeValid(value)
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
 
 /** URL codec: plain string with light validation on encode/decode.
  *  Currently accepts any non-empty string; tightening the validation

--- a/src/data/api/codecs.ts
+++ b/src/data/api/codecs.ts
@@ -57,6 +57,14 @@ export interface RefCodec extends Codec<string> {
 export interface RefListCodec extends Codec<readonly string[]> {
   readonly type: 'refList'
   readonly targetTypes: readonly string[]
+  /** Lenient element-wise decode for reference projection. Decodes each
+   *  element through the element codec, *dropping* (never throwing on)
+   *  the ones that fail, and returns the well-formed ids. Non-array input
+   *  yields `[]`. This is the projection-safe counterpart to `decode`:
+   *  one malformed element must not strip the whole field's backlinks to
+   *  `[]` (issue #189). `decode` stays strict for the write/read boundary
+   *  call sites that want shape errors surfaced. */
+  decodeValid(json: unknown): string[]
 }
 
 const stringCodec: Codec<string> = {
@@ -170,6 +178,21 @@ const refList = (options?: RefCodecOptions): RefListCodec => {
     decode: j => {
       if (!Array.isArray(j)) throw new CodecError('array', j)
       return j.map(item => stringCodec.decode(item))
+    },
+    decodeValid: j => {
+      // Element-wise + fault-tolerant: a non-array has nothing to recover,
+      // and a single bad element drops only itself. Never strips the whole
+      // field's derived refs to [] (issue #189).
+      if (!Array.isArray(j)) return []
+      const out: string[] = []
+      for (const item of j) {
+        try {
+          out.push(stringCodec.decode(item))
+        } catch {
+          // Drop only the malformed element; keep the well-formed ids.
+        }
+      }
+      return out
     },
   }
 }

--- a/src/data/internals/refProjection.test.ts
+++ b/src/data/internals/refProjection.test.ts
@@ -87,9 +87,18 @@ describe('projectedRefsForField', () => {
   })
 
   it('returns [] when the value fails to decode (malformed)', () => {
-    // ref expects a string; refList expects an array of strings.
+    // ref expects a string; refList expects an array of strings. A whole-value
+    // shape mismatch (non-array refList) has nothing to recover.
     expect(projectedRefsForField(block({ reviewer: 42 }), refProp, 'reviewer')).toEqual([])
     expect(projectedRefsForField(block({ related: 'not-an-array' }), refListProp, 'related')).toEqual([])
+  })
+
+  it('keeps the well-formed ids when one refList element is malformed (#189, no whole-field strip)', () => {
+    // ['target-b', 42, 'target-c'] must not strip target-b/target-c alongside 42.
+    expect(projectedRefsForField(block({ related: ['target-b', 42, 'target-c'] }), refListProp, 'related')).toEqual([
+      { id: 'target-b', alias: 'target-b', sourceField: 'related' },
+      { id: 'target-c', alias: 'target-c', sourceField: 'related' },
+    ])
   })
 
   it('returns [] for a present but non-ref schema', () => {

--- a/src/data/internals/refProjection.ts
+++ b/src/data/internals/refProjection.ts
@@ -109,12 +109,10 @@ export const projectedRefsForField = (
     return refs
   }
   if (isRefListCodec(schema.codec)) {
-    try {
-      for (const id of schema.codec.decode(encodedValue)) {
-        appendRefProjection(refs, seen, sourceField, id)
-      }
-    } catch {
-      return []
+    // Element-wise lenient decode: a single malformed element drops only
+    // itself instead of stripping the whole field's backlinks to [] (#189).
+    for (const id of schema.codec.decodeValid(encodedValue)) {
+      appendRefProjection(refs, seen, sourceField, id)
     }
   }
   return refs

--- a/src/data/internals/refProjection.ts
+++ b/src/data/internals/refProjection.ts
@@ -20,7 +20,7 @@ import type {
   BlockReference,
   TypeContribution,
 } from '@/data/api'
-import { isRefCodec, isRefListCodec } from '@/data/api'
+import { decodeRefListIds, isRefCodec, isRefListCodec } from '@/data/api'
 
 /** Build the merged property-schema registry: type-lifted schemas first
  *  (each `TypeContribution.properties`), then direct `propertySchemasFacet`
@@ -111,7 +111,7 @@ export const projectedRefsForField = (
   if (isRefListCodec(schema.codec)) {
     // Element-wise lenient decode: a single malformed element drops only
     // itself instead of stripping the whole field's backlinks to [] (#189).
-    for (const id of schema.codec.decodeValid(encodedValue)) {
+    for (const id of decodeRefListIds(schema.codec, encodedValue)) {
       appendRefProjection(refs, seen, sourceField, id)
     }
   }

--- a/src/plugins/references/referenceProjection.ts
+++ b/src/plugins/references/referenceProjection.ts
@@ -42,12 +42,10 @@ export const projectPropertyReferences = (
     }
 
     if (isRefListCodec(schema.codec)) {
-      try {
-        for (const id of schema.codec.decode(encodedValue)) {
-          appendPropertyRef(refs, seen, name, id)
-        }
-      } catch {
-        // See single-ref case above.
+      // Element-wise lenient decode: a single malformed element drops only
+      // itself instead of stripping the whole field's backlinks to [] (#189).
+      for (const id of schema.codec.decodeValid(encodedValue)) {
+        appendPropertyRef(refs, seen, name, id)
       }
     }
   }

--- a/src/plugins/references/referenceProjection.ts
+++ b/src/plugins/references/referenceProjection.ts
@@ -1,4 +1,5 @@
 import {
+  decodeRefListIds,
   isRefCodec,
   isRefListCodec,
   type AnyPropertySchema,
@@ -44,7 +45,7 @@ export const projectPropertyReferences = (
     if (isRefListCodec(schema.codec)) {
       // Element-wise lenient decode: a single malformed element drops only
       // itself instead of stripping the whole field's backlinks to [] (#189).
-      for (const id of schema.codec.decodeValid(encodedValue)) {
+      for (const id of decodeRefListIds(schema.codec, encodedValue)) {
         appendPropertyRef(refs, seen, name, id)
       }
     }

--- a/src/plugins/references/test/referenceProjection.test.ts
+++ b/src/plugins/references/test/referenceProjection.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
   ChangeScope,
+  CodecError,
   codecs,
   defineProperty,
   type AnyPropertySchema,
+  type RefListCodec,
 } from '@/data/api'
 import { projectPropertyReferences } from '../referenceProjection'
 
@@ -20,6 +22,27 @@ const relatedProp = defineProperty<readonly string[]>('related', {
 const reviewerProp = defineProperty<string>('reviewer', {
   codec: codecs.ref(),
   defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
+// A refList codec authored against the pre-`decodeValid` public interface — an
+// external/older plugin that still satisfies `isRefListCodec` (discriminator
+// only) but has no `decodeValid` method.
+const legacyRefListCodec: RefListCodec = {
+  type: 'refList',
+  targetTypes: [],
+  encode: v => v.map(item => item),
+  decode: j => {
+    if (!Array.isArray(j)) throw new CodecError('array', j)
+    return j.map(item => {
+      if (typeof item !== 'string') throw new CodecError('string', item)
+      return item
+    })
+  },
+}
+const legacyRelatedProp = defineProperty<readonly string[]>('related', {
+  codec: legacyRefListCodec,
+  defaultValue: [],
   changeScope: ChangeScope.BlockDefault,
 })
 
@@ -60,5 +83,22 @@ describe('projectPropertyReferences', () => {
         schemas(relatedProp),
       ),
     ).toEqual([])
+  })
+
+  it('a refList codec lacking decodeValid does not abort the block projection', () => {
+    // Regression for the #214 follow-up: removing the property-local try/catch
+    // meant a refList codec without `decodeValid` would throw
+    // `decodeValid is not a function`, stripping the whole block's refs
+    // (including the other well-formed ref field). It must recover the good
+    // ids instead and leave the other field's ref intact.
+    expect(
+      projectPropertyReferences(
+        { properties: { related: ['ok', 42], reviewer: 'target-a' } },
+        schemas(legacyRelatedProp, reviewerProp),
+      ),
+    ).toEqual([
+      { id: 'ok', alias: 'ok', sourceField: 'related' },
+      { id: 'target-a', alias: 'target-a', sourceField: 'reviewer' },
+    ])
   })
 })

--- a/src/plugins/references/test/referenceProjection.test.ts
+++ b/src/plugins/references/test/referenceProjection.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ChangeScope,
+  codecs,
+  defineProperty,
+  type AnyPropertySchema,
+} from '@/data/api'
+import { projectPropertyReferences } from '../referenceProjection'
+
+// `projectPropertyReferences` is the post-commit references processor's
+// per-block projection (the site named in issue #189). The whole-field strip
+// it used to suffer — one malformed `refList` element discarding every backlink
+// the field contributed — is the bug these tests pin against.
+
+const relatedProp = defineProperty<readonly string[]>('related', {
+  codec: codecs.refList(),
+  defaultValue: [],
+  changeScope: ChangeScope.BlockDefault,
+})
+const reviewerProp = defineProperty<string>('reviewer', {
+  codec: codecs.ref(),
+  defaultValue: '',
+  changeScope: ChangeScope.BlockDefault,
+})
+
+const schemas = (...props: AnyPropertySchema[]): ReadonlyMap<string, AnyPropertySchema> =>
+  new Map(props.map(p => [p.name, p]))
+
+describe('projectPropertyReferences', () => {
+  it('keeps the well-formed ids when one refList element is malformed (#189)', () => {
+    // ['valid-1','valid-2',42] previously decoded to [] — both valid backlinks
+    // lost. Now only the malformed 42 is dropped.
+    expect(
+      projectPropertyReferences(
+        { properties: { related: ['valid-1', 'valid-2', 42] } },
+        schemas(relatedProp),
+      ),
+    ).toEqual([
+      { id: 'valid-1', alias: 'valid-1', sourceField: 'related' },
+      { id: 'valid-2', alias: 'valid-2', sourceField: 'related' },
+    ])
+  })
+
+  it('a malformed refList field does not block another well-formed ref field', () => {
+    expect(
+      projectPropertyReferences(
+        { properties: { related: ['ok', {}], reviewer: 'target-a' } },
+        schemas(relatedProp, reviewerProp),
+      ),
+    ).toEqual([
+      { id: 'ok', alias: 'ok', sourceField: 'related' },
+      { id: 'target-a', alias: 'target-a', sourceField: 'reviewer' },
+    ])
+  })
+
+  it('a wholly wrong-shape refList value (non-array) still projects nothing', () => {
+    expect(
+      projectPropertyReferences(
+        { properties: { related: 'not-an-array' } },
+        schemas(relatedProp),
+      ),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #189. One malformed element in a `refList` property silently deleted **all** of that field's backlinks for the affected block.

`refList.decode` mapped every element through `stringCodec.decode`, so a single non-string element threw and aborted the whole `map`. Both reference-projection sites caught the throw and yielded `[]`, and the references processor then *replaced* the references column with the empty set:

`['valid-1','valid-2',42]` → `decode` throws on `42` → projection yields `[]` → both valid backlinks lost, triggered by the next unrelated content edit. Because `setProperty` doesn't validate on write and the `copy` sync path copies `properties_json` verbatim, a wrong-shape value planted by a buggy plugin / schema skew on one device propagated and stripped backlinks cross-device.

To confirm the scope (this came up in discussion): the loss is **per-block** — only the specific block whose `refList` value actually contains the bad element. A different block that merely uses the same property but holds a well-formed value is untouched. The "ALL" is *within* that one field on that one block (the good siblings were wiped alongside the bad element).

## Fix

- Add a lenient, element-wise `RefListCodec.decodeValid(json)` that decodes each element and **drops only** the ones that fail, returning the well-formed ids (non-array input → `[]`). `decode` stays strict so the write/read boundary call sites still surface shape errors.
- Route both projection sites through it:
  - `projectPropertyReferences` (`src/plugins/references/referenceProjection.ts`) — the post-commit references processor.
  - `projectedRefsForField` (`src/data/internals/refProjection.ts`) — the repo reprojection path.

A `refList` with one bad element now keeps the good elements' backlinks instead of stripping the whole field to `[]`.

## Tests

- `codecs.test.ts`: `decodeValid` keeps well-formed ids / drops malformed elements / returns `[]` on non-array.
- `refProjection.test.ts`: `projectedRefsForField` keeps the well-formed ids when one `refList` element is malformed.
- New `referenceProjection.test.ts`: direct coverage for `projectPropertyReferences` — partial recovery, a malformed `refList` field not blocking another well-formed ref field, and the non-array case.

## Verification

- Typecheck (`tsc -b`): green
- ESLint on changed files: green
- Full test suite: 3303 passed (302 files)

(Note: this environment only has Node 22 available while the project pins ≥24, so commands were run directly rather than via `yarn run check`, which blocks on the engine field.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGQbpxskziFEDofP3BF2eT)_