### PR TITLE
perf(extensions): persistent compile cache + lazy-load Babel (#167)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.5.0",
     "jsdom": "^29.1.0",
     "pg": "^8.20.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -120,12 +120,19 @@ self.addEventListener('install', (event) => {
         caches.open(ASSET_CACHE),
       ])
       // Shell entries use { cache: 'reload' } so an SW update always
-      // pulls fresh HTML/icons from the network. The first-paint asset
-      // list uses { cache: 'default' } so the install satisfies from the
-      // browser's HTTP cache (the page itself populated it moments ago) —
-      // copying it into Cache Storage costs almost nothing and gives this
-      // generation full offline-boot coverage. Per-URL failures are
-      // swallowed so one 404 can't strand install.
+      // pulls fresh HTML/icons from the network. The asset list uses
+      // { cache: 'default' }: for the first-paint modules the page just
+      // fetched them, so the install satisfies from the browser's HTTP
+      // cache almost for free. NOTE: PRECACHE_ASSETS also includes a few
+      // must-be-offline LAZY chunks (e.g. @babel/standalone) that were NOT
+      // first-painted — their install fetch is a genuine network round-trip.
+      // Per-URL failures are swallowed so one 404 can't strand install, but
+      // that means if a lazy entry's fetch fails here (offline/flaky during
+      // an SW update) it's absent from this generation's cache, and a COLD
+      // offline compile on this generation would fail until the app is
+      // online once — at which point `assetCacheFirst` fetches + caches it
+      // on demand (self-heal). The persistent IndexedDB compile cache
+      // (survives deploys) covers the warm case regardless.
       const fetchInto = (cache, url, mode) =>
         fetch(new Request(url, {cache: mode}))
           .then((res) => (res && res.ok ? cache.put(url, res) : null))

--- a/public/sw.js
+++ b/public/sw.js
@@ -76,6 +76,13 @@ const SHELL_URLS = [
 const PRECACHE_ASSETS = JSON.parse('__PRECACHE_ASSETS__')
   .map((p) => new URL(p, scopeURL).toString())
 
+// Build-injected list of must-be-offline LAZY chunks (e.g. @babel/standalone
+// + transitive deps) that are NOT in the first-paint graph. Kept separate
+// from PRECACHE_ASSETS because they're installed with a different cache mode
+// (see install). Replaced by scripts/inject-sw-build-id.mjs.
+const PRECACHE_LAZY_ASSETS = JSON.parse('__PRECACHE_LAZY_ASSETS__')
+  .map((p) => new URL(p, scopeURL).toString())
+
 const VENDOR_HOSTS = new Set(['esm.sh'])
 
 // --- generation ledger ------------------------------------------------------
@@ -119,20 +126,24 @@ self.addEventListener('install', (event) => {
         caches.open(SHELL_CACHE),
         caches.open(ASSET_CACHE),
       ])
-      // Shell entries use { cache: 'reload' } so an SW update always
-      // pulls fresh HTML/icons from the network. The asset list uses
-      // { cache: 'default' }: for the first-paint modules the page just
-      // fetched them, so the install satisfies from the browser's HTTP
-      // cache almost for free. NOTE: PRECACHE_ASSETS also includes a few
-      // must-be-offline LAZY chunks (e.g. @babel/standalone) that were NOT
-      // first-painted — their install fetch is a genuine network round-trip.
-      // Per-URL failures are swallowed so one 404 can't strand install, but
-      // that means if a lazy entry's fetch fails here (offline/flaky during
-      // an SW update) it's absent from this generation's cache, and a COLD
-      // offline compile on this generation would fail until the app is
-      // online once — at which point `assetCacheFirst` fetches + caches it
-      // on demand (self-heal). The persistent IndexedDB compile cache
-      // (survives deploys) covers the warm case regardless.
+      // Three cache modes, by what the browser's HTTP cache holds for each:
+      //   - SHELL_URLS → 'reload': always pull fresh HTML/icons from network.
+      //   - PRECACHE_ASSETS (first-paint) → 'default': the page just fetched
+      //     these exact unhashed URLs, so the HTTP cache holds THIS
+      //     generation's bytes — copying them into Cache Storage is near-free.
+      //   - PRECACHE_LAZY_ASSETS (e.g. @babel/standalone) → 'reload': these
+      //     were NOT first-painted and their unhashed URLs carry per-deploy-
+      //     varying bytes, so a 'default' fetch could copy a STALE prior-
+      //     deploy entry out of the HTTP cache into this generation's cache
+      //     (an offline cold compile would then run old compiler bytes under
+      //     the new build). 'reload' forces the network for the current bytes.
+      // Per-URL failures are swallowed so one 404 can't strand install. For a
+      // lazy entry that means a fetch failure here (offline/flaky during an SW
+      // update) leaves it absent from this generation; a COLD offline compile
+      // would then fail until the app is online once, at which point
+      // `assetCacheFirst` fetches + caches it on demand (self-heal). The
+      // persistent IndexedDB compile cache (survives deploys) covers the warm
+      // case regardless.
       const fetchInto = (cache, url, mode) =>
         fetch(new Request(url, {cache: mode}))
           .then((res) => (res && res.ok ? cache.put(url, res) : null))
@@ -140,6 +151,7 @@ self.addEventListener('install', (event) => {
       await Promise.all([
         ...SHELL_URLS.map((u) => fetchInto(shell, u, 'reload')),
         ...PRECACHE_ASSETS.map((u) => fetchInto(assets, u, 'default')),
+        ...PRECACHE_LAZY_ASSETS.map((u) => fetchInto(assets, u, 'reload')),
       ])
     })(),
   )

--- a/scripts/inject-sw-build-id.mjs
+++ b/scripts/inject-sw-build-id.mjs
@@ -1,20 +1,25 @@
 /**
- * Post-build step that stamps dist/sw.js with two things:
+ * Post-build step that stamps dist/sw.js with three things:
  *
  *   1. A per-build identifier (`__BUILD_ID__` placeholder) so each deploy
  *      lands in its own cache namespace and stale entries are dropped on
  *      activate. Source order: SW_BUILD_ID env, GITHUB_SHA, git rev-parse
  *      HEAD, then a timestamped fallback.
- *   2. The list of emitted JS/CSS assets (`__PRECACHE_ASSETS__`
- *      placeholder) so the install handler can fetch them up front. The
- *      initial module graph is dispatched by the browser before our SW
- *      activates, so without this list a first-time offline reload would
- *      fail to boot. This covers the first-paint HTML graph PLUS a small
- *      set of must-be-offline lazy chunks and their transitive deps
- *      (`@babel/standalone` — see scripts/precache-lazy-assets.mjs).
+ *   2. The first-paint asset list (`__PRECACHE_ASSETS__` placeholder) — the
+ *      HTML graph the browser dispatches before our SW activates — so the
+ *      install handler can fetch them up front; without it a first-time
+ *      offline reload would fail to boot. Installed `{ cache: 'default' }`
+ *      (the page just fetched these exact URLs).
+ *   3. The must-be-offline LAZY asset list (`__PRECACHE_LAZY_ASSETS__`) —
+ *      chunks not in the first-paint graph but needed offline, plus their
+ *      transitive deps (`@babel/standalone` — see
+ *      scripts/precache-lazy-assets.mjs). Kept SEPARATE because the SW
+ *      installs them `{ cache: 'reload' }`: they weren't first-painted and
+ *      their unhashed URLs carry per-deploy-varying bytes, so a default
+ *      fetch could copy a stale prior-deploy entry into this generation.
  *
- * Fails the build if either placeholder is missing — both are required
- * for the SW to behave correctly.
+ * Fails the build if any placeholder is missing — all are required for the
+ * SW to behave correctly.
  */
 import {readFileSync, writeFileSync, existsSync, readdirSync} from 'node:fs'
 import {execSync} from 'node:child_process'
@@ -98,8 +103,22 @@ const collectLazyPrecacheAssets = () =>
   }).map(toBaseUrl)
 
 const buildId = resolveBuildId()
-const precacheAssets = [
-  ...new Set([...collectPrecacheAssets(), ...collectLazyPrecacheAssets()]),
+
+// Two lists, fetched with DIFFERENT cache modes at install (see sw.js):
+//   - first-paint assets → { cache: 'default' }: the page just fetched these
+//     exact (unhashed) URLs, so the browser HTTP cache holds THIS generation's
+//     bytes — copying them into Cache Storage is near-free and correct.
+//   - lazy assets (Babel) → { cache: 'reload' }: these were NOT first-painted,
+//     and their URLs are unhashed with bytes that vary per deploy, so a
+//     { cache: 'default' } fetch could copy a STALE prior-deploy entry out of
+//     the HTTP cache into this generation's cache. 'reload' forces the network
+//     so the generation always gets its own bytes.
+// A chunk that IS first-painted (e.g. the shared rolldown runtime that Babel
+// also imports) stays in the first-paint list only — no double fetch.
+const firstPaintAssets = collectPrecacheAssets()
+const firstPaintSet = new Set(firstPaintAssets)
+const lazyPrecacheAssets = [
+  ...new Set(collectLazyPrecacheAssets().filter((u) => !firstPaintSet.has(u))),
 ].sort()
 
 let source = readFileSync(swPath, 'utf8')
@@ -112,14 +131,18 @@ const requirePlaceholder = (placeholder) => {
 }
 requirePlaceholder('__BUILD_ID__')
 requirePlaceholder('__PRECACHE_ASSETS__')
+requirePlaceholder('__PRECACHE_LAZY_ASSETS__')
 
-source = source.split('__BUILD_ID__').join(buildId)
 // Embed as a JSON string then JSON.parse at runtime so the array can
 // contain any number of entries without breaking the surrounding source.
-source = source.split('__PRECACHE_ASSETS__').join(
-  JSON.stringify(precacheAssets).replace(/\\/g, '\\\\').replace(/'/g, "\\'"),
-)
+const encodeArray = (arr) =>
+  JSON.stringify(arr).replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+
+source = source.split('__BUILD_ID__').join(buildId)
+source = source.split('__PRECACHE_ASSETS__').join(encodeArray(firstPaintAssets))
+source = source.split('__PRECACHE_LAZY_ASSETS__').join(encodeArray(lazyPrecacheAssets))
 writeFileSync(swPath, source)
 console.log(
-  `[inject-sw-build-id] stamped sw.js with ${buildId} and ${precacheAssets.length} precache assets`,
+  `[inject-sw-build-id] stamped sw.js with ${buildId}, ` +
+  `${firstPaintAssets.length} first-paint + ${lazyPrecacheAssets.length} lazy precache assets`,
 )

--- a/scripts/inject-sw-build-id.mjs
+++ b/scripts/inject-sw-build-id.mjs
@@ -9,7 +9,9 @@
  *      placeholder) so the install handler can fetch them up front. The
  *      initial module graph is dispatched by the browser before our SW
  *      activates, so without this list a first-time offline reload would
- *      fail to boot.
+ *      fail to boot. This covers the first-paint HTML graph PLUS a small
+ *      set of must-be-offline lazy chunks and their transitive deps
+ *      (`@babel/standalone` — see scripts/precache-lazy-assets.mjs).
  *
  * Fails the build if either placeholder is missing — both are required
  * for the SW to behave correctly.
@@ -18,6 +20,7 @@ import {readFileSync, writeFileSync, existsSync, readdirSync} from 'node:fs'
 import {execSync} from 'node:child_process'
 import {dirname, resolve, relative, sep} from 'node:path'
 import {fileURLToPath} from 'node:url'
+import {transitiveClosure} from './precache-lazy-assets.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const distDir = resolve(__dirname, '..', 'dist')
@@ -68,8 +71,36 @@ const collectPrecacheAssets = () => {
   return [...hrefs].sort()
 }
 
+// Lazy chunks that are NOT in the first-paint HTML graph but must be
+// offline-available — and their transitive sibling-chunk deps. Today this
+// is `@babel/standalone`, dynamically imported by compileExtensionModule
+// on a compile-cache miss; without re-precaching it, a cold offline
+// compile would fail (see scripts/precache-lazy-assets.mjs). Paths are
+// dist-relative (POSIX), stable + unhashed thanks to preserveModules.
+const LAZY_PRECACHE_ENTRYPOINTS = ['node_modules/@babel/standalone/babel.js']
+
+// Base-prefix a dist-relative path the same way Vite emits the
+// index.html-derived precache URLs (absolute, under the configured base),
+// so the two sets dedupe and the SW resolves them against its scope. Base
+// is read the same way vite.config.ts derives it.
+const base = (() => {
+  let b = process.env.APP_BASE_PATH?.trim() || '/'
+  if (!b.startsWith('/')) b = `/${b}`
+  if (!b.endsWith('/')) b = `${b}/`
+  return b
+})()
+const toBaseUrl = (rel) => `${base}${rel.replace(/^\/+/, '')}`
+
+const collectLazyPrecacheAssets = () =>
+  transitiveClosure(LAZY_PRECACHE_ENTRYPOINTS, {
+    exists: (rel) => existsSync(resolve(distDir, rel)),
+    readFile: (rel) => readFileSync(resolve(distDir, rel), 'utf8'),
+  }).map(toBaseUrl)
+
 const buildId = resolveBuildId()
-const precacheAssets = collectPrecacheAssets()
+const precacheAssets = [
+  ...new Set([...collectPrecacheAssets(), ...collectLazyPrecacheAssets()]),
+].sort()
 
 let source = readFileSync(swPath, 'utf8')
 

--- a/scripts/precache-lazy-assets.mjs
+++ b/scripts/precache-lazy-assets.mjs
@@ -29,7 +29,12 @@ import {posix} from 'node:path'
 // capture RELATIVE specifiers (`./` or `../`), which is what keeps a
 // `from "..."` sitting inside a module's body (Babel ships codegen
 // templates full of them) from being mistaken for a real graph edge.
-const FROM_IMPORT = /(?:^|\n)\s*(?:import|export)\b[^\n;'"`]*?\bfrom\s*["'](\.[^"']*)["']/g
+// The clause between `import`/`export` and `from` MAY span newlines (a
+// multi-line `import {\n a,\n b\n} from './x'`) — we still exclude
+// quotes/backticks/`;`, so a `from "..."` inside a string literal can't be
+// crossed into. `assertClosureComplete` (below) is the backstop for any
+// edge these miss.
+const FROM_IMPORT = /(?:^|\n)\s*(?:import|export)\b[^;'"`]*?\bfrom\s*["'](\.[^"']*)["']/g
 const BARE_IMPORT = /(?:^|\n)\s*import\s*["'](\.[^"']*)["']/g
 
 const relativeImports = (source) => {
@@ -38,6 +43,41 @@ const relativeImports = (source) => {
     for (const match of source.matchAll(re)) specs.add(match[1])
   }
   return [...specs]
+}
+
+// Broad relative-specifier matcher used ONLY to VERIFY the precise walk
+// above didn't drop an edge. Deliberately permissive — it also catches
+// dynamic `import("./x")`, which the static walk never follows — because a
+// precached chunk that imports a NON-precached chunk would 404 offline, and
+// we want that to be a loud build failure rather than a silent break. It is
+// safe to be loose: a match only matters when it RESOLVES to one of our
+// emitted chunks, so a relative path sitting in a code string (which won't
+// resolve to a chunk) can't cause a spurious failure.
+const VERIFY_REL_SPEC = /(?:\bfrom\s*|\bimport\s*\(\s*)["'](\.[^"']+)["']/g
+
+/**
+ * Backstop for {@link transitiveClosure}: assert every relative import edge
+ * out of a precached chunk lands inside the closure. Throws (fails the
+ * build) if a precached chunk references an emitted chunk that wasn't
+ * included — converting a silent offline break into a build error.
+ */
+const assertClosureComplete = (closure, {exists, readFile}) => {
+  const inClosure = new Set(closure)
+  const missing = new Set()
+  for (const rel of closure) {
+    for (const match of readFile(rel).matchAll(VERIFY_REL_SPEC)) {
+      const dep = posix.normalize(posix.join(posix.dirname(rel), match[1]))
+      if (exists(dep) && !inClosure.has(dep)) missing.add(`${rel} -> ${dep}`)
+    }
+  }
+  if (missing.size > 0) {
+    throw new Error(
+      '[precache] lazy-precache closure is INCOMPLETE — a precached chunk ' +
+      'imports an emitted chunk that was not included, so it would 404 ' +
+      'offline. The import-walk likely missed a form (multi-line or dynamic ' +
+      `import). Missing edges:\n  ${[...missing].join('\n  ')}`,
+    )
+  }
 }
 
 /**
@@ -77,5 +117,10 @@ export const transitiveClosure = (entryRelPaths, {exists, readFile}) => {
     }
   }
 
-  return [...seen].sort()
+  const closure = [...seen].sort()
+  // Backstop: fail loudly if the precise walk missed any edge (e.g. a
+  // dynamic import, or a form the regex doesn't model) rather than ship a
+  // chunk that 404s offline.
+  assertClosureComplete(closure, {exists, readFile})
+  return closure
 }

--- a/scripts/precache-lazy-assets.mjs
+++ b/scripts/precache-lazy-assets.mjs
@@ -1,0 +1,81 @@
+/**
+ * Transitive-closure walk over the emitted ESM module graph, used by
+ * `inject-sw-build-id.mjs` to precache lazy chunks that must stay
+ * offline-available.
+ *
+ * Why this exists: `@babel/standalone` (~0.85 MB gz) is dynamically
+ * imported by `compileExtensionModule` only when an extension's source
+ * needs (re)compiling. Removing its static import (#167) took it out of
+ * the first-paint HTML graph — and therefore out of the service worker's
+ * precache set — so a COLD offline compile (first boot after upgrade, or
+ * editing an extension before Babel was ever fetched) would fail. Adding
+ * the chunk back to the precache restores offline parity while keeping
+ * #167's actual win: Babel is still out of the eager `modulepreload` set
+ * and is never parsed/evaluated on boot, only fetched-from-cache + parsed
+ * when a compile actually runs.
+ *
+ * A lazy chunk can import sibling chunks (e.g. Babel pulls in the shared
+ * `_virtual/_rolldown/runtime.js`), so precaching just the entry file
+ * isn't enough — we follow its static relative imports transitively.
+ *
+ * Pure + dependency-injected (`exists` / `readFile` over dist-relative
+ * POSIX paths) so it unit-tests without touching the real filesystem.
+ */
+import {posix} from 'node:path'
+
+// Match the bundler-emitted static imports/exports that pull in a sibling
+// chunk. Two shapes: `import/export ... from './x'` and the bare
+// side-effect `import './x'`. Both are anchored to a line start and only
+// capture RELATIVE specifiers (`./` or `../`), which is what keeps a
+// `from "..."` sitting inside a module's body (Babel ships codegen
+// templates full of them) from being mistaken for a real graph edge.
+const FROM_IMPORT = /(?:^|\n)\s*(?:import|export)\b[^\n;'"`]*?\bfrom\s*["'](\.[^"']*)["']/g
+const BARE_IMPORT = /(?:^|\n)\s*import\s*["'](\.[^"']*)["']/g
+
+const relativeImports = (source) => {
+  const specs = new Set()
+  for (const re of [FROM_IMPORT, BARE_IMPORT]) {
+    for (const match of source.matchAll(re)) specs.add(match[1])
+  }
+  return [...specs]
+}
+
+/**
+ * Resolve the transitive closure of `entryRelPaths` (dist-relative POSIX
+ * paths) over static relative imports.
+ *
+ * @param {string[]} entryRelPaths - entry chunks; each MUST exist on disk
+ *   (a missing one means the build's chunk layout drifted — throws so the
+ *   build fails loudly rather than silently shipping a broken precache).
+ * @param {{exists: (rel: string) => boolean, readFile: (rel: string) => string}} fs
+ * @returns {string[]} every reachable chunk (incl. the entries), sorted.
+ */
+export const transitiveClosure = (entryRelPaths, {exists, readFile}) => {
+  const seen = new Set()
+  const stack = []
+
+  for (const rel of entryRelPaths) {
+    const norm = posix.normalize(rel)
+    if (!exists(norm)) {
+      throw new Error(`[precache] expected lazy precache entry missing: ${norm}`)
+    }
+    stack.push(norm)
+  }
+
+  while (stack.length > 0) {
+    const rel = stack.pop()
+    if (seen.has(rel)) continue
+    seen.add(rel)
+    for (const spec of relativeImports(readFile(rel))) {
+      const dep = posix.normalize(posix.join(posix.dirname(rel), spec))
+      if (seen.has(dep)) continue
+      // A spec that doesn't resolve to an emitted file is almost certainly
+      // a `from "..."` inside the module body, not a real edge — skip it
+      // (genuine bundler edges always exist) rather than fail the build.
+      if (!exists(dep)) continue
+      stack.push(dep)
+    }
+  }
+
+  return [...seen].sort()
+}

--- a/scripts/precache-lazy-assets.test.ts
+++ b/scripts/precache-lazy-assets.test.ts
@@ -21,6 +21,14 @@ describe('transitiveClosure', () => {
     ])
   })
 
+  it('follows a multi-line static import', () => {
+    const fs = fakeFs({
+      'a.js': 'import {\n  foo,\n  bar,\n} from "./b.js"\nconsole.log(foo, bar)',
+      'b.js': '',
+    })
+    expect(transitiveClosure(['a.js'], fs)).toEqual(['a.js', 'b.js'])
+  })
+
   it('ignores bare/external specifiers and only walks relative chunk edges', () => {
     const fs = fakeFs({
       'a.js': 'import "react"\nimport x from "@babel/core"\nimport y from "./b.js"',
@@ -51,5 +59,26 @@ describe('transitiveClosure', () => {
 
   it('throws when an entrypoint is missing (chunk layout drift)', () => {
     expect(() => transitiveClosure(['gone.js'], fakeFs({}))).toThrow(/missing/)
+  })
+
+  it('FAILS LOUDLY when a precached chunk imports an emitted chunk the walk missed', () => {
+    // A dynamic `import("./b.js")` isn't followed by the static walk, so b.js
+    // would be left out of the precache — the completeness backstop must catch
+    // it (it would 404 offline) and fail the build instead of silently shipping.
+    const fs = fakeFs({
+      'a.js': 'const load = () => import("./b.js")',
+      'b.js': '',
+    })
+    expect(() => transitiveClosure(['a.js'], fs)).toThrow(/INCOMPLETE/)
+  })
+
+  it('does not false-fail on a relative path that resolves to no emitted chunk', () => {
+    // A `from "./x"` inside a code string whose target isn't an emitted chunk
+    // must neither be walked nor trip the completeness backstop.
+    const fs = fakeFs({
+      'a.js': 'const code = `import z from "./nope.js"`\nimport y from "./b.js"',
+      'b.js': '',
+    })
+    expect(transitiveClosure(['a.js'], fs)).toEqual(['a.js', 'b.js'])
   })
 })

--- a/scripts/precache-lazy-assets.test.ts
+++ b/scripts/precache-lazy-assets.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from 'vitest'
+// @ts-expect-error - .mjs build helper without types
+import {transitiveClosure} from './precache-lazy-assets.mjs'
+
+/** Build an injected fs from a `{ relPath: source }` map. */
+const fakeFs = (files: Record<string, string>) => ({
+  exists: (rel: string) => Object.prototype.hasOwnProperty.call(files, rel),
+  readFile: (rel: string) => files[rel] ?? '',
+})
+
+describe('transitiveClosure', () => {
+  it('follows static relative imports transitively (Babel → shared runtime)', () => {
+    const fs = fakeFs({
+      'node_modules/@babel/standalone/babel.js':
+        'import { __commonJSMin } from "../../../_virtual/_rolldown/runtime.js";\nconsole.log(1)',
+      '_virtual/_rolldown/runtime.js': 'export const __commonJSMin = () => {}',
+    })
+    expect(transitiveClosure(['node_modules/@babel/standalone/babel.js'], fs)).toEqual([
+      '_virtual/_rolldown/runtime.js',
+      'node_modules/@babel/standalone/babel.js',
+    ])
+  })
+
+  it('ignores bare/external specifiers and only walks relative chunk edges', () => {
+    const fs = fakeFs({
+      'a.js': 'import "react"\nimport x from "@babel/core"\nimport y from "./b.js"',
+      'b.js': '',
+    })
+    expect(transitiveClosure(['a.js'], fs)).toEqual(['a.js', 'b.js'])
+  })
+
+  it('skips a relative spec that resolves to no emitted file (body false-positive, not an edge)', () => {
+    // A `from "./x"` inside a string/template must not fail the build or be
+    // precached when no such chunk exists.
+    const fs = fakeFs({
+      'a.js': 'const code = `\\nimport z from "./does-not-exist.js"\\n`\nimport y from "./b.js"',
+      'b.js': '',
+    })
+    expect(transitiveClosure(['a.js'], fs)).toEqual(['a.js', 'b.js'])
+  })
+
+  it('dedupes diamond dependencies', () => {
+    const fs = fakeFs({
+      'a.js': 'import b from "./b.js"\nimport c from "./c.js"',
+      'b.js': 'import d from "./d.js"',
+      'c.js': 'import d from "./d.js"',
+      'd.js': '',
+    })
+    expect(transitiveClosure(['a.js'], fs)).toEqual(['a.js', 'b.js', 'c.js', 'd.js'])
+  })
+
+  it('throws when an entrypoint is missing (chunk layout drift)', () => {
+    expect(() => transitiveClosure(['gone.js'], fakeFs({}))).toThrow(/missing/)
+  })
+})

--- a/src/data/repoProvider.ts
+++ b/src/data/repoProvider.ts
@@ -35,6 +35,7 @@ import { createSyncResolver, type SyncResolver } from '@/sync/keys/resolver.js'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
 import type { MaterializeDeps } from '@/data/internals/syncObserver/materialize.js'
 import { consumePendingWipe } from '@/sync/keys/flows/lockAndWipe.js'
+import { clearCompiledModuleCache } from '@/extensions/compiledModuleCache.js'
 import { removeOpfsDbFile } from '@/utils/exportSqliteDb.js'
 import {
   BLOCKS_SYNCED_RAW_TABLE,
@@ -199,8 +200,13 @@ export const ensurePowerSyncReady = async (
   // not hold an OPFS sync-access handle on a file being removed). A fresh init
   // then recreates an empty DB and re-syncs; e2ee workspaces re-enter their
   // locked state (their WKs were dropped at lock time) since the mode pins
-  // survive the wipe. Runs before any DB handle exists for this user.
-  await consumePendingWipe(userId, removeOpfsDbFile, dbFilenameForUser)
+  // survive the wipe. Runs before any DB handle exists for this user. Also drops
+  // the compiled-extension cache (a separate IndexedDB store of plaintext-derived
+  // source that the file delete wouldn't touch) — at this boot point no compile
+  // has run, so nothing can re-populate it.
+  await consumePendingWipe(userId, removeOpfsDbFile, dbFilenameForUser, {
+    clearCompiledCache: clearCompiledModuleCache,
+  })
 
   const db = getPowerSyncDb(userId)
 

--- a/src/extensions/compileExtensionModule.ts
+++ b/src/extensions/compileExtensionModule.ts
@@ -1,20 +1,34 @@
-import * as Babel from '@babel/standalone'
+import {
+  getCompiledModuleCache,
+  type CompiledModuleCache,
+  type CompiledRecord,
+} from '@/extensions/compiledModuleCache.js'
 
 // Bump when the Babel preset list / transform options change so older
-// in-memory cache entries don't deliver wrong-shaped output.
+// cache entries (in-memory OR persisted) don't deliver wrong-shaped
+// output. This is checked against the persisted record's
+// `compilerVersion`, NOT folded into the source hash — a compiler bump
+// must invalidate cached *output* without looking like a *source*
+// change (which Phase 2 / #67 would treat as needing re-approval).
 const COMPILER_VERSION = '1'
 
 export type ExtensionModule = Record<string, unknown>
 
 export interface CompileResult {
   module: ExtensionModule
+  /** Pure SHA-256 of the block source (no compiler-version salt). */
   contentHash: string
 }
 
 /**
- * A compile cache. The app uses a single shared instance (lives for
- * the lifetime of the page); tests construct their own instances to
+ * In-memory compile cache. The app uses a single shared instance (lives
+ * for the lifetime of the page); tests construct their own instances to
  * avoid cross-test pollution from the module-level singleton.
+ *
+ * This sits ABOVE the persistent {@link CompiledModuleCache}: an L1/L2
+ * hit returns a live module reference with no IndexedDB round-trip; only
+ * an L1 miss consults the persistent cache (and only a persistent miss
+ * loads Babel).
  */
 export interface CompileCache {
   // L1: contentHash -> in-flight or resolved compile.
@@ -42,17 +56,49 @@ export const createCompileCache = (): CompileCache => ({
 // compiled this session — eviction is a follow-up.
 const defaultCache = createCompileCache()
 
-// Underlying compile is injectable so tests can drive cache behavior
-// without depending on jsdom's blob-URL dynamic-import support.
-export type CompileImpl = (content: string) => Promise<ExtensionModule>
+// ──────────────────────────────────────────────────────────────────────
+// Injectable pipeline seams (test-only overrides)
+//
+// The compile pipeline is two steps so the persistent cache can store
+// the transpiled string and rebuild a module from it without Babel:
+//   transpile(source) -> JS string   (the expensive, Babel-loading half)
+//   instantiate(JS)   -> module       (blob-URL ESM import)
+//
+// `compileImpl` is a *full* override (source -> module) that bypasses
+// persistence + Babel entirely — kept for the many existing tests that
+// just want to hand back a module. When set, the persistent cache is not
+// touched.
+// ──────────────────────────────────────────────────────────────────────
 
-let compileImpl: CompileImpl = defaultCompileViaBabelBlob
+export type CompileImpl = (content: string) => Promise<ExtensionModule>
+export type TranspileImpl = (content: string) => Promise<string>
+export type InstantiateImpl = (compiled: string) => Promise<ExtensionModule>
+
+let compileImplOverride: CompileImpl | null = null
+let transpileImpl: TranspileImpl = defaultTranspileViaBabel
+let instantiateImpl: InstantiateImpl = defaultInstantiateViaBlob
 
 export function __setCompileImplForTest(impl: CompileImpl): () => void {
-  const previous = compileImpl
-  compileImpl = impl
+  const previous = compileImplOverride
+  compileImplOverride = impl
   return () => {
-    compileImpl = previous
+    compileImplOverride = previous
+  }
+}
+
+export function __setTranspileImplForTest(impl: TranspileImpl): () => void {
+  const previous = transpileImpl
+  transpileImpl = impl
+  return () => {
+    transpileImpl = previous
+  }
+}
+
+export function __setInstantiateImplForTest(impl: InstantiateImpl): () => void {
+  const previous = instantiateImpl
+  instantiateImpl = impl
+  return () => {
+    instantiateImpl = previous
   }
 }
 
@@ -64,41 +110,101 @@ export function __resetCompileCacheForTest(): void {
 const hexEncoder = (bytes: Uint8Array) =>
   Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
 
-async function hashContent(content: string): Promise<string> {
-  // Salt with COMPILER_VERSION so a transform-config change globally
-  // shifts every key (forcing recompilation).
-  const data = new TextEncoder().encode(`${COMPILER_VERSION}:${content}`)
+/** Pure SHA-256 of the source. The compiler version is intentionally NOT
+ *  mixed in here — see {@link COMPILER_VERSION}. */
+async function hashSource(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content)
   const digest = await crypto.subtle.digest('SHA-256', data)
   return hexEncoder(new Uint8Array(digest))
 }
 
-async function defaultCompileViaBabelBlob(content: string): Promise<ExtensionModule> {
+/** Transpile TS/JSX source to JS. Babel is loaded with a dynamic
+ *  `import()` so `@babel/standalone` (~0.85 MB gz) leaves the eager
+ *  startup preload set (#167) — it's fetched/evaluated only here, on a
+ *  genuine compile-cache miss. */
+async function defaultTranspileViaBabel(content: string): Promise<string> {
+  const Babel = await import('@babel/standalone')
   const transpiled = Babel.transform(content, {
     filename: 'extension-block.tsx',
     presets: ['react', 'typescript'],
   }).code
   if (!transpiled) throw new Error('Transpiled extension code is empty')
+  return transpiled
+}
 
-  const blob = new Blob([transpiled], {type: 'text/javascript'})
+/** Build an ESM module from already-transpiled JS via a blob URL. This
+ *  is the only step that touches the network/loader, and the only step
+ *  that runs on a persistent-cache hit (no Babel). */
+async function defaultInstantiateViaBlob(compiled: string): Promise<ExtensionModule> {
+  const blob = new Blob([compiled], {type: 'text/javascript'})
   const blobUrl = URL.createObjectURL(blob)
   try {
-    const module = (await import(/* @vite-ignore */ blobUrl)) as ExtensionModule
-    return module
+    return (await import(/* @vite-ignore */ blobUrl)) as ExtensionModule
   } finally {
     // Revoke as soon as the module's resolved — the JS engine has the
-    // module recorded against this URL and won't fetch it again. The old
-    // renderer pipeline leaked these.
+    // module recorded against this URL and won't fetch it again.
     URL.revokeObjectURL(blobUrl)
   }
 }
 
 /**
+ * Produce a module for a block, consulting the persistent compile cache
+ * before reaching for Babel:
+ *
+ *   1. persistent hit (same source hash + compiler version) → rebuild
+ *      from the cached JS string. **Babel is not loaded.**
+ *   2. miss → transpile (loads Babel), persist the output, instantiate.
+ *
+ * A flaky persistent read/write must never break extension loading, so
+ * both are best-effort: a failed read is treated as a miss, a failed
+ * write is logged and ignored (the freshly compiled module is still
+ * returned).
+ */
+async function buildModule(
+  content: string,
+  sourceHash: string,
+  blockId: string,
+  persistent: CompiledModuleCache,
+): Promise<ExtensionModule> {
+  // Full test override: bypass persistence + Babel entirely.
+  if (compileImplOverride) return compileImplOverride(content)
+
+  let cached: CompiledRecord | undefined
+  try {
+    cached = await persistent.read(blockId)
+  } catch (error) {
+    console.warn(`Extension compile cache read failed for ${blockId}`, error)
+  }
+  if (
+    cached &&
+    cached.sourceHash === sourceHash &&
+    cached.compilerVersion === COMPILER_VERSION
+  ) {
+    return instantiateImpl(cached.compiled)
+  }
+
+  const compiled = await transpileImpl(content)
+  try {
+    await persistent.write(blockId, {
+      sourceHash,
+      compiled,
+      compilerVersion: COMPILER_VERSION,
+    })
+  } catch (error) {
+    console.warn(`Extension compile cache write failed for ${blockId}`, error)
+  }
+  return instantiateImpl(compiled)
+}
+
+/**
  * Compile a block's content into a module. Caches by content hash (L1)
  * and by blockId (L2) so unchanged blocks return identical module
- * references across runtime resolutions.
+ * references across runtime resolutions, and persists transpiled output
+ * (L3, via {@link CompiledModuleCache}) so a warm boot skips Babel.
  *
- * Pass a `cache` instance to scope caching (tests use this for
- * isolation). Omit to use the process-wide singleton.
+ * Pass a `cache` instance to scope in-memory caching (tests use this for
+ * isolation), and a `persistent` instance to scope the cross-reload
+ * cache. Omit either to use the process-wide singletons.
  *
  * Throws if compilation fails — caller is expected to catch and report.
  */
@@ -106,8 +212,9 @@ export async function compileExtensionModule(
   content: string,
   blockId: string,
   cache: CompileCache = defaultCache,
+  persistent: CompiledModuleCache = getCompiledModuleCache(),
 ): Promise<CompileResult> {
-  const contentHash = await hashContent(content)
+  const contentHash = await hashSource(content)
 
   // L2 hit: same block + same content → reuse the module reference.
   const cachedForBlock = cache.byBlock.get(blockId)
@@ -122,7 +229,7 @@ export async function compileExtensionModule(
   // source.
   let modulePromise = cache.byHash.get(contentHash)
   if (!modulePromise) {
-    modulePromise = compileImpl(content)
+    modulePromise = buildModule(content, contentHash, blockId, persistent)
     cache.byHash.set(contentHash, modulePromise)
     // Don't poison the cache forever on a transient failure: drop the
     // rejected promise from BOTH cache layers so the next call retries.
@@ -149,6 +256,10 @@ export async function compileExtensionModule(
  * Drop a block's entry from L2. Use when a block is deleted so its
  * modulePromise is eligible for GC. (L1 entry under the old hash may
  * survive — that's acceptable since other blocks could share it.)
+ *
+ * Note: this clears only the in-memory layer. The persisted row is
+ * keyed by blockId and overwritten on source change, so it's bounded;
+ * wiring its deletion to extension uninstall is a Phase-2 concern.
  */
 export function evictBlockFromCache(
   blockId: string,

--- a/src/extensions/compiledModuleCache.ts
+++ b/src/extensions/compiledModuleCache.ts
@@ -46,6 +46,14 @@ export interface CompiledModuleCache {
   read(blockId: string): Promise<CompiledRecord | undefined>
   write(blockId: string, record: CompiledRecord): Promise<void>
   delete(blockId: string): Promise<void>
+  /** Drop every row. This is a derived cache of (potentially
+   *  E2EE-workspace) extension *source*, so the §6 lock & wipe flow
+   *  clears it to avoid leaving plaintext behind after the SQLite DB is
+   *  wiped. The store has no per-user/per-workspace dimension (keyed only
+   *  by the globally-unique blockId), so the clear is coarse — but
+   *  over-clearing is harmless here: unlike workspace keys, a dropped
+   *  compiled row only costs a one-time recompile, never a lockout. */
+  clear(): Promise<void>
 }
 
 /** In-memory store. Used in tests and as the fallback when IndexedDB is
@@ -65,6 +73,10 @@ export class InMemoryCompiledModuleCache implements CompiledModuleCache {
 
   async delete(blockId: string): Promise<void> {
     this.rows.delete(blockId)
+  }
+
+  async clear(): Promise<void> {
+    this.rows.clear()
   }
 }
 
@@ -144,6 +156,10 @@ export class IndexedDbCompiledModuleCache implements CompiledModuleCache {
 
   async delete(blockId: string): Promise<void> {
     await this.tx('readwrite', store => store.delete(blockId))
+  }
+
+  async clear(): Promise<void> {
+    await this.tx('readwrite', store => store.clear())
   }
 }
 

--- a/src/extensions/compiledModuleCache.ts
+++ b/src/extensions/compiledModuleCache.ts
@@ -1,0 +1,166 @@
+/**
+ * Persistent (cross-reload) compile cache for extension modules.
+ *
+ * Issue #167: `@babel/standalone` (~0.85 MB gz) is needed *only* to
+ * transpile an extension block's TS/JSX source into runnable JS. The
+ * in-memory cache in `compileExtensionModule.ts` is empty on every cold
+ * start, so the current fleet — where every user has ≥1 enabled
+ * extension — re-runs Babel on every boot. Persisting the transpiled JS
+ * lets a warm boot rebuild the module from the cached string via the
+ * blob-URL path WITHOUT loading Babel at all; Babel is then fetched only
+ * on a genuine cache miss (first-ever compile or the source changed).
+ *
+ * Storage shape — one self-contained row per block — is deliberately the
+ * Phase-2 "approval record" shape running in implicit auto-approve mode:
+ * issue #67 layers a device-local trust gate on top of the same row
+ * (binding execution to an approved `sourceHash`). Keying by `blockId`
+ * (a globally-unique id) keeps the store bounded by the number of
+ * installed extensions — a row is overwritten when its source changes,
+ * so there is nothing to evict.
+ *
+ * Mirrors the interface + in-memory-fallback + IndexedDB pattern of
+ * `sync/keys/keyStore.ts`. Unlike that store — which holds a
+ * non-cloneable `CryptoKey` and therefore can't run under Node's
+ * `structuredClone` — our records are plain JSON, so the IndexedDB path
+ * is exercised directly in tests via `fake-indexeddb`.
+ */
+
+export interface CompiledRecord {
+  /** Pure SHA-256 of the block's source. NOT salted by compiler version
+   *  (that lives in `compilerVersion`) — Phase 2 reuses this exact hash
+   *  as the content the user approves, and a compiler bump must not look
+   *  like a source change. */
+  sourceHash: string
+  /** Transpiled JS string (Babel output) ready for blob-URL import. */
+  compiled: string
+  /** The `COMPILER_VERSION` the `compiled` string was produced under. A
+   *  bump invalidates the row (forces recompile) while leaving
+   *  `sourceHash` — and therefore any Phase-2 approval — intact. */
+  compilerVersion: string
+}
+
+/** A device-local store of transpiled extension modules, keyed by block
+ *  id. All operations are async (IndexedDB) and must tolerate being
+ *  called when persistence is unavailable — see the in-memory fallback. */
+export interface CompiledModuleCache {
+  read(blockId: string): Promise<CompiledRecord | undefined>
+  write(blockId: string, record: CompiledRecord): Promise<void>
+  delete(blockId: string): Promise<void>
+}
+
+/** In-memory store. Used in tests and as the fallback when IndexedDB is
+ *  unavailable (private-mode, SSR, etc.) — persistence then degrades to
+ *  "per page lifetime", which just means the next cold start recompiles
+ *  via Babel, exactly the pre-#167 behavior. */
+export class InMemoryCompiledModuleCache implements CompiledModuleCache {
+  private readonly rows = new Map<string, CompiledRecord>()
+
+  async read(blockId: string): Promise<CompiledRecord | undefined> {
+    return this.rows.get(blockId)
+  }
+
+  async write(blockId: string, record: CompiledRecord): Promise<void> {
+    this.rows.set(blockId, record)
+  }
+
+  async delete(blockId: string): Promise<void> {
+    this.rows.delete(blockId)
+  }
+}
+
+export const DB_NAME = 'km-extension-compiled'
+export const STORE_NAME = 'compiled_modules'
+const DB_VERSION = 1
+
+const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+
+/** IndexedDB-backed store. The values are plain JSON, so unlike
+ *  `keyStore.ts` this path runs fine under `fake-indexeddb` in tests. */
+export class IndexedDbCompiledModuleCache implements CompiledModuleCache {
+  private dbPromise: Promise<IDBDatabase> | null = null
+
+  private openDb(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, DB_VERSION)
+        request.onupgradeneeded = () => {
+          const db = request.result
+          if (!db.objectStoreNames.contains(STORE_NAME)) {
+            db.createObjectStore(STORE_NAME)
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      }).catch((err: unknown) => {
+        // Don't cache a rejected open: a transient failure (storage
+        // pressure, a racing version upgrade) would otherwise wedge every
+        // later read/write on this instance. Clear the handle so the next
+        // call retries a fresh open — a missed read just recompiles.
+        this.dbPromise = null
+        throw err
+      })
+    }
+    return this.dbPromise
+  }
+
+  private async tx<T>(
+    mode: IDBTransactionMode,
+    run: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    const db = await this.openDb()
+    const transaction = db.transaction(STORE_NAME, mode)
+    // Resolve on the transaction commit (`oncomplete`), not just the
+    // request's `onsuccess` — a write is only durable once the tx
+    // commits, and the cross-reload read in our tests depends on that
+    // durability. Register handlers synchronously so a commit that fires
+    // before we await can't be missed.
+    const committed = new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => resolve()
+      transaction.onabort = () =>
+        reject(transaction.error ?? new Error('IndexedDB transaction aborted'))
+      transaction.onerror = () =>
+        reject(transaction.error ?? new Error('IndexedDB transaction error'))
+    })
+    const store = transaction.objectStore(STORE_NAME)
+    const result = await promisifyRequest(run(store))
+    await committed
+    return result
+  }
+
+  async read(blockId: string): Promise<CompiledRecord | undefined> {
+    const result = await this.tx<CompiledRecord | undefined>('readonly', store =>
+      store.get(blockId),
+    )
+    return result ?? undefined
+  }
+
+  async write(blockId: string, record: CompiledRecord): Promise<void> {
+    await this.tx('readwrite', store => store.put(record, blockId))
+  }
+
+  async delete(blockId: string): Promise<void> {
+    await this.tx('readwrite', store => store.delete(blockId))
+  }
+}
+
+/** Pick the IndexedDB store when available, else the in-memory fallback. */
+export const createCompiledModuleCache = (): CompiledModuleCache => {
+  try {
+    if (typeof indexedDB !== 'undefined') {
+      return new IndexedDbCompiledModuleCache()
+    }
+  } catch {
+    // fall through to in-memory
+  }
+  return new InMemoryCompiledModuleCache()
+}
+
+// Process-wide singleton shared by the loader. Tests inject their own
+// instance and never touch this.
+let sharedCache: CompiledModuleCache | null = null
+export const getCompiledModuleCache = (): CompiledModuleCache =>
+  (sharedCache ??= createCompiledModuleCache())

--- a/src/extensions/compiledModuleCache.ts
+++ b/src/extensions/compiledModuleCache.ts
@@ -14,9 +14,13 @@
  * Phase-2 "approval record" shape running in implicit auto-approve mode:
  * issue #67 layers a device-local trust gate on top of the same row
  * (binding execution to an approved `sourceHash`). Keying by `blockId`
- * (a globally-unique id) keeps the store bounded by the number of
- * installed extensions — a row is overwritten when its source changes,
- * so there is nothing to evict.
+ * (a globally-unique id) means each LIVE extension occupies exactly one
+ * row (overwritten when its source changes). Deleting a block leaves its
+ * row orphaned — there is no production `delete`/evict caller yet (that's
+ * Phase 2) — so the row count tracks cumulative blockId churn, not the
+ * current extension count. The lock & wipe path empties the whole store
+ * (`clearCompiledModuleCache`), which is the only thing that bounds it
+ * today.
  *
  * Mirrors the interface + in-memory-fallback + IndexedDB pattern of
  * `sync/keys/keyStore.ts`. Unlike that store — which holds a
@@ -46,13 +50,14 @@ export interface CompiledModuleCache {
   read(blockId: string): Promise<CompiledRecord | undefined>
   write(blockId: string, record: CompiledRecord): Promise<void>
   delete(blockId: string): Promise<void>
-  /** Drop every row. This is a derived cache of (potentially
-   *  E2EE-workspace) extension *source*, so the §6 lock & wipe flow
-   *  clears it to avoid leaving plaintext behind after the SQLite DB is
-   *  wiped. The store has no per-user/per-workspace dimension (keyed only
-   *  by the globally-unique blockId), so the clear is coarse — but
-   *  over-clearing is harmless here: unlike workspace keys, a dropped
-   *  compiled row only costs a one-time recompile, never a lockout. */
+  /** Empty the whole store. Used by §6 lock & wipe's boot-time half to
+   *  drop plaintext-derived extension source that lives OUTSIDE the
+   *  per-user SQLite file. Clearing through a transaction (rather than
+   *  `deleteDatabase`) is deliberate: a delete is BLOCKED by any
+   *  concurrent connection — a sibling tab mid-reload during the wipe is
+   *  exactly that — whereas a readwrite `clear()` is not. Coarse (no
+   *  per-user/workspace dimension), but over-clearing only costs a
+   *  recompile, never a lockout. */
   clear(): Promise<void>
 }
 
@@ -180,3 +185,25 @@ export const createCompiledModuleCache = (): CompiledModuleCache => {
 let sharedCache: CompiledModuleCache | null = null
 export const getCompiledModuleCache = (): CompiledModuleCache =>
   (sharedCache ??= createCompiledModuleCache())
+
+/**
+ * Empty the compiled-module store, best-effort and never-rejecting. Used
+ * by §6 lock & wipe's boot-time half (`consumePendingWipe`) to remove
+ * plaintext-derived extension source that lives OUTSIDE the per-user
+ * SQLite file the wipe deletes.
+ *
+ * Goes through the cache's `clear()` (a readwrite transaction) rather than
+ * `indexedDB.deleteDatabase`: a database delete is blocked by any
+ * concurrent connection — a sibling tab still mid-reload during the wipe
+ * is exactly that — and could silently no-op, whereas a `clear()` tx
+ * isn't blocked by other connections. Swallows any error: a derived cache
+ * must never strand the boot or the wipe (the load-bearing plaintext
+ * removal is the SQLite file delete).
+ */
+export const clearCompiledModuleCache = async (): Promise<void> => {
+  try {
+    await getCompiledModuleCache().clear()
+  } catch (error) {
+    console.warn('Failed to clear compiled-extension cache', error)
+  }
+}

--- a/src/extensions/test/compiledModuleCache.test.ts
+++ b/src/extensions/test/compiledModuleCache.test.ts
@@ -59,6 +59,15 @@ describe('CompiledModuleCache stores', () => {
         await store.delete(`${name}-del`)
         expect(await store.read(`${name}-del`)).toBeUndefined()
       })
+
+      it('clear() drops every row (lock & wipe)', async () => {
+        const store = make()
+        await store.write(`${name}-c1`, record({compiled: 'A'}))
+        await store.write(`${name}-c2`, record({compiled: 'B'}))
+        await store.clear()
+        expect(await store.read(`${name}-c1`)).toBeUndefined()
+        expect(await store.read(`${name}-c2`)).toBeUndefined()
+      })
     })
   }
 
@@ -161,6 +170,7 @@ describe('compileExtensionModule — persistent (L3) cache', () => {
       read: async () => { throw new Error('read boom') },
       write: async () => {},
       delete: async () => {},
+      clear: async () => {},
     }
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -174,6 +184,7 @@ describe('compileExtensionModule — persistent (L3) cache', () => {
       read: async () => undefined,
       write: async () => { throw new Error('write boom') },
       delete: async () => {},
+      clear: async () => {},
     }
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/src/extensions/test/compiledModuleCache.test.ts
+++ b/src/extensions/test/compiledModuleCache.test.ts
@@ -6,6 +6,8 @@ import 'fake-indexeddb/auto'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {
+  clearCompiledModuleCache,
+  getCompiledModuleCache,
   IndexedDbCompiledModuleCache,
   InMemoryCompiledModuleCache,
   type CompiledModuleCache,
@@ -60,7 +62,7 @@ describe('CompiledModuleCache stores', () => {
         expect(await store.read(`${name}-del`)).toBeUndefined()
       })
 
-      it('clear() drops every row (lock & wipe)', async () => {
+      it('clear() empties every row', async () => {
         const store = make()
         await store.write(`${name}-c1`, record({compiled: 'A'}))
         await store.write(`${name}-c2`, record({compiled: 'B'}))
@@ -79,6 +81,21 @@ describe('CompiledModuleCache stores', () => {
     // same named DB — the row must still be there.
     const reader = new IndexedDbCompiledModuleCache()
     expect(await reader.read('reload-block')).toMatchObject({compiled: 'PERSISTED'})
+  })
+
+  it('clearCompiledModuleCache empties the store via a connection (§6 lock & wipe, boot)', async () => {
+    // Operates on the process singleton (IndexedDB-backed in this file).
+    const cache = getCompiledModuleCache()
+    await cache.write('wipe-a', record({compiled: 'A'}))
+    await cache.write('wipe-b', record({compiled: 'B'}))
+
+    await clearCompiledModuleCache()
+
+    expect(await cache.read('wipe-a')).toBeUndefined()
+    expect(await cache.read('wipe-b')).toBeUndefined()
+    // Store is still usable (clear empties rows, doesn't drop the store).
+    await cache.write('wipe-c', record({compiled: 'C'}))
+    expect(await cache.read('wipe-c')).toMatchObject({compiled: 'C'})
   })
 })
 
@@ -115,6 +132,29 @@ describe('compileExtensionModule — persistent (L3) cache', () => {
 
     expect(transpileCount).toBe(1)
     expect(result.module).toEqual({default: 'transpiled:SRC'})
+    expect(await persistent.read('block-1')).toMatchObject({
+      compiled: 'transpiled:SRC',
+      compilerVersion: '1',
+    })
+  })
+
+  it('persists the transpiled output BEFORE instantiating (a failing instantiate still leaves a valid row)', async () => {
+    // Ordering contract: the row holds the *transpiled JS*, which is valid even
+    // when the module throws at import-eval. So a transpile-success /
+    // instantiate-failure persists a good row, and the next load skips Babel —
+    // the failure is in the module code, not the cache. Pin it so a reorder
+    // (e.g. persisting only after a successful instantiate) is caught.
+    restoreInstantiate()
+    restoreInstantiate = __setInstantiateImplForTest(async () => {
+      throw new Error('module threw at import-eval')
+    })
+    const persistent = new InMemoryCompiledModuleCache()
+
+    await expect(
+      compileExtensionModule('SRC', 'block-1', createCompileCache(), persistent),
+    ).rejects.toThrow(/import-eval/)
+
+    expect(transpileCount).toBe(1)
     expect(await persistent.read('block-1')).toMatchObject({
       compiled: 'transpiled:SRC',
       compilerVersion: '1',

--- a/src/extensions/test/compiledModuleCache.test.ts
+++ b/src/extensions/test/compiledModuleCache.test.ts
@@ -1,0 +1,183 @@
+// File-scoped IndexedDB polyfill — sets global `indexedDB`/`IDBKeyRange`
+// for this test file only (vitest isolates modules per file), so the
+// real IndexedDbCompiledModuleCache path runs in Node. Our records are
+// plain JSON, so unlike keyStore's CryptoKey this clones fine.
+import 'fake-indexeddb/auto'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+  IndexedDbCompiledModuleCache,
+  InMemoryCompiledModuleCache,
+  type CompiledModuleCache,
+  type CompiledRecord,
+} from '@/extensions/compiledModuleCache'
+import {
+  __setInstantiateImplForTest,
+  __setTranspileImplForTest,
+  compileExtensionModule,
+  createCompileCache,
+} from '@/extensions/compileExtensionModule'
+
+const record = (over: Partial<CompiledRecord> = {}): CompiledRecord => ({
+  sourceHash: 'hash-1',
+  compiled: 'export default 1',
+  compilerVersion: '1',
+  ...over,
+})
+
+describe('CompiledModuleCache stores', () => {
+  // Run the same contract against both implementations. The IndexedDB
+  // one uses fake-indexeddb; a fresh instance reopening the same DB is
+  // how we model a page reload.
+  const stores: Array<[string, () => CompiledModuleCache]> = [
+    ['InMemoryCompiledModuleCache', () => new InMemoryCompiledModuleCache()],
+    ['IndexedDbCompiledModuleCache', () => new IndexedDbCompiledModuleCache()],
+  ]
+
+  for (const [name, make] of stores) {
+    describe(name, () => {
+      it('round-trips a record', async () => {
+        const store = make()
+        await store.write(`${name}-rt`, record({compiled: 'CODE'}))
+        expect(await store.read(`${name}-rt`)).toMatchObject({compiled: 'CODE'})
+      })
+
+      it('returns undefined for an unknown block', async () => {
+        expect(await make().read(`${name}-missing`)).toBeUndefined()
+      })
+
+      it('overwrites the row for the same block id', async () => {
+        const store = make()
+        await store.write(`${name}-ow`, record({sourceHash: 'a', compiled: 'A'}))
+        await store.write(`${name}-ow`, record({sourceHash: 'b', compiled: 'B'}))
+        expect(await store.read(`${name}-ow`)).toMatchObject({sourceHash: 'b', compiled: 'B'})
+      })
+
+      it('deletes a row', async () => {
+        const store = make()
+        await store.write(`${name}-del`, record())
+        await store.delete(`${name}-del`)
+        expect(await store.read(`${name}-del`)).toBeUndefined()
+      })
+    })
+  }
+
+  it('IndexedDB row survives a "reload" (fresh instance, same DB)', async () => {
+    const writer = new IndexedDbCompiledModuleCache()
+    await writer.write('reload-block', record({compiled: 'PERSISTED'}))
+
+    // A brand-new instance has its own connection handle but reopens the
+    // same named DB — the row must still be there.
+    const reader = new IndexedDbCompiledModuleCache()
+    expect(await reader.read('reload-block')).toMatchObject({compiled: 'PERSISTED'})
+  })
+})
+
+describe('compileExtensionModule — persistent (L3) cache', () => {
+  let transpileCount = 0
+  let restoreTranspile: () => void
+  let restoreInstantiate: () => void
+
+  beforeEach(() => {
+    transpileCount = 0
+    // Stub the pipeline so no real Babel / blob-URL import runs: transpile
+    // tags the source, instantiate exposes which compiled string it built
+    // from so we can assert the cache fed it (not Babel).
+    restoreTranspile = __setTranspileImplForTest(async (content) => {
+      transpileCount += 1
+      return `transpiled:${content}`
+    })
+    restoreInstantiate = __setInstantiateImplForTest(async (compiled) => ({
+      default: compiled,
+    }))
+  })
+
+  afterEach(() => {
+    restoreInstantiate()
+    restoreTranspile()
+    vi.restoreAllMocks()
+  })
+
+  it('compiles on a cold miss and persists the transpiled output', async () => {
+    const persistent = new InMemoryCompiledModuleCache()
+    const result = await compileExtensionModule(
+      'SRC', 'block-1', createCompileCache(), persistent,
+    )
+
+    expect(transpileCount).toBe(1)
+    expect(result.module).toEqual({default: 'transpiled:SRC'})
+    expect(await persistent.read('block-1')).toMatchObject({
+      compiled: 'transpiled:SRC',
+      compilerVersion: '1',
+    })
+  })
+
+  it('serves a warm reload from the persistent cache WITHOUT re-transpiling', async () => {
+    // Use a real (fake-indexeddb) store and two separate cache instances
+    // to model: compile this session, reload, compile next session.
+    const session1Persistent = new IndexedDbCompiledModuleCache()
+    await compileExtensionModule('SRC', 'warm-1', createCompileCache(), session1Persistent)
+    expect(transpileCount).toBe(1)
+
+    // Fresh in-memory L1/L2 (page reload) + fresh store handle (same DB).
+    const session2Persistent = new IndexedDbCompiledModuleCache()
+    const result = await compileExtensionModule(
+      'SRC', 'warm-1', createCompileCache(), session2Persistent,
+    )
+
+    expect(transpileCount).toBe(1) // Babel/transpile not loaded again
+    expect(result.module).toEqual({default: 'transpiled:SRC'})
+  })
+
+  it('recompiles when the stored output was built under a different compiler version', async () => {
+    const persistent = new InMemoryCompiledModuleCache()
+    await compileExtensionModule('SRC', 'cv-1', createCompileCache(), persistent)
+    expect(transpileCount).toBe(1)
+
+    // Simulate a COMPILER_VERSION bump: same source hash, stale output.
+    const stored = await persistent.read('cv-1')
+    await persistent.write('cv-1', {...stored!, compilerVersion: 'stale'})
+
+    await compileExtensionModule('SRC', 'cv-1', createCompileCache(), persistent)
+    expect(transpileCount).toBe(2) // invalidated → recompiled
+  })
+
+  it('recompiles and overwrites the row when the source changes', async () => {
+    const persistent = new InMemoryCompiledModuleCache()
+    await compileExtensionModule('V1', 'src-1', createCompileCache(), persistent)
+    const first = await persistent.read('src-1')
+
+    const result = await compileExtensionModule('V2', 'src-1', createCompileCache(), persistent)
+    expect(transpileCount).toBe(2)
+    expect(result.module).toEqual({default: 'transpiled:V2'})
+
+    const second = await persistent.read('src-1')
+    expect(second!.compiled).toBe('transpiled:V2')
+    expect(second!.sourceHash).not.toBe(first!.sourceHash)
+  })
+
+  it('still compiles when the persistent read fails (treated as a miss)', async () => {
+    const flaky: CompiledModuleCache = {
+      read: async () => { throw new Error('read boom') },
+      write: async () => {},
+      delete: async () => {},
+    }
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await compileExtensionModule('SRC', 'r-1', createCompileCache(), flaky)
+    expect(transpileCount).toBe(1)
+    expect(result.module).toEqual({default: 'transpiled:SRC'})
+  })
+
+  it('still returns the module when the persistent write fails', async () => {
+    const flaky: CompiledModuleCache = {
+      read: async () => undefined,
+      write: async () => { throw new Error('write boom') },
+      delete: async () => {},
+    }
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await compileExtensionModule('SRC', 'w-1', createCompileCache(), flaky)
+    expect(result.module).toEqual({default: 'transpiled:SRC'})
+  })
+})

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -81,6 +81,7 @@ import {
 } from '@/utils/exportSqliteDb.js'
 import { broadcastWipeReload, flushUploadQueue, lockAndWipe } from '@/sync/keys/flows/lockAndWipe.js'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
+import { getCompiledModuleCache } from '@/extensions/compiledModuleCache.js'
 import { getPowerSyncDb } from '@/data/repoProvider.js'
 import { focusPropertyRow } from '@/utils/propertyNavigation.js'
 import { reloadInSafeMode } from '@/utils/safeMode.js'
@@ -559,7 +560,11 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           }
 
           banner.update('Wiping local data — reloading…')
-          await lockAndWipe({ userId: repo.user.id, keyStore: getWorkspaceKeyStore() })
+          await lockAndWipe({
+            userId: repo.user.id,
+            keyStore: getWorkspaceKeyStore(),
+            compiledCache: getCompiledModuleCache(),
+          })
           // Reload every other same-user tab too (multi-tab): otherwise they
           // keep the wiped plaintext in memory and hold the OPFS DB handle open,
           // blocking the boot-time file delete. Then reload self — the armed

--- a/src/shortcuts/defaultShortcuts.ts
+++ b/src/shortcuts/defaultShortcuts.ts
@@ -81,7 +81,6 @@ import {
 } from '@/utils/exportSqliteDb.js'
 import { broadcastWipeReload, flushUploadQueue, lockAndWipe } from '@/sync/keys/flows/lockAndWipe.js'
 import { getWorkspaceKeyStore } from '@/sync/keys/keyStore.js'
-import { getCompiledModuleCache } from '@/extensions/compiledModuleCache.js'
 import { getPowerSyncDb } from '@/data/repoProvider.js'
 import { focusPropertyRow } from '@/utils/propertyNavigation.js'
 import { reloadInSafeMode } from '@/utils/safeMode.js'
@@ -560,11 +559,7 @@ export function getDefaultActionGroups({repo}: { repo: Repo }) {
           }
 
           banner.update('Wiping local data — reloading…')
-          await lockAndWipe({
-            userId: repo.user.id,
-            keyStore: getWorkspaceKeyStore(),
-            compiledCache: getCompiledModuleCache(),
-          })
+          await lockAndWipe({ userId: repo.user.id, keyStore: getWorkspaceKeyStore() })
           // Reload every other same-user tab too (multi-tab): otherwise they
           // keep the wiped plaintext in memory and hold the OPFS DB handle open,
           // blocking the boot-time file delete. Then reload self — the armed

--- a/src/sync/keys/flows/lockAndWipe.test.ts
+++ b/src/sync/keys/flows/lockAndWipe.test.ts
@@ -182,35 +182,46 @@ describe('lockAndWipe commit (§6)', () => {
     expect(isPendingWipe(USER)).toBe(false)
   })
 
-  it('clears the compiled-extension cache so no plaintext survives the wipe', async () => {
-    const keyStore = new InMemoryWorkspaceKeyStore()
-    const compiledCache = { clear: vi.fn(async () => {}) }
-
-    await lockAndWipe({ userId: USER, keyStore, compiledCache })
-
-    expect(compiledCache.clear).toHaveBeenCalledTimes(1)
-    expect(isPendingWipe(USER)).toBe(true)
-  })
-
-  it('refuses the wipe (no keys dropped, no marker) when the compiled-cache clear fails', async () => {
-    // The compiled cache is plaintext-derived source the wipe must remove, so a
-    // clear failure has to BLOCK the wipe — not report success while it lingers.
-    // Clearing first means we refuse before anything destructive happens.
-    const keyStore = new InMemoryWorkspaceKeyStore()
-    const clearForUser = vi.spyOn(keyStore, 'clearForUser')
-    const compiledCache = { clear: vi.fn(async () => { throw new Error('idb clear boom') }) }
-
-    await expect(
-      lockAndWipe({ userId: USER, keyStore, compiledCache }),
-    ).rejects.toThrow(/idb clear boom/)
-
-    expect(clearForUser).not.toHaveBeenCalled()
-    expect(isPendingWipe(USER)).toBe(false)
-  })
 })
 
 describe('consumePendingWipe (boot-time, §6)', () => {
   const resolveFilename = (userId: string) => `kmp-v6-${userId}.db`
+
+  it('drops the compiled-extension cache when a wipe is armed (before the file delete)', async () => {
+    markPendingWipe(USER)
+    const order: string[] = []
+    const clearCompiledCache = vi.fn(async () => { order.push('compiled') })
+    const remove = vi.fn(async () => { order.push('file') })
+
+    const wiped = await consumePendingWipe(USER, remove, resolveFilename, {clearCompiledCache})
+
+    expect(wiped).toBe(true)
+    expect(clearCompiledCache).toHaveBeenCalledTimes(1)
+    // Compiled cache is dropped before the (possibly retrying) file delete.
+    expect(order).toEqual(['compiled', 'file'])
+  })
+
+  it('does not touch the compiled-extension cache when no wipe is armed', async () => {
+    const clearCompiledCache = vi.fn(async () => {})
+    await consumePendingWipe(USER, vi.fn().mockResolvedValue(undefined), resolveFilename, {
+      clearCompiledCache,
+    })
+    expect(clearCompiledCache).not.toHaveBeenCalled()
+  })
+
+  it('still wipes (best-effort) when the compiled-cache clear rejects — a derived cache must not block the wipe', async () => {
+    markPendingWipe(USER)
+    const clearCompiledCache = vi.fn(async () => { throw new Error('idb gone') })
+    const remove = vi.fn().mockResolvedValue(undefined)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const wiped = await consumePendingWipe(USER, remove, resolveFilename, {clearCompiledCache})
+
+    expect(wiped).toBe(true)
+    expect(remove).toHaveBeenCalledWith('kmp-v6-user-1.db')
+    expect(isPendingWipe(USER)).toBe(false)
+    warn.mockRestore()
+  })
 
   it('does nothing when no wipe is armed', async () => {
     const remove = vi.fn().mockResolvedValue(undefined)

--- a/src/sync/keys/flows/lockAndWipe.test.ts
+++ b/src/sync/keys/flows/lockAndWipe.test.ts
@@ -187,7 +187,7 @@ describe('lockAndWipe commit (§6)', () => {
 describe('consumePendingWipe (boot-time, §6)', () => {
   const resolveFilename = (userId: string) => `kmp-v6-${userId}.db`
 
-  it('drops the compiled-extension cache when a wipe is armed (before the file delete)', async () => {
+  it('drops the compiled-extension cache AFTER the file delete succeeds (siblings gone)', async () => {
     markPendingWipe(USER)
     const order: string[] = []
     const clearCompiledCache = vi.fn(async () => { order.push('compiled') })
@@ -197,8 +197,26 @@ describe('consumePendingWipe (boot-time, §6)', () => {
 
     expect(wiped).toBe(true)
     expect(clearCompiledCache).toHaveBeenCalledTimes(1)
-    // Compiled cache is dropped before the (possibly retrying) file delete.
-    expect(order).toEqual(['compiled', 'file'])
+    // File delete first: its success means all sibling tabs released the OPFS
+    // handle, so no sibling can still write a row after we clear.
+    expect(order).toEqual(['file', 'compiled'])
+  })
+
+  it('does NOT clear the compiled-extension cache if the file delete never succeeds', async () => {
+    // No file delete ⟹ siblings may still be alive/writing, and the wipe itself
+    // hasn't completed — so we must not clear (and disarm); retry next boot.
+    markPendingWipe(USER)
+    const clearCompiledCache = vi.fn(async () => {})
+    const remove = vi.fn().mockRejectedValue(new Error('NoModificationAllowedError'))
+
+    await expect(
+      consumePendingWipe(USER, remove, resolveFilename, {
+        clearCompiledCache, retries: 1, sleep: async () => {},
+      }),
+    ).rejects.toThrow(/close other tabs/i)
+
+    expect(clearCompiledCache).not.toHaveBeenCalled()
+    expect(isPendingWipe(USER)).toBe(true) // still armed → retried next boot
   })
 
   it('does not touch the compiled-extension cache when no wipe is armed', async () => {

--- a/src/sync/keys/flows/lockAndWipe.test.ts
+++ b/src/sync/keys/flows/lockAndWipe.test.ts
@@ -192,21 +192,20 @@ describe('lockAndWipe commit (§6)', () => {
     expect(isPendingWipe(USER)).toBe(true)
   })
 
-  it('still completes the wipe when the compiled-cache clear fails (best-effort)', async () => {
-    // The load-bearing plaintext removal (key drop + armed DB-file wipe) has
-    // already happened, so a flaky derived-cache clear must not abort it.
+  it('refuses the wipe (no keys dropped, no marker) when the compiled-cache clear fails', async () => {
+    // The compiled cache is plaintext-derived source the wipe must remove, so a
+    // clear failure has to BLOCK the wipe — not report success while it lingers.
+    // Clearing first means we refuse before anything destructive happens.
     const keyStore = new InMemoryWorkspaceKeyStore()
     const clearForUser = vi.spyOn(keyStore, 'clearForUser')
     const compiledCache = { clear: vi.fn(async () => { throw new Error('idb clear boom') }) }
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     await expect(
       lockAndWipe({ userId: USER, keyStore, compiledCache }),
-    ).resolves.toBeUndefined()
+    ).rejects.toThrow(/idb clear boom/)
 
-    expect(clearForUser).toHaveBeenCalledWith(USER)
-    expect(isPendingWipe(USER)).toBe(true) // wipe stays armed
-    warn.mockRestore()
+    expect(clearForUser).not.toHaveBeenCalled()
+    expect(isPendingWipe(USER)).toBe(false)
   })
 })
 

--- a/src/sync/keys/flows/lockAndWipe.test.ts
+++ b/src/sync/keys/flows/lockAndWipe.test.ts
@@ -181,6 +181,33 @@ describe('lockAndWipe commit (§6)', () => {
     )
     expect(isPendingWipe(USER)).toBe(false)
   })
+
+  it('clears the compiled-extension cache so no plaintext survives the wipe', async () => {
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const compiledCache = { clear: vi.fn(async () => {}) }
+
+    await lockAndWipe({ userId: USER, keyStore, compiledCache })
+
+    expect(compiledCache.clear).toHaveBeenCalledTimes(1)
+    expect(isPendingWipe(USER)).toBe(true)
+  })
+
+  it('still completes the wipe when the compiled-cache clear fails (best-effort)', async () => {
+    // The load-bearing plaintext removal (key drop + armed DB-file wipe) has
+    // already happened, so a flaky derived-cache clear must not abort it.
+    const keyStore = new InMemoryWorkspaceKeyStore()
+    const clearForUser = vi.spyOn(keyStore, 'clearForUser')
+    const compiledCache = { clear: vi.fn(async () => { throw new Error('idb clear boom') }) }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(
+      lockAndWipe({ userId: USER, keyStore, compiledCache }),
+    ).resolves.toBeUndefined()
+
+    expect(clearForUser).toHaveBeenCalledWith(USER)
+    expect(isPendingWipe(USER)).toBe(true) // wipe stays armed
+    warn.mockRestore()
+  })
 })
 
 describe('consumePendingWipe (boot-time, §6)', () => {

--- a/src/sync/keys/flows/lockAndWipe.ts
+++ b/src/sync/keys/flows/lockAndWipe.ts
@@ -28,8 +28,11 @@
  * surgery. Chasing one workspace's plaintext across every local surface (blocks,
  * derived indexes, FTS, caches) is exactly what the coarse file-wipe sidesteps —
  * for surfaces that live INSIDE that file. The one derived cache that lives
- * outside it (the compiled-extension store in its own IndexedDB DB) is cleared
- * explicitly here via {@link LockAndWipeDeps.compiledCache}.
+ * outside it (the compiled-extension store in its own IndexedDB DB) is dropped
+ * by {@link consumePendingWipe} on the next boot, alongside the file delete and
+ * gated by the same armed marker (see its `clearCompiledCache` option) — NOT at
+ * lock time, so it can't be re-populated by an in-flight recompile before the
+ * reload, and a flaky IndexedDB can never block the wipe.
  */
 
 import type { WorkspaceKeyStore } from '../keyStore.js'
@@ -152,33 +155,18 @@ export const flushUploadQueue = async (
   return { flushed: true, remaining: 0 }
 }
 
-/** The slice of the extension compile cache §6 needs: drop every locally
- *  persisted compiled-extension blob. Injected (rather than imported) so
- *  this keys-layer flow stays free of an `@/extensions` dependency. */
-export interface LocalCompiledCache {
-  clear(): Promise<void>
-}
-
 export interface LockAndWipeDeps {
   /** The signed-in user — keys, pins, and the DB file are all per-user. */
   readonly userId: string
   /** This device's workspace-key store (§5); every WK is dropped. */
   readonly keyStore: WorkspaceKeyStore
-  /** Device-local cache of transpiled extension *source* (a separate
-   *  IndexedDB store, NOT inside the per-user SQLite file the wipe
-   *  deletes). Cleared so a lock & wipe doesn't leave plaintext-derived
-   *  extension code behind. Cleared FIRST — before keys are dropped or the
-   *  wipe is armed — so that if it can't be cleared we refuse the whole
-   *  command rather than report success with that plaintext still on disk.
-   *  Optional: skipped when absent. */
-  readonly compiledCache?: LocalCompiledCache
 }
 
 /**
- * Commit the wipe: clear the compiled-extension cache, arm the next-boot
- * DB-file wipe, then drop this user's workspace keys. Does NOT reload — the
- * caller forces the reload (which also clears the in-memory BlockCache and other
- * live JS state) and the file delete happens on that next boot via
+ * Commit the wipe: arm the next-boot DB-file wipe, then drop this user's
+ * workspace keys. Does NOT reload — the caller forces the reload (which also
+ * clears the in-memory BlockCache and other live JS state) and the file delete
+ * (plus the compiled-extension-cache drop) happens on that next boot via
  * {@link consumePendingWipe}.
  *
  * Key clearing is scoped to `deps.userId`: the IndexedDB key store is shared
@@ -196,12 +184,10 @@ export interface LockAndWipeDeps {
  * it first also closes the residual TOCTOU window a sibling tab or quota change
  * could open between the probe and the write.
  *
- * The compiled-extension cache is cleared even earlier — before the marker — for
- * the same reason: it is plaintext-derived source living outside the SQLite file,
- * so if IndexedDB can't drop it we must refuse the wipe up front rather than
- * report success (and reload) with that plaintext still on disk. It is cleared
- * first rather than last so a failure costs nothing destructive; `clear()` is
- * idempotent, so a retry or the key-drop rollback below is harmless.
+ * The compiled-extension cache (a separate IndexedDB store of plaintext-derived
+ * source) is NOT touched here. It is dropped on the next boot by
+ * {@link consumePendingWipe}, gated by the same armed marker — see that
+ * function for why boot, not lock time.
  */
 export const lockAndWipe = async (deps: LockAndWipeDeps): Promise<void> => {
   if (!canPersistPins()) {
@@ -210,16 +196,6 @@ export const lockAndWipe = async (deps: LockAndWipeDeps): Promise<void> => {
         '(private mode or storage disabled).',
     )
   }
-  // Drop the compiled-extension cache FIRST. It is plaintext-derived source
-  // living outside the SQLite file, so the boot-time file wipe wouldn't touch
-  // it. Letting a failure here propagate (before anything destructive) means a
-  // wipe that can't remove this plaintext REFUSES rather than reporting success
-  // and reloading with the code still on disk. `clear()` is idempotent, so the
-  // user can simply retry.
-  if (deps.compiledCache) {
-    await deps.compiledCache.clear()
-  }
-
   markPendingWipe(deps.userId)
   try {
     await deps.keyStore.clearForUser(deps.userId)
@@ -238,18 +214,33 @@ export interface ConsumeWipeOptions {
   readonly retries?: number
   readonly delayMs?: number
   readonly sleep?: (ms: number) => Promise<void>
+  /** Empty the compiled-extension IndexedDB store (plaintext-derived source
+   *  that lives OUTSIDE the SQLite file). Injected so the keys layer keeps
+   *  no `@/extensions` import and tests can stub it; production wires
+   *  `clearCompiledModuleCache`. Best-effort — see below. */
+  readonly clearCompiledCache?: () => Promise<void>
 }
 
 /**
- * Boot-time half of the wipe: if a wipe is armed for this user, delete the DB
- * file, then disarm. MUST run before the DB is opened (see file header).
+ * Boot-time half of the wipe: if a wipe is armed for this user, drop the
+ * compiled-extension cache and delete the DB file, then disarm. MUST run before
+ * the DB is opened (see file header).
  *
  * The OPFS remover and filename resolver are injected so this orchestration is
  * unit-testable without a browser; production wires the real OPFS delete +
  * `dbFilenameForUser`. Returns whether a wipe was carried out.
  *
- * Retries the delete a few times: with multi-tab enabled, another same-user tab
- * that received the {@link broadcastWipeReload} signal may still be mid-reload
+ * Why the compiled-extension cache is cleared HERE (boot), not in `lockAndWipe`
+ * (lock time): it's a separate IndexedDB store the file delete doesn't touch, so
+ * it needs explicit removal — and doing it at boot, gated by the armed marker
+ * and before any compile can run, is what makes it durable. A lock-time clear
+ * could be re-populated by an in-flight recompile (this tab) or a sibling tab
+ * before the reload completes; here nothing can write a row back in. It is also
+ * BEST-EFFORT (the injected fn never rejects): a derived cache must never block
+ * the wipe — the load-bearing plaintext removal is the file delete below.
+ *
+ * Retries the file delete a few times: with multi-tab enabled, another same-user
+ * tab that received the {@link broadcastWipeReload} signal may still be mid-reload
  * and holding the OPFS sync-access handle, so the first attempt can fail with a
  * "no modification allowed" error that clears within ~a second. If every attempt
  * fails the marker is deliberately LEFT armed and the error propagates (aborting
@@ -264,6 +255,17 @@ export const consumePendingWipe = async (
   opts: ConsumeWipeOptions = {},
 ): Promise<boolean> => {
   if (!isPendingWipe(userId)) return false
+
+  // Drop the compiled-extension cache first — before the (possibly throwing)
+  // file-delete loop, so it still runs if the file delete defers to a later
+  // boot. Best-effort and defensively guarded: the load-bearing plaintext
+  // removal is the file delete, so a derived-cache hiccup must never abort the
+  // wipe (the injected fn is contracted not to reject, but we don't rely on it).
+  try {
+    await opts.clearCompiledCache?.()
+  } catch (err) {
+    console.warn('[lock-and-wipe] failed to clear compiled-extension cache on boot', err)
+  }
 
   const retries = opts.retries ?? 5
   const delayMs = opts.delayMs ?? 200

--- a/src/sync/keys/flows/lockAndWipe.ts
+++ b/src/sync/keys/flows/lockAndWipe.ts
@@ -167,16 +167,19 @@ export interface LockAndWipeDeps {
   /** Device-local cache of transpiled extension *source* (a separate
    *  IndexedDB store, NOT inside the per-user SQLite file the wipe
    *  deletes). Cleared so a lock & wipe doesn't leave plaintext-derived
-   *  extension code behind. Optional/best-effort — a flaky clear must not
-   *  block the load-bearing key drop + DB-file wipe. */
+   *  extension code behind. Cleared FIRST — before keys are dropped or the
+   *  wipe is armed — so that if it can't be cleared we refuse the whole
+   *  command rather than report success with that plaintext still on disk.
+   *  Optional: skipped when absent. */
   readonly compiledCache?: LocalCompiledCache
 }
 
 /**
- * Commit the wipe: arm the next-boot DB-file wipe, then drop this user's
- * workspace keys. Does NOT reload — the caller forces the reload (which also
- * clears the in-memory BlockCache and other live JS state) and the file delete
- * happens on that next boot via {@link consumePendingWipe}.
+ * Commit the wipe: clear the compiled-extension cache, arm the next-boot
+ * DB-file wipe, then drop this user's workspace keys. Does NOT reload — the
+ * caller forces the reload (which also clears the in-memory BlockCache and other
+ * live JS state) and the file delete happens on that next boot via
+ * {@link consumePendingWipe}.
  *
  * Key clearing is scoped to `deps.userId`: the IndexedDB key store is shared
  * across all accounts in the browser profile, but the wipe (marker + DB file) is
@@ -192,6 +195,13 @@ export interface LockAndWipeDeps {
  * `canPersistPins()` preflight makes the marker write near-certain, but ordering
  * it first also closes the residual TOCTOU window a sibling tab or quota change
  * could open between the probe and the write.
+ *
+ * The compiled-extension cache is cleared even earlier — before the marker — for
+ * the same reason: it is plaintext-derived source living outside the SQLite file,
+ * so if IndexedDB can't drop it we must refuse the wipe up front rather than
+ * report success (and reload) with that plaintext still on disk. It is cleared
+ * first rather than last so a failure costs nothing destructive; `clear()` is
+ * idempotent, so a retry or the key-drop rollback below is harmless.
  */
 export const lockAndWipe = async (deps: LockAndWipeDeps): Promise<void> => {
   if (!canPersistPins()) {
@@ -200,6 +210,16 @@ export const lockAndWipe = async (deps: LockAndWipeDeps): Promise<void> => {
         '(private mode or storage disabled).',
     )
   }
+  // Drop the compiled-extension cache FIRST. It is plaintext-derived source
+  // living outside the SQLite file, so the boot-time file wipe wouldn't touch
+  // it. Letting a failure here propagate (before anything destructive) means a
+  // wipe that can't remove this plaintext REFUSES rather than reporting success
+  // and reloading with the code still on disk. `clear()` is idempotent, so the
+  // user can simply retry.
+  if (deps.compiledCache) {
+    await deps.compiledCache.clear()
+  }
+
   markPendingWipe(deps.userId)
   try {
     await deps.keyStore.clearForUser(deps.userId)
@@ -208,17 +228,6 @@ export const lockAndWipe = async (deps: LockAndWipeDeps): Promise<void> => {
     // still present (and don't report success). Rollback is best-effort.
     clearPendingWipe(deps.userId)
     throw err
-  }
-
-  // Keys dropped + wipe armed. Now clear the separate compiled-extension
-  // cache — it lives outside the SQLite file, so the boot-time file wipe
-  // wouldn't touch it, leaving plaintext-derived extension source on disk.
-  // Best-effort: the critical plaintext removal (key drop + DB-file wipe)
-  // has already happened/is armed, so a failing clear is logged, not fatal.
-  try {
-    await deps.compiledCache?.clear()
-  } catch (err) {
-    console.warn('[lock-and-wipe] failed to clear compiled-extension cache', err)
   }
 }
 

--- a/src/sync/keys/flows/lockAndWipe.ts
+++ b/src/sync/keys/flows/lockAndWipe.ts
@@ -26,7 +26,10 @@
  *
  * Coarse by design: the whole DB file is wiped rather than per-workspace
  * surgery. Chasing one workspace's plaintext across every local surface (blocks,
- * derived indexes, FTS, caches) is exactly what the coarse file-wipe sidesteps.
+ * derived indexes, FTS, caches) is exactly what the coarse file-wipe sidesteps —
+ * for surfaces that live INSIDE that file. The one derived cache that lives
+ * outside it (the compiled-extension store in its own IndexedDB DB) is cleared
+ * explicitly here via {@link LockAndWipeDeps.compiledCache}.
  */
 
 import type { WorkspaceKeyStore } from '../keyStore.js'
@@ -149,11 +152,24 @@ export const flushUploadQueue = async (
   return { flushed: true, remaining: 0 }
 }
 
+/** The slice of the extension compile cache §6 needs: drop every locally
+ *  persisted compiled-extension blob. Injected (rather than imported) so
+ *  this keys-layer flow stays free of an `@/extensions` dependency. */
+export interface LocalCompiledCache {
+  clear(): Promise<void>
+}
+
 export interface LockAndWipeDeps {
   /** The signed-in user — keys, pins, and the DB file are all per-user. */
   readonly userId: string
   /** This device's workspace-key store (§5); every WK is dropped. */
   readonly keyStore: WorkspaceKeyStore
+  /** Device-local cache of transpiled extension *source* (a separate
+   *  IndexedDB store, NOT inside the per-user SQLite file the wipe
+   *  deletes). Cleared so a lock & wipe doesn't leave plaintext-derived
+   *  extension code behind. Optional/best-effort — a flaky clear must not
+   *  block the load-bearing key drop + DB-file wipe. */
+  readonly compiledCache?: LocalCompiledCache
 }
 
 /**
@@ -192,6 +208,17 @@ export const lockAndWipe = async (deps: LockAndWipeDeps): Promise<void> => {
     // still present (and don't report success). Rollback is best-effort.
     clearPendingWipe(deps.userId)
     throw err
+  }
+
+  // Keys dropped + wipe armed. Now clear the separate compiled-extension
+  // cache — it lives outside the SQLite file, so the boot-time file wipe
+  // wouldn't touch it, leaving plaintext-derived extension source on disk.
+  // Best-effort: the critical plaintext removal (key drop + DB-file wipe)
+  // has already happened/is armed, so a failing clear is logged, not fatal.
+  try {
+    await deps.compiledCache?.clear()
+  } catch (err) {
+    console.warn('[lock-and-wipe] failed to clear compiled-extension cache', err)
   }
 }
 

--- a/src/sync/keys/flows/lockAndWipe.ts
+++ b/src/sync/keys/flows/lockAndWipe.ts
@@ -222,8 +222,8 @@ export interface ConsumeWipeOptions {
 }
 
 /**
- * Boot-time half of the wipe: if a wipe is armed for this user, drop the
- * compiled-extension cache and delete the DB file, then disarm. MUST run before
+ * Boot-time half of the wipe: if a wipe is armed for this user, delete the DB
+ * file, then drop the compiled-extension cache, then disarm. MUST run before
  * the DB is opened (see file header).
  *
  * The OPFS remover and filename resolver are injected so this orchestration is
@@ -232,12 +232,18 @@ export interface ConsumeWipeOptions {
  *
  * Why the compiled-extension cache is cleared HERE (boot), not in `lockAndWipe`
  * (lock time): it's a separate IndexedDB store the file delete doesn't touch, so
- * it needs explicit removal — and doing it at boot, gated by the armed marker
- * and before any compile can run, is what makes it durable. A lock-time clear
- * could be re-populated by an in-flight recompile (this tab) or a sibling tab
- * before the reload completes; here nothing can write a row back in. It is also
- * BEST-EFFORT (the injected fn never rejects): a derived cache must never block
- * the wipe — the load-bearing plaintext removal is the file delete below.
+ * it needs explicit removal, and a lock-time clear could be re-populated by an
+ * in-flight recompile before the reload. It is BEST-EFFORT (isolated from the
+ * delete loop): a derived cache must never block the wipe — the load-bearing
+ * plaintext removal is the file delete.
+ *
+ * Crucially the clear runs AFTER the file delete SUCCEEDS, not before. The delete
+ * succeeding is the synchronization point: it means every sibling same-user tab
+ * has released the OPFS sync-access handle — i.e. its wa-sqlite worker (and page)
+ * has been torn down — so none can still be running an extension compile that
+ * would write a fresh plaintext row. Clearing before the (retrying) delete would
+ * race a sibling that finishes an in-flight compile during the wait and writes a
+ * row after the clear, which the subsequent disarm would then leave behind.
  *
  * Retries the file delete a few times: with multi-tab enabled, another same-user
  * tab that received the {@link broadcastWipeReload} signal may still be mid-reload
@@ -256,38 +262,45 @@ export const consumePendingWipe = async (
 ): Promise<boolean> => {
   if (!isPendingWipe(userId)) return false
 
-  // Drop the compiled-extension cache first — before the (possibly throwing)
-  // file-delete loop, so it still runs if the file delete defers to a later
-  // boot. Best-effort and defensively guarded: the load-bearing plaintext
-  // removal is the file delete, so a derived-cache hiccup must never abort the
-  // wipe (the injected fn is contracted not to reject, but we don't rely on it).
-  try {
-    await opts.clearCompiledCache?.()
-  } catch (err) {
-    console.warn('[lock-and-wipe] failed to clear compiled-extension cache on boot', err)
-  }
-
   const retries = opts.retries ?? 5
   const delayMs = opts.delayMs ?? 200
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)))
   const filename = resolveFilename(userId)
 
   let lastErr: unknown
+  let deleted = false
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       await removeDbFile(filename)
-      clearPendingWipe(userId)
-      return true
+      deleted = true
+      break
     } catch (err) {
       lastErr = err
       if (attempt < retries) await sleep(delayMs)
     }
   }
-  throw new Error(
-    'Could not finish wiping local data — another tab of this app may still be ' +
-      'open and holding the database. Close other tabs and reload to finish.',
-    { cause: lastErr },
-  )
+
+  if (!deleted) {
+    throw new Error(
+      'Could not finish wiping local data — another tab of this app may still be ' +
+        'open and holding the database. Close other tabs and reload to finish.',
+      { cause: lastErr },
+    )
+  }
+
+  // File deleted ⟹ all sibling tabs released the OPFS handle (their workers/
+  // pages are torn down), so the last possible compiled-row write has happened.
+  // Clear the compiled-extension cache NOW. Best-effort + isolated from the
+  // delete loop (its own try/catch): a derived-cache hiccup must never abort or
+  // retry the already-completed file wipe.
+  try {
+    await opts.clearCompiledCache?.()
+  } catch (err) {
+    console.warn('[lock-and-wipe] failed to clear compiled-extension cache on boot', err)
+  }
+
+  clearPendingWipe(userId)
+  return true
 }
 
 // Cross-tab reload signal (BroadcastChannel — the design's §5/§6 cross-tab

--- a/yarn.lock
+++ b/yarn.lock
@@ -2887,6 +2887,11 @@ extend@^3.0.0:
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+fake-indexeddb@^6.2.5:
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz#74285b6821467d6c102af092f0a4517ad5521613"
+  integrity sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==
+
 fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"


### PR DESCRIPTION
## Phase 1 of the #167 / #67 plugin-runtime work

This is the perf-focused first phase. It gets `@babel/standalone` out of the startup critical path **for real** (including for the current fleet, who recompile every boot) without touching the trust model yet. Phase 2 (#67) layers the device-local, content-hash-pinned approval gate on top of the same storage row.

### The problem (#167)
`@babel/standalone` (~0.85 MB gz, ~39% of startup JS) was statically imported at the top of `compileExtensionModule.ts`, so it landed in the eager `modulepreload` set and was fetched/parsed on **every cold start**. As the issue notes, lazy-loading alone is *insufficient*: the in-memory compile cache is empty on every reload, so every user with ≥1 enabled extension (the whole fleet) re-runs Babel on every boot. The **persistent cache is the load-bearing fix**.

### What this PR does
- **New `CompiledModuleCache`** (`src/extensions/compiledModuleCache.ts`) — IndexedDB-backed, mirroring the interface + in-memory-fallback + factory pattern of `sync/keys/keyStore.ts`. One self-contained row per block `{ sourceHash, compiled, compilerVersion }`, overwritten on source change → **bounded by installed extensions, no eviction needed**. This is deliberately the **Phase-2 "approval record" shape** running in implicit auto-approve mode.
- **L3 persistent layer in `compileExtensionModule`** — on an in-memory miss it rebuilds the module from cached transpiled JS via the existing blob-URL path **without loading Babel**; only a genuine miss (first-ever compile, or the source changed) does `await import('@babel/standalone')`. Flaky IndexedDB reads/writes are best-effort and never break extension loading.
- **Split the two hashes** — the source hash is now pure `SHA-256(content)` (no `COMPILER_VERSION` salt); the compiler version is a separate record field checked for cache validity. A compiler bump invalidates cached *output* without looking like a *source* change (which #67 will treat as needing re-approval).

### Verification
- **Prod build confirms the payoff**: `dist/index.html` no longer preloads `@babel/standalone/babel.js` (only the trivial, pre-existing `@babel/runtime` helpers remain); the built compile chunk references babel via a dynamic `import("…/@babel/standalone/babel.js")`.
- Full suite green: **305 files / 3363 tests**. Lint + typecheck clean.
- New tests use **`fake-indexeddb`** (new devDependency) to exercise the *real* IndexedDB store — round-trip, overwrite, delete, and cross-"reload" persistence (a fresh store instance reopening the same DB) — plus integration: cold miss compiles + persists, warm reload serves from cache without re-transpiling, compiler-version bump and source change both recompile, and read/write failures degrade gracefully.

### Not in this PR (Phase 2 → #67)
Device-local trust gate keyed by `(workspaceId, blockId, sourceHash)`, "keep running the approved/pinned version until you explicitly update", re-approval-on-source-change UX, the synced overrides map reframed as non-executing "intent" + cross-device "enable here too?" prompt, and updating the agent-cli `install/enable/uninstall` commands + guidance to drive the approval layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHdhtuVxjNgzB6PMYox1bi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHdhtuVxjNgzB6PMYox1bi)_