### PR TITLE
fix(data): skip same-tx processors on undo/redo replay (#187)

### DIFF
--- a/src/data/internals/commitPipeline.ts
+++ b/src/data/internals/commitPipeline.ts
@@ -162,6 +162,17 @@ export interface RunTxParams<R> {
    *  Throws (e.g. `ProcessorRejection`) propagate out and roll back
    *  the user's tx atomically. */
   sameTxProcessors: ReadonlyMap<string, AnySameTxProcessor>
+  /** When true this tx is an undo/redo replay driven by
+   *  `TxImpl.applyRaw` (see `Repo._replay`). The same-tx processor
+   *  pass is SKIPPED for replays: `applyRaw` is contracted to drive
+   *  each row to EXACTLY the restored snapshot (§10 step 7, the
+   *  `applyRaw` doc in `txEngine.ts`), but its write is still a field
+   *  change in the replay tx — so a value-deriving same-tx processor
+   *  (e.g. one that appends to `content`) would re-fire and override
+   *  the restore, leaving the row at a derived value rather than the
+   *  state being restored to. Post-commit processors are unaffected;
+   *  they dispatch from `_runAndDispatch` regardless. Default false. */
+  isReplay?: boolean
   /** Merged property-schema registry snapshot, captured at the same
    *  boundary as `processors` so processor code sees a consistent
    *  runtime bundle. */
@@ -203,6 +214,7 @@ export const runTx = async <R>(params: RunTxParams<R>): Promise<TxResult<R>> => 
     db, cache, fn, opts, user, isReadOnly,
     newTxId, newTxSeq, newId, now,
     mutators, processors, sameTxProcessors, propertySchemas,
+    isReplay = false,
   } = params
   const {scope, description} = opts
 
@@ -274,7 +286,12 @@ export const runTx = async <R>(params: RunTxParams<R>): Promise<TxResult<R>> => 
     // Only the snapshot taken at tx start (`sameTxProcessors`) is
     // iterated — mid-tx facet swaps don't affect the running tx,
     // matching the §3/§8 contract.
-    if (sameTxProcessors.size > 0 && (snapshots.size > 0 || sameTxEvents.length > 0)) {
+    //
+    // Replay txs (undo/redo) skip this pass entirely (`isReplay`):
+    // `applyRaw` drives each row to EXACTLY the restored snapshot, so
+    // re-deriving here would override the restore. See the `isReplay`
+    // doc on RunTxParams.
+    if (!isReplay && sameTxProcessors.size > 0 && (snapshots.size > 0 || sameTxEvents.length > 0)) {
       for (const processor of sameTxProcessors.values()) {
         const changedRows = collectSameTxFieldMatches(processor, snapshots)
         const emittedEvents = collectSameTxEventMatches(processor, sameTxEvents)

--- a/src/data/internals/sameTxRunner.test.ts
+++ b/src/data/internals/sameTxRunner.test.ts
@@ -342,6 +342,58 @@ describe('Same-tx runner — ordering', () => {
   })
 })
 
+describe('Same-tx runner — undo/redo replay skip (#187)', () => {
+  // A value-deriving same-tx processor: appends '!' to content whenever
+  // content changes (and isn't already suffixed). Non-idempotent in the
+  // sense that re-running on a restore would corrupt the restored value.
+  const appendBang: AnySameTxProcessor = {
+    name: 'test.appendBang',
+    watches: {kind: 'field', table: 'blocks', fields: ['content']},
+    apply: async (event, ctx) => {
+      for (const row of event.changedRows) {
+        if (row.after && !row.after.content.endsWith('!')) {
+          await ctx.tx.update(row.id, {content: `${row.after.content}!`}, {skipMetadata: true})
+        }
+      }
+    },
+  }
+
+  it('does not re-run a value-deriving same-tx processor during undo/redo (restore is exact)', async () => {
+    // Seed content='orig' BEFORE registering the processor, so the
+    // restored snapshot is the bare 'orig' (no '!' suffix). This is
+    // what makes the bug observable: if the same-tx pass re-ran on the
+    // undo's applyRaw write, 'orig' (no trailing '!') would be amended
+    // to 'orig!'.
+    await env.repo.tx(async tx => {
+      await tx.create({id: 'a', workspaceId: WS, parentId: null, orderKey: 'a0', content: 'orig'})
+    }, {scope: ChangeScope.BlockDefault})
+
+    env.repo.__setSameTxProcessorsForTesting([appendBang])
+
+    // Update to 'changed' → processor appends → 'changed!'. The undo
+    // entry for this tx captures before={content:'orig'},
+    // after={content:'changed!'}.
+    await env.repo.tx(async tx => {
+      await tx.update('a', {content: 'changed'})
+    }, {scope: ChangeScope.BlockDefault})
+    const changed = await env.h.db.get<{content: string}>('SELECT content FROM blocks WHERE id = ?', ['a'])
+    expect(changed.content).toBe('changed!')
+
+    // Undo: applyRaw drives content back to exactly 'orig'. That's a
+    // content change in the replay tx, so a non-gated same-tx pass
+    // would re-derive to 'orig!'. With the replay-skip gate it stays
+    // 'orig' (#187).
+    expect(await env.repo.undo(ChangeScope.BlockDefault)).toBe(true)
+    const undone = await env.h.db.get<{content: string}>('SELECT content FROM blocks WHERE id = ?', ['a'])
+    expect(undone.content).toBe('orig')
+
+    // Redo: applyRaw restores the post-update snapshot exactly.
+    expect(await env.repo.redo(ChangeScope.BlockDefault)).toBe(true)
+    const redone = await env.h.db.get<{content: string}>('SELECT content FROM blocks WHERE id = ?', ['a'])
+    expect(redone.content).toBe('changed!')
+  })
+})
+
 describe('Same-tx runner — zero-write tx', () => {
   it('skips dispatch when no writes happened', async () => {
     const log: FireLog = {events: []}

--- a/src/data/internals/txEngine.ts
+++ b/src/data/internals/txEngine.ts
@@ -638,7 +638,14 @@ export class TxImpl implements Tx {
    *
    *  Captures `(currentRow, applied)` into the snapshots map so the
    *  pipeline's commit-walk updates the cache and fires handles for the
-   *  rolled-back row. */
+   *  rolled-back row.
+   *
+   *  Exactness depends on the commit pipeline SKIPPING its same-tx
+   *  processor pass for replay txs (`runTx`'s `isReplay`, threaded from
+   *  `Repo._replay`). `applyRaw`'s write is still a field change in the
+   *  replay tx, so without that gate a value-deriving same-tx processor
+   *  would re-derive and override the restore — leaving the row at a
+   *  derived value, not `target` (#187). */
   async applyRaw(id: string, target: BlockData | null): Promise<void> {
     const beforeRow = await this.ctx.txDb.getOptional<BlockRow>(SELECT_BY_ID_SQL, [id])
     const beforeData = beforeRow === null ? null : parseBlockRow(beforeRow)

--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -1018,6 +1018,7 @@ export class Repo {
   private async _runAndDispatch<R>(
     fn: (tx: Tx) => Promise<R>,
     opts: RepoTxOptions,
+    isReplay = false,
   ) {
     const txT0 = performance.now()
     let result
@@ -1037,6 +1038,10 @@ export class Repo {
         processors: this.processors,
         sameTxProcessors: this.sameTxProcessors,
         propertySchemas: this._propertySchemas,
+        // Undo/redo replays skip the same-tx processor pass so a
+        // value-deriving processor can't override `applyRaw`'s exact
+        // restore (#187). Post-commit processors still dispatch below.
+        isReplay,
       })
     } catch (err) {
       const collision = parseAliasCollisionError(err)
@@ -1116,7 +1121,7 @@ export class Repo {
       for (const [id, snap] of entry.snapshots) {
         await txImpl.applyRaw(id, snap[direction])
       }
-    }, {scope: entry.scope, description})
+    }, {scope: entry.scope, description}, true)
   }
 
   /** Dynamic dispatch — used by runtime-loaded plugins where the


### PR DESCRIPTION
Fixes #187.

## Problem
`applyRaw` is contracted to drive a row to **exactly** the restored snapshot during undo/redo replay, but the commit pipeline's same-tx processor pass ran on the replay tx too. `applyRaw`'s restore write is itself a field change, so a value-deriving same-tx processor re-fires and overrides the restore.

Probe: a same-tx processor that appends `'!'` to `content`. Seed `content='orig'`, update → `'changed'` → processor → `'changed!'`. Undo's `applyRaw` writes `content='orig'`, the same-tx pass re-fires → `'orig!'`, **not** the intended `'orig'`.

No current production processor derives non-idempotently (`normalizeReferences`, alias-sync are idempotent), so there's no live data loss today — this closes the replay-contract hole before such a processor exists.

## Fix
Thread an internal `isReplay` flag `Repo._replay` → `_runAndDispatch` → `runTx` (kept **off** the public `RepoTxOptions`) and gate the same-tx processor pass on `!isReplay`. Post-commit processors still dispatch on replay. The `applyRaw` doc now notes the dependency.

## Test
Probe-based test in `sameTxRunner.test.ts`: seed `'orig'` *before* registering the append-`'!'` processor (so the restored snapshot is bare `'orig'`), update → `'changed!'`, then assert undo restores exactly `'orig'` (not `'orig!'`) and redo restores `'changed!'`. Verified it fails without the gate and passes with it.

## Verification
`yarn run check` green — lint 0 errors, all 304 test files / 3349 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdNDQqjQ3LRjHgNEkmMtSP)_