### PR TITLE
fix(sync): isolate throwing plugin invalidation rules (#191)

### DIFF
--- a/src/data/internals/invalidation.test.ts
+++ b/src/data/internals/invalidation.test.ts
@@ -28,7 +28,7 @@ import { BlockCache } from '@/data/blockCache'
 import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { BLOCKS_SYNCED_RAW_TABLE, blockToRowParams } from '@/data/blockSchema'
 import { Repo } from '../repo'
-import { resolveFacetRuntimeSync } from '@/facets/facet.js'
+import { resolveFacetRuntimeSync, type AppExtension } from '@/facets/facet.js'
 import { kernelDataExtension } from '@/data/kernelDataExtension.js'
 import {
   LoaderHandle,
@@ -36,11 +36,12 @@ import {
   type ChangeSnapshot,
 } from './handleStore'
 import type { InvalidationRule } from '@/data/invalidation.js'
+import { invalidationRulesFacet } from '@/data/facets.js'
 
 interface Harness { h: TestDb; cache: BlockCache; repo: Repo }
 
 const setup = async (
-  opts: {startTail?: boolean} = {},
+  opts: {startTail?: boolean; extraExtensions?: readonly AppExtension[]} = {},
 ): Promise<Harness> => {
   // Shared DB opened once per file (beforeAll), reset per test in setup().
   await resetTestDb(sharedDb.db)
@@ -54,6 +55,7 @@ const setup = async (
   })
   repo.setFacetRuntime(resolveFacetRuntimeSync([
     kernelDataExtension,
+    ...(opts.extraExtensions ?? []),
   ]))
   return {h, cache, repo}
 }
@@ -731,6 +733,41 @@ describe('sync observer: sync-applied invalidation', () => {
     await Promise.resolve()
     expect(env.repo.handleStore.metrics.snapshot().invalidations).toBe(invalidationsBefore)
     expect(fired.length).toBe(firedBefore)
+  })
+
+  it('a throwing plugin rule does NOT leave a real handle permanently stale (#191 acceptance)', async () => {
+    // The issue's literal acceptance criterion, end-to-end with a REAL
+    // LoaderHandle + subscriber (not a spy handleStore): a plugin
+    // InvalidationRule that throws for an id must still leave that id's handle
+    // invalidated. The kernel parent-edge dep is computed independently of the
+    // plugin loop, so children(p) re-resolves on the sync-applied child even
+    // though the registered rule throws on every pass. Pre-fix, the throw
+    // aborted the drain before the watermark DELETE and the notification was
+    // lost for good.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const throwingRule: InvalidationRule = {
+      id: 'test.always-throws',
+      collectFromSnapshots: () => { throw new Error('rule boom') },
+    }
+    env = await setup({
+      startTail: false,
+      extraExtensions: [invalidationRulesFacet.of(throwingRule, {source: 'test'})],
+    })
+
+    await create('p')
+    const h = env.repo.query.children({id: 'p'})
+    const fired: string[][] = []
+    h.subscribe(v => fired.push(v.map(b => b.id)))
+    await vi.waitFor(() => expect(fired).toEqual([[]]))
+
+    env.repo.startSyncObserver({throttleMs: 0})
+    await syncApply({id: 'c-remote', parentId: 'p', orderKey: 'a0', content: 'remote'})
+    await env.repo.flushSyncObserver()
+
+    // The handle re-resolved despite the throwing rule — not permanently stale.
+    await vi.waitFor(() => expect(fired).toEqual([[], ['c-remote']]))
+    expect(warn).toHaveBeenCalled() // the rule's failure was logged, not silent
+    warn.mockRestore()
   })
 
 })

--- a/src/data/internals/invalidation.test.ts
+++ b/src/data/internals/invalidation.test.ts
@@ -194,6 +194,36 @@ describe('snapshotsToChangeNotification', () => {
     expect(Array.from(note.plugin?.get('test.channel') ?? []).sort()).toEqual(['a', 'b'])
   })
 
+  it('isolates a throwing rule: kernel deps and sibling rules still contribute (#191)', () => {
+    // A plugin rule that throws must not abort the whole pass. In the sync
+    // observer this loop runs before the drain's watermark DELETE, so an
+    // un-isolated throw would skip both the watermark advance and the handle
+    // notification, permanently stranding the UI on a since-equal stamp. The
+    // throw is swallowed (logged) so the kernel rowIds and other rules survive.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const throwing: InvalidationRule = {
+      id: 'test.throwing-rule',
+      collectFromSnapshots: () => { throw new Error('boom') },
+    }
+    const sibling: InvalidationRule = {
+      id: 'test.sibling-rule',
+      collectFromSnapshots: (snapshots, emit) => {
+        for (const id of snapshots.keys()) emit('sibling.channel', id)
+      },
+    }
+    const map = new Map<string, ChangeSnapshot>([
+      ['a', {before: null, after: {parentId: null, workspaceId: 'w'}}],
+    ])
+
+    const note = snapshotsToChangeNotification(map, [throwing, sibling])
+    // Kernel notification unaffected by the throw.
+    expect(Array.from(note.rowIds!)).toEqual(['a'])
+    // The sibling rule (registered after the thrower) still ran.
+    expect(Array.from(note.plugin?.get('sibling.channel') ?? [])).toEqual(['a'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
   it('plugin invalidations stay undefined when no rule emits', () => {
     const rule: InvalidationRule = {
       id: 'test.noop-rule',

--- a/src/data/internals/syncObserver/observer.test.ts
+++ b/src/data/internals/syncObserver/observer.test.ts
@@ -334,12 +334,15 @@ describe('blocksSyncedObserver — robustness', () => {
     // disk gate skip-staled the now-equal stamp so handleStore.invalidate never
     // re-fired — a permanently-stale UI. Per-rule isolation now lets the kernel
     // notification AND the watermark DELETE both run.
-    let throwsLeft = 1
+    //
+    // The rule throws on EVERY call (the worst case: a permanently-buggy plugin,
+    // which is also what could strand a window forever pre-fix). We then assert
+    // it was invoked exactly once — proving the watermark advanced and the row
+    // was NOT requeued for a (futile, skip-staled) reprocess.
+    let calls = 0
     const flakyRule: InvalidationRule = {
       id: 'test.flaky-rule',
-      collectFromSnapshots: () => {
-        if (throwsLeft > 0) { throwsLeft -= 1; throw new Error('rule boom') }
-      },
+      collectFromSnapshots: () => { calls += 1; throw new Error('rule boom') },
     }
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     await put(data({ content: 'fresh' }))
@@ -349,6 +352,8 @@ describe('blocksSyncedObserver — robustness', () => {
     })
 
     await observer.flush()
+    // A second flush would re-run the rule if the row were still queued.
+    await observer.flush()
     warn.mockRestore()
 
     // The throw didn't abort the watermark DELETE: the row materialized and the
@@ -356,6 +361,7 @@ describe('blocksSyncedObserver — robustness', () => {
     expect(await blocks()).toEqual([{ id: 'b1', content: 'fresh' }])
     expect(await queueLen()).toBe(0)
     expect(cache.getSnapshot('b1')).toMatchObject({ content: 'fresh' })
+    expect(calls).toBe(1) // consumed once; not reprocessed despite the throw
     // The kernel notification still reached the handle store despite the throw —
     // the handle for b1 is invalidated, not permanently stale.
     expect(notifications).toHaveLength(1)

--- a/src/data/internals/syncObserver/observer.test.ts
+++ b/src/data/internals/syncObserver/observer.test.ts
@@ -14,6 +14,7 @@ import type { GetMaterializability, Materializability } from './materialize.js'
 import { encodeForWire, type GetCek } from '@/sync/transform.js'
 import { generateWorkspaceKeyBytes, importWorkspaceKey } from '@/sync/crypto/workspaceKey.js'
 import type { ChangeNotification } from '@/data/internals/handleStore'
+import type { InvalidationRule } from '@/data/invalidation'
 import type { BlockData, CycleDetectedEvent } from '@/data/api'
 
 const data = (o: Partial<BlockData> = {}): BlockData => ({
@@ -80,6 +81,7 @@ const start = (opts: {
   onCycleDetected?: (e: CycleDetectedEvent) => void
   drainChunkSize?: number
   onError?: (err: unknown) => void
+  getInvalidationRules?: () => readonly InvalidationRule[]
 }): Harness => {
   const cache = new BlockCache()
   const notifications: ChangeNotification[] = []
@@ -95,6 +97,7 @@ const start = (opts: {
     throttleMs: 5,
     drainChunkSize: opts.drainChunkSize,
     onError: opts.onError,
+    getInvalidationRules: opts.getInvalidationRules,
   })
   observers.push(observer)
   return { observer, cache, notifications }
@@ -321,6 +324,42 @@ describe('blocksSyncedObserver — robustness', () => {
     // materialize unit level.)
     expect(await blocks()).toEqual([{ id: 'good', content: 'readable' }])
     expect(await queueLen()).toBe(0)
+  })
+
+  it('isolates a throwing plugin invalidation rule: watermark still advances and the handle still invalidates (#191)', async () => {
+    // A plugin InvalidationRule is a live extension point. Before #191's fix, a
+    // throw from one rule propagated out of snapshotsToChangeNotification →
+    // applySyncInvalidation, aborting the drain AFTER the committed materialize
+    // but BEFORE its watermark DELETE: the row stayed queued, and on retry the
+    // disk gate skip-staled the now-equal stamp so handleStore.invalidate never
+    // re-fired — a permanently-stale UI. Per-rule isolation now lets the kernel
+    // notification AND the watermark DELETE both run.
+    let throwsLeft = 1
+    const flakyRule: InvalidationRule = {
+      id: 'test.flaky-rule',
+      collectFromSnapshots: () => {
+        if (throwsLeft > 0) { throwsLeft -= 1; throw new Error('rule boom') }
+      },
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await put(data({ content: 'fresh' }))
+    const { observer, cache, notifications } = start({
+      getMaterializability: constMat('copy'),
+      getInvalidationRules: () => [flakyRule],
+    })
+
+    await observer.flush()
+    warn.mockRestore()
+
+    // The throw didn't abort the watermark DELETE: the row materialized and the
+    // queue fully drained — no retry-on-equal-stamp that would lose the notify.
+    expect(await blocks()).toEqual([{ id: 'b1', content: 'fresh' }])
+    expect(await queueLen()).toBe(0)
+    expect(cache.getSnapshot('b1')).toMatchObject({ content: 'fresh' })
+    // The kernel notification still reached the handle store despite the throw —
+    // the handle for b1 is invalidated, not permanently stale.
+    expect(notifications).toHaveLength(1)
+    expect([...(notifications[0]!.rowIds ?? [])]).toEqual(['b1'])
   })
 
   it('drains a backlog larger than the chunk size across bounded windows', async () => {

--- a/src/data/invalidation.ts
+++ b/src/data/invalidation.ts
@@ -64,7 +64,20 @@ export const collectPluginInvalidationsFromSnapshots = (
   if (rules.length === 0 || snapshots.size === 0) return undefined
   const out: MutablePluginInvalidationMap = new Map()
   const emit = createPluginInvalidationEmitter(out)
-  for (const rule of rules) rule.collectFromSnapshots?.(snapshots, emit)
+  // Isolate each plugin rule. `InvalidationRule` is a live extension point, and
+  // this loop runs inside the sync observer's drain window BEFORE its watermark
+  // DELETE. A throw from one rule must not abort the pass: it would skip the
+  // watermark advance and the handle invalidation, and on retry the disk gate
+  // skip-stales the now-equal stamp, so the handle never re-fires — a
+  // permanently-stale UI (issue #191). Swallow + log so the kernel rowIds /
+  // parentIds notification and the other rules still go through.
+  for (const rule of rules) {
+    try {
+      rule.collectFromSnapshots?.(snapshots, emit)
+    } catch (err) {
+      console.warn(`[invalidation] rule "${rule.id}" threw; skipping its contribution`, err)
+    }
+  }
   return out.size > 0 ? out : undefined
 }
 

--- a/src/data/invalidation.ts
+++ b/src/data/invalidation.ts
@@ -69,13 +69,20 @@ export const collectPluginInvalidationsFromSnapshots = (
   // DELETE. A throw from one rule must not abort the pass: it would skip the
   // watermark advance and the handle invalidation, and on retry the disk gate
   // skip-stales the now-equal stamp, so the handle never re-fires — a
-  // permanently-stale UI (issue #191). Swallow + log so the kernel rowIds /
-  // parentIds notification and the other rules still go through.
+  // permanently-stale UI (issue #191). The kernel rowIds/parentIds/workspaceIds
+  // are computed by the caller independently of this loop, so the affected ids'
+  // row/parent deps still invalidate regardless; only deps that depend SOLELY on
+  // a throwing rule's channel can miss this window. We keep whatever the rule
+  // emitted before it threw (over-firing an invalidation is a harmless re-read;
+  // under-firing is the bug), drop the rest, and log loudly.
   for (const rule of rules) {
     try {
       rule.collectFromSnapshots?.(snapshots, emit)
     } catch (err) {
-      console.warn(`[invalidation] rule "${rule.id}" threw; skipping its contribution`, err)
+      console.warn(
+        `[invalidation] rule "${rule.id}" threw; keeping its emissions so far, dropping the rest`,
+        err,
+      )
     }
   }
   return out.size > 0 ? out : undefined


### PR DESCRIPTION
Fixes #191.

## Problem
A throw from a plugin `InvalidationRule` after the committed Phase-2 sync write but before the watermark delete permanently dropped that drain window's cache/handle invalidation.

`collectPluginInvalidationsFromSnapshots` (`src/data/invalidation.ts`) iterated plugin rules with no try/catch. A throw propagated up through `snapshotsToChangeNotification` → `applySyncInvalidation` → `applyOutcome` → `applyWindow`, aborting `drainQueueOnce` **before** its `DELETE … WHERE seq <= maxSeq` watermark advance. The window's rows stayed queued; on retry the reconcile disk gate skip-staled the now-equal stamp, so `handleStore.invalidate` never re-fired. Disk was correct — only the UI notification was lost, leaving the UI stale until an unrelated change or a reload.

## Fix
Wrap the per-rule call in `try/catch` so one throwing rule is isolated: the kernel `rowIds`/`parentIds` notification and the remaining rules still run, and the watermark `DELETE` still advances. The failure is logged via `console.warn`, not swallowed silently.

## Tests
- `observer.test.ts` — end-to-end against the real DB: a rule that throws once still leaves the row materialized, the queue fully drained (the watermark advance), and the handle store notified with `rowIds: ['b1']`. Wired `getInvalidationRules` through the test harness.
- `invalidation.test.ts` — focused unit test: a throwing rule doesn't suppress the kernel `rowIds` or a sibling rule's contribution, and the failure is logged.

## Verification
`yarn run check` is green — 0 lint errors (only pre-existing warnings), all 3350 tests across 304 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124VJGbCrBTPZN5szqNGLiq

---
_Generated by [Claude Code](https://claude.ai/code/session_0124VJGbCrBTPZN5szqNGLiq)_