### PR TITLE
test(sync): pin empty-plaintext envelope boundary (#193)

### DIFF
--- a/src/sync/crypto/aead.test.ts
+++ b/src/sync/crypto/aead.test.ts
@@ -15,6 +15,20 @@ describe('AES-256-GCM seal/open', () => {
     expect(await open(key, envelope, aad)).toBe('Hello, world 🌍')
   })
 
+  it('round-trips the empty string (blank block content)', async () => {
+    // A blank block's content seals to a payload at exactly the
+    // nonce+tag floor (the empty plaintext adds no ciphertext bytes), so
+    // it sits right on decodeEnvelope's `< floor` boundary. This pins
+    // open(seal('')) === '' so a future off-by-one in the floor check
+    // (e.g. `< floor` → `<= floor`) can't silently quarantine every
+    // empty block on download.
+    const key = await keyFrom(0x01)
+    const aad = contentAad('block-1', 'ws-A', 'content')
+    const envelope = await seal(key, '', aad)
+    expect(envelope.startsWith(ENVELOPE_PREFIX)).toBe(true)
+    expect(await open(key, envelope, aad)).toBe('')
+  })
+
   it('produces a fresh nonce per seal (distinct envelopes for identical input)', async () => {
     const key = await keyFrom(0x01)
     const aad = contentAad('block-1', 'ws-A', 'content')

--- a/src/sync/crypto/envelope.test.ts
+++ b/src/sync/crypto/envelope.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { bytesToBase64Url } from './base64url.js'
 import {
   ENVELOPE_PREFIX,
   GCM_TAG_BYTES,
@@ -9,6 +10,10 @@ import {
 } from './envelope.js'
 
 const filled = (len: number, value: number) => new Uint8Array(len).fill(value)
+
+/** Envelope whose decoded payload is exactly `payloadLen` bytes. */
+const envelopeWithPayloadLen = (payloadLen: number) =>
+  ENVELOPE_PREFIX + bytesToBase64Url(filled(payloadLen, 0))
 
 describe('enc:v1: envelope', () => {
   it('round-trips nonce and ciphertext', () => {
@@ -33,6 +38,24 @@ describe('enc:v1: envelope', () => {
   it('rejects a payload too short to hold a nonce and tag', () => {
     const tooShort = encodeEnvelope(filled(NONCE_BYTES, 0), filled(GCM_TAG_BYTES - 1, 0))
     expect(() => decodeEnvelope(tooShort)).toThrow(/too short/)
+  })
+
+  it('pins the nonce+tag floor: rejects every payload below it, accepts it exactly', () => {
+    // The floor is the smallest legal payload: a nonce plus a bare GCM tag
+    // (what the empty plaintext seals to). Walk every truncated length in
+    // [0, floor) and assert rejection, then assert the floor itself decodes.
+    // This brackets the `< floor` check so a future `<= floor` regression —
+    // which would quarantine every empty block on download — fails here.
+    const floor = NONCE_BYTES + GCM_TAG_BYTES
+    for (let payloadLen = 0; payloadLen < floor; payloadLen++) {
+      expect(
+        () => decodeEnvelope(envelopeWithPayloadLen(payloadLen)),
+        `payload of ${payloadLen} bytes must be rejected`,
+      ).toThrow(/too short/)
+    }
+    const decoded = decodeEnvelope(envelopeWithPayloadLen(floor))
+    expect(decoded.nonce.length).toBe(NONCE_BYTES)
+    expect(decoded.ciphertext.length).toBe(GCM_TAG_BYTES)
   })
 
   it('hasEnvelopePrefix is a pure prefix check, not a decode', () => {


### PR DESCRIPTION
Closes #193.

## Background

A blank block's `content` seals to a payload at **exactly** the nonce+tag floor (`NONCE_BYTES + GCM_TAG_BYTES` = 12 + 16 = 28) — the empty plaintext adds no ciphertext bytes, just the 16-byte GCM tag. That payload sits right on `decodeEnvelope`'s `payload.length < NONCE_BYTES + GCM_TAG_BYTES` check, but nothing exercised it. A future off-by-one (`< floor` → `<= floor`) would silently quarantine every empty block on download with no test to catch it.

This is a **test-only** change — no production bug was found.

## Changes

- **`aead.test.ts`** — round-trip the empty string: `open(seal('')) === ''`, placed beside the analogous non-empty round-trip. Exercises the exact-floor decode end-to-end.
- **`envelope.test.ts`** — floor-pinning truncation test: walks every payload length in `[0, floor)` and asserts each is rejected (`/too short/`), then asserts the floor itself (28 bytes) decodes into a `NONCE_BYTES` nonce + `GCM_TAG_BYTES` ciphertext. The "accepts it exactly" half brackets the boundary so a `<= floor` regression fails here.

Uses the real named constants (`NONCE_BYTES`, `GCM_TAG_BYTES`) rather than hardcoding 28.

## Verification

`yarn run check` is green — 0 lint errors (only pre-existing warnings), all 304 test files / 3350 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgA8vMmffPNpwn7ciR97M8)_