### PR TITLE
fix(data): typed precondition error for merge-into-descendant (#188)

### DIFF
--- a/src/data/api/errors.test.ts
+++ b/src/data/api/errors.test.ts
@@ -8,6 +8,7 @@ import {
   DeletedConflictError,
   DeterministicIdCrossWorkspaceError,
   DuplicateIdError,
+  MergeIntoDescendantError,
   MutatorNotRegisteredError,
   NotDeletedError,
   ParentDeletedError,
@@ -29,6 +30,7 @@ describe('data-layer errors', () => {
       new DeletedConflictError('a'),
       new DeterministicIdCrossWorkspaceError('a', 'w1', 'w2'),
       new DuplicateIdError('a'),
+      new MergeIntoDescendantError('into', 'from'),
       new MutatorNotRegisteredError('m'),
       new NotDeletedError('a'),
       new ParentDeletedError('p'),
@@ -55,6 +57,12 @@ describe('data-layer errors', () => {
     const cyc = new CycleError('child', 'newParent')
     expect(cyc.movedId).toBe('child')
     expect(cyc.targetParentId).toBe('newParent')
+
+    const merge = new MergeIntoDescendantError('intoX', 'fromY')
+    expect(merge.intoId).toBe('intoX')
+    expect(merge.fromId).toBe('fromY')
+    expect(merge.message).toContain('intoX')
+    expect(merge.message).toContain('fromY')
 
     const cross = new DeterministicIdCrossWorkspaceError('id', 'wa', 'wb')
     expect(cross.id).toBe('id')

--- a/src/data/api/errors.ts
+++ b/src/data/api/errors.ts
@@ -86,6 +86,24 @@ export class CycleError extends DataLayerError {
   }
 }
 
+/** Precondition failure raised by the block-merge helper when `into` is a
+ *  descendant of `from`. Folding `from`'s subtree into one of its own
+ *  descendants would re-home an ancestor of `into` under `into` (via
+ *  `tx.move`) and trip the cycle guard mid-fold — the merge can never
+ *  succeed in that direction. Surfaced up front as a typed, user-actionable
+ *  error (e.g. the alias-collision "Merge into…" affordance) instead of
+ *  leaking the raw `CycleError` after a partial fold + rollback (#188). */
+export class MergeIntoDescendantError extends DataLayerError {
+  constructor(
+    public readonly intoId: string,
+    public readonly fromId: string,
+  ) {
+    super(
+      `cannot merge ${fromId} into ${intoId}: ${intoId} is a descendant of ${fromId}`,
+    )
+  }
+}
+
 /** Thrown by the tx engine's parent preflight when a write references a
  *  non-existent parent_id. The storage layer still backs this invariant, but
  *  its local trigger collapses missing-parent and cross-workspace failures

--- a/src/data/api/tx.ts
+++ b/src/data/api/tx.ts
@@ -195,6 +195,14 @@ export interface Tx {
    *  exist. Reads SQL via the writeTransaction. */
   parentOf(childId: string): Promise<BlockData | null>
 
+  /** True when `potentialAncestorId` is an ancestor of `id` (i.e. `id` is
+   *  a descendant of `potentialAncestorId`). Walks `parent_id` up from `id`
+   *  via the same bounded CTE (`IS_DESCENDANT_OF_SQL`) that backs
+   *  `tx.move`'s cycle guard, so — like that guard — it does NOT filter
+   *  soft-deleted nodes: a tombstone on the ancestor chain is still a real
+   *  structural edge (#183). `id === potentialAncestorId` returns true. */
+  isDescendantOf(id: string, potentialAncestorId: string): Promise<boolean>
+
   /** Look up the live block in `workspaceId` whose `aliases` property
    *  contains the exact `alias` text. Returns null when no such block
    *  exists. Tx-aware version of the kernel `core.aliasLookup` query;

--- a/src/data/blockMerge.ts
+++ b/src/data/blockMerge.ts
@@ -1,5 +1,6 @@
 import {
   CORE_BLOCK_MERGED_EVENT,
+  MergeIntoDescendantError,
   type BlockData,
   type BlockMergeAliasRewrite,
   type Tx,
@@ -50,6 +51,18 @@ export const mergeBlocksInTx = async (
   // content (read-after-delete via requireExisting), and orphan its children
   // under the tombstone. Treat self-merge as a no-op.
   if (into.id === from.id) return
+
+  // Merging `from` into one of its own descendants can never succeed: the
+  // child re-homing below would move an ancestor of `into` under `into` and
+  // trip `tx.move`'s cycle guard mid-fold (clean rollback, raw CycleError).
+  // The alias-collision "Merge into…" button drives exactly this direction
+  // when an aliased ancestor page is renamed onto a descendant page's alias,
+  // so retries fail identically and the button gets stuck (#188). Pre-check
+  // with the same ancestry walk the cycle guard uses and surface a typed,
+  // user-actionable precondition error up front instead.
+  if (await tx.isDescendantOf(into.id, from.id)) {
+    throw new MergeIntoDescendantError(into.id, from.id)
+  }
 
   const intoChildren = await tx.childrenOf(into.id)
   const fromChildren = await tx.childrenOf(from.id)

--- a/src/data/internals/txEngine.test.ts
+++ b/src/data/internals/txEngine.test.ts
@@ -786,6 +786,42 @@ describe('tx.childrenOf / tx.parentOf', () => {
   })
 })
 
+describe('tx.isDescendantOf', () => {
+  // Pins the boolean wrapper + argument order at the public Tx surface.
+  // tx.move's cycle guard and blockMerge's pre-check both route through
+  // this, so an inverted-argument regression would break two live
+  // guarantees at once; the SQL itself is covered in treeQueries.test.ts.
+  beforeEach(async () => {
+    // gp → p → c
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'd-gp', workspaceId: 'ws-1', parentId: null,   orderKey: 'a0'})
+      await tx.create({id: 'd-p',  workspaceId: 'ws-1', parentId: 'd-gp', orderKey: 'a0'})
+      await tx.create({id: 'd-c',  workspaceId: 'ws-1', parentId: 'd-p',  orderKey: 'a0'})
+      await tx.create({id: 'd-x',  workspaceId: 'ws-1', parentId: null,   orderKey: 'a1'})
+    }, {scope: ChangeScope.BlockDefault})
+  })
+
+  it('is true when the second arg is an ancestor of the first (and false the other way)', async () => {
+    await env.repo.tx(async tx => {
+      expect(await tx.isDescendantOf('d-c', 'd-gp')).toBe(true)
+      // Argument order matters: ancestor-of-descendant is not symmetric.
+      expect(await tx.isDescendantOf('d-gp', 'd-c')).toBe(false)
+    }, {scope: ChangeScope.BlockDefault})
+  })
+
+  it('is false for unrelated blocks', async () => {
+    await env.repo.tx(async tx => {
+      expect(await tx.isDescendantOf('d-c', 'd-x')).toBe(false)
+    }, {scope: ChangeScope.BlockDefault})
+  })
+
+  it('is true on identity (a node is in its own chain)', async () => {
+    await env.repo.tx(async tx => {
+      expect(await tx.isDescendantOf('d-c', 'd-c')).toBe(true)
+    }, {scope: ChangeScope.BlockDefault})
+  })
+})
+
 describe('tx.aliasLookup', () => {
   it('finds a block by exact alias inside the user tx (read-your-own-writes)', async () => {
     await env.repo.tx(async tx => {

--- a/src/data/internals/txEngine.ts
+++ b/src/data/internals/txEngine.ts
@@ -427,11 +427,9 @@ export class TxImpl implements Tx {
       target.parentId !== before.parentId &&
       target.parentId !== id
     ) {
-      const hit = await this.ctx.txDb.getOptional<{hit: number}>(
-        IS_DESCENDANT_OF_SQL,
-        [target.parentId, id],
-      )
-      if (hit !== null) throw new CycleError(id, target.parentId)
+      if (await this.isDescendantOf(target.parentId, id)) {
+        throw new CycleError(id, target.parentId)
+      }
     } else if (target.parentId === id) {
       throw new CycleError(id, id)
     }
@@ -557,6 +555,14 @@ export class TxImpl implements Tx {
   async parentOf(childId: string): Promise<BlockData | null> {
     const row = await this.ctx.txDb.getOptional<BlockRow>(SELECT_PARENT_SQL, [childId])
     return row === null ? null : parseBlockRow(row)
+  }
+
+  async isDescendantOf(id: string, potentialAncestorId: string): Promise<boolean> {
+    const hit = await this.ctx.txDb.getOptional<{hit: number}>(
+      IS_DESCENDANT_OF_SQL,
+      [id, potentialAncestorId],
+    )
+    return hit !== null
   }
 
   async aliasLookup(alias: string, workspaceId: string): Promise<BlockData | null> {

--- a/src/data/mutators.test.ts
+++ b/src/data/mutators.test.ts
@@ -17,6 +17,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import {
   CORE_BLOCK_MERGED_EVENT,
   ChangeScope,
+  MergeIntoDescendantError,
   ParentDeletedError,
   codecs,
   defineProperty,
@@ -1053,6 +1054,47 @@ describe('core.merge', () => {
     expect(env.read('c')!.parentId).toBe('x')
     expect(env.read('c')!.deleted).toBe(false)
     expect(await env.childIds('x')).toEqual(['c'])
+  })
+
+  it('rejects merging into a descendant with a typed precondition error, not a raw CycleError (#188)', async () => {
+    // ancestor → mid → leaf. Merging the ancestor INTO the leaf would
+    // re-home `mid` (an ancestor of leaf) under leaf and trip the cycle
+    // guard mid-fold. The pre-check turns that into a typed, actionable
+    // MergeIntoDescendantError up front — clean, no partial mutation.
+    await env.repo.tx(
+      tx => tx.create({id: 'p', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'}),
+      {scope: ChangeScope.BlockDefault},
+    )
+    await env.repo.mutate.createChild({parentId: 'p', id: 'ancestor', content: 'A'})
+    await env.repo.mutate.createChild({parentId: 'ancestor', id: 'mid', content: 'M'})
+    await env.repo.mutate.createChild({parentId: 'mid', id: 'leaf', content: 'L'})
+
+    await expect(env.repo.mutate.merge({intoId: 'leaf', fromId: 'ancestor'}))
+      .rejects.toBeInstanceOf(MergeIntoDescendantError)
+
+    // Nothing folded or tombstoned — the tx rolled back cleanly.
+    expect(env.read('ancestor')!.deleted).toBe(false)
+    expect(env.read('leaf')!.deleted).toBe(false)
+    expect(env.read('mid')!.parentId).toBe('ancestor')
+    expect(env.read('leaf')!.parentId).toBe('mid')
+  })
+
+  it('rejects merging into a direct child with the typed precondition error (#188)', async () => {
+    // The degenerate descendant case: `into` is a direct child of `from`,
+    // so the fold would try to move `into` under itself. Still caught by
+    // the up-front pre-check rather than the self-move cycle guard.
+    await env.repo.tx(
+      tx => tx.create({id: 'p', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'}),
+      {scope: ChangeScope.BlockDefault},
+    )
+    await env.repo.mutate.createChild({parentId: 'p', id: 'parent', content: 'P'})
+    await env.repo.mutate.createChild({parentId: 'parent', id: 'child', content: 'C'})
+
+    await expect(env.repo.mutate.merge({intoId: 'child', fromId: 'parent'}))
+      .rejects.toBeInstanceOf(MergeIntoDescendantError)
+
+    expect(env.read('parent')!.deleted).toBe(false)
+    expect(env.read('child')!.deleted).toBe(false)
   })
 
   it("re-parents source's children under the target so they aren't stranded", async () => {

--- a/src/data/mutators.test.ts
+++ b/src/data/mutators.test.ts
@@ -1097,6 +1097,29 @@ describe('core.merge', () => {
     expect(env.read('child')!.deleted).toBe(false)
   })
 
+  it('still merges a descendant UP into its ancestor — the legal direction is not over-blocked (#188)', async () => {
+    // Inverse of the rejected case: into=ancestor, from=leaf (a descendant).
+    // `isDescendantOf(into, from)` is false here, so the pre-check must NOT
+    // fire; the fold proceeds and re-homes leaf's own child up under the
+    // ancestor. Guards against an inverted-argument regression in the check.
+    await env.repo.tx(
+      tx => tx.create({id: 'p', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'}),
+      {scope: ChangeScope.BlockDefault},
+    )
+    await env.repo.mutate.createChild({parentId: 'p', id: 'ancestor', content: 'A:'})
+    await env.repo.mutate.createChild({parentId: 'ancestor', id: 'mid', content: 'M'})
+    await env.repo.mutate.createChild({parentId: 'mid', id: 'leaf', content: 'L:'})
+    await env.repo.mutate.createChild({parentId: 'leaf', id: 'leafKid', content: 'k'})
+
+    await env.repo.mutate.merge({intoId: 'ancestor', fromId: 'leaf'})
+
+    expect(env.read('leaf')!.deleted).toBe(true)
+    expect(env.read('ancestor')!.content).toBe('A:L:')
+    // leaf's child re-homed under the ancestor, not stranded.
+    expect(env.read('leafKid')!.parentId).toBe('ancestor')
+    expect(env.read('leafKid')!.deleted).toBe(false)
+  })
+
   it("re-parents source's children under the target so they aren't stranded", async () => {
     await env.repo.tx(
       tx => tx.create({id: 'p', workspaceId: 'ws-1', parentId: null, orderKey: 'a0'}),

--- a/src/plugins/alias/AliasCollisionToast.tsx
+++ b/src/plugins/alias/AliasCollisionToast.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { getLayoutSessionBlock, getUIStateBlock } from '@/data/stateBlocks.js'
 import { navigate } from '@/utils/navigation.js'
 import { dismissToast, showError } from '@/utils/toast.js'
+import { MergeIntoDescendantError } from '@/data/api'
 import type { Repo } from '@/data/repo'
 import { ALIAS_COLLISION_MERGE_MUTATOR } from './collisionMerge.ts'
 import { getLayoutSessionId } from '@/utils/layoutSessionId.js'
@@ -55,6 +56,11 @@ export const AliasCollisionToast = ({
   repo,
 }: AliasCollisionToastProps) => {
   const [pending, setPending] = useState(false)
+  // Set once a merge fails a precondition that no retry can satisfy (the
+  // target is nested inside the page being renamed). Hides the doomed
+  // "Merge into…" button so the toast stops looping on the same failure
+  // and steers the user to "Open" for manual resolution (#188).
+  const [mergeBlocked, setMergeBlocked] = useState(false)
 
   const openExisting = () => {
     navigate(repo, {target: 'main', blockId: conflictingBlockId, workspaceId})
@@ -81,6 +87,22 @@ export const AliasCollisionToast = ({
       }
       dismissToast(toastId)
     } catch (error) {
+      if (error instanceof MergeIntoDescendantError) {
+        // The existing block is nested inside the page being renamed, so
+        // this merge direction can never succeed. Don't re-offer the
+        // doomed retry — explain the situation and leave "Open" so the
+        // user can move the content manually.
+        setMergeBlocked(true)
+        setPending(false)
+        const targetLabel = conflictingBlockTitle.trim() === ''
+          ? alias
+          : conflictingBlockTitle.trim()
+        showError(
+          `Can't merge into "${truncate(targetLabel, 30)}" — it's nested inside ` +
+          `the page you're renaming. Open it to move the content manually.`,
+        )
+        return
+      }
       // Surface the failure rather than disappearing silently. Leave
       // the collision toast open so the user can retry or pick Open.
       showError(error instanceof Error ? error.message : 'Merge failed')
@@ -99,7 +121,7 @@ export const AliasCollisionToast = ({
         <Button variant="ghost" size="sm" disabled={pending} onClick={openExisting}>
           Open
         </Button>
-        {offerMerge && (
+        {offerMerge && !mergeBlocked && (
           <Button variant="default" size="sm" disabled={pending} onClick={() => { void mergeIntoExisting() }}>
             {pending ? 'Merging…' : mergeLabel}
           </Button>

--- a/src/plugins/alias/test/aliasCollisionToast.test.tsx
+++ b/src/plugins/alias/test/aliasCollisionToast.test.tsx
@@ -1,0 +1,61 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MergeIntoDescendantError } from '@/data/api'
+import type { Repo } from '@/data/repo'
+import { AliasCollisionToast } from '../AliasCollisionToast.tsx'
+
+// The component surfaces failures via the toast helpers; mock them so the
+// test asserts on the calls instead of mounting a real toaster.
+vi.mock('@/utils/toast.js', () => ({
+  showError: vi.fn(),
+  dismissToast: vi.fn(),
+}))
+import { showError } from '@/utils/toast.js'
+
+const baseProps = {
+  toastId: 'toast-1',
+  message: 'collision',
+  alias: 'Q4',
+  attemptedOn: 'ancestor',
+  conflictingBlockId: 'descendant',
+  conflictingBlockTitle: 'Q4 Plans',
+  workspaceId: 'ws-1',
+  offerMerge: true,
+}
+
+const renderToast = (run: Repo['run']) =>
+  render(<AliasCollisionToast {...baseProps} repo={{run} as Repo} />)
+
+describe('AliasCollisionToast — merge-into-descendant (#188)', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('hides the doomed Merge button on a MergeIntoDescendantError, keeping Open for manual fixup', async () => {
+    const run = vi.fn().mockRejectedValue(new MergeIntoDescendantError('descendant', 'ancestor'))
+    renderToast(run as unknown as Repo['run'])
+
+    const mergeButton = screen.getByRole('button', {name: /Merge into/})
+    await act(async () => { fireEvent.click(mergeButton) })
+
+    // The button that can never succeed is gone — no more stuck retry loop.
+    expect(screen.queryByRole('button', {name: /Merge into/})).not.toBeInTheDocument()
+    // Open stays available so the user can resolve the nesting manually.
+    expect(screen.getByRole('button', {name: 'Open'})).toBeEnabled()
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(showError).mock.calls[0]?.[0]).toContain('nested inside')
+  })
+
+  it('keeps the Merge button for an ordinary merge failure so the user can retry', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('transient boom'))
+    renderToast(run as unknown as Repo['run'])
+
+    const mergeButton = screen.getByRole('button', {name: /Merge into/})
+    await act(async () => { fireEvent.click(mergeButton) })
+
+    // Non-precondition failures stay retryable: button present and re-enabled.
+    expect(screen.getByRole('button', {name: /Merge into/})).toBeEnabled()
+    expect(vi.mocked(showError).mock.calls[0]?.[0]).toBe('transient boom')
+  })
+})

--- a/src/plugins/alias/test/collisionMerge.test.ts
+++ b/src/plugins/alias/test/collisionMerge.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { ChangeScope, type BlockData } from '@/data/api'
+import { ChangeScope, MergeIntoDescendantError, type BlockData } from '@/data/api'
 import { BlockCache } from '@/data/blockCache'
 import { createTestDb, resetTestDb, type TestDb } from '@/data/test/createTestDb'
 import { Repo } from '@/data/repo'
@@ -90,6 +90,36 @@ describe('alias.mergeCollision', () => {
     expect(env.read('source')!.deleted).toBe(true)
     expect(env.read('target')!.content).toBe('Existing')
     expect(env.read('target')!.properties[aliasesProp.name]).toEqual(['Existing', 'Other'])
+  })
+
+  it('rejects merging into a descendant with the typed precondition error (#188)', async () => {
+    // Reproduces the stuck "Merge into…" flow: renaming an aliased
+    // ancestor page onto a descendant page's alias offers a merge with
+    // the descendant as target. That direction can never succeed, so the
+    // mutator must surface MergeIntoDescendantError (which the toast turns
+    // into an actionable message) rather than a raw CycleError.
+    await createBlock('ancestor', 'Ancestor', ['Ancestor'], 'a0')
+    await env.repo.tx(
+      tx => tx.create({
+        id: 'descendant',
+        workspaceId: WS,
+        parentId: 'ancestor',
+        orderKey: 'a0',
+        content: 'Descendant',
+        properties: aliasProperty(['Descendant']),
+      }),
+      {scope: ChangeScope.BlockDefault},
+    )
+
+    await expect(env.repo.run(ALIAS_COLLISION_MERGE_MUTATOR, {
+      intoId: 'descendant',
+      fromId: 'ancestor',
+      collisionAlias: 'Descendant',
+    })).rejects.toBeInstanceOf(MergeIntoDescendantError)
+
+    expect(env.read('ancestor')!.deleted).toBe(false)
+    expect(env.read('descendant')!.deleted).toBe(false)
+    expect(env.read('descendant')!.parentId).toBe('ancestor')
   })
 
   it('keeps all source aliases for direct alias collisions when no rename alias is supplied', async () => {


### PR DESCRIPTION
Fixes #188.

## Problem
Merging a block into one of its own descendants re-homes an ancestor of `into` under `into` via `tx.move`, tripping the cycle guard mid-fold (clean rollback, raw `CycleError`). The alias-collision **"Merge into…"** button drives exactly this direction when an aliased ancestor page is renamed onto a descendant page's alias — so every retry failed identically and the button got **permanently stuck** surfacing a raw error message.

## Fix
Pre-check ancestry and emit a **typed, user-actionable precondition error** before any partial mutation, rather than catching `CycleError` after the fact.

- **`errors.ts`** — new typed `MergeIntoDescendantError(intoId, fromId)` (subclasses `DataLayerError`).
- **`tx.ts` / `txEngine.ts`** — added `tx.isDescendantOf(id, potentialAncestorId)`, backed by the same `IS_DESCENDANT_OF_SQL` ancestry walk the cycle guard already uses (faithful re: soft-deleted ancestors, #183). Refactored `tx.move`'s cycle check to call it — a pure extraction that aligns the code with the method's existing doc comment.
- **`blockMerge.ts`** — pre-check up front: `if (await tx.isDescendantOf(into.id, from.id)) throw new MergeIntoDescendantError(...)`. Covers both `core.merge` and `alias.mergeCollision`.
- **`AliasCollisionToast.tsx`** — catches the typed error, shows a clear *"it's nested inside the page you're renaming — open it to move the content manually"* message, and hides the doomed Merge button so the toast stops looping on the same failure.

## Tests
- `mutators.test.ts` — acceptance test: a merge where `into` is a descendant of `from` rejects with `MergeIntoDescendantError` (not a raw `CycleError`), with clean-rollback assertions; plus the direct-child degenerate case.
- `collisionMerge.test.ts` — alias-path test mirroring the real rename-onto-descendant scenario.
- `errors.test.ts` — added the new error to the broad-catch + identifying-fields coverage.

## Verification
`yarn run check` green — 0 lint errors, 3351 tests passing (304 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rf8uPTufxZcShSfhHfbzAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf8uPTufxZcShSfhHfbzAB)_