### PR TITLE
fix(sync): strip internal whitespace from workspace-key paste (#192)

### DIFF
--- a/src/sync/crypto/workspaceKey.test.ts
+++ b/src/sync/crypto/workspaceKey.test.ts
@@ -30,6 +30,18 @@ describe('workspace key', () => {
     expect(parseWorkspaceKey(formatted.toUpperCase())).toEqual(bytes)
   })
 
+  it('tolerates internal whitespace/newlines on paste (#192)', () => {
+    const bytes = generateWorkspaceKeyBytes()
+    const formatted = formatWorkspaceKey(bytes)
+    const payload = formatted.slice(WK_PREFIX.length)
+    // Line-wrapped paste: payload split across lines.
+    const wrapped = `${WK_PREFIX}${payload.slice(0, 26)}\n${payload.slice(26)}`
+    expect(parseWorkspaceKey(wrapped)).toEqual(bytes)
+    // Retyped-from-paper: a space between every character (prefix included).
+    const spaced = formatted.split('').join(' ')
+    expect(parseWorkspaceKey(`\t${spaced}\n`)).toEqual(bytes)
+  })
+
   it('rejects a string without the prefix', () => {
     expect(() => parseWorkspaceKey('AAAA')).toThrow(/prefix/)
   })

--- a/src/sync/crypto/workspaceKey.ts
+++ b/src/sync/crypto/workspaceKey.ts
@@ -30,17 +30,21 @@ export const formatWorkspaceKey = (bytes: Uint8Array): string => {
 }
 
 /** Parse a pasted `kmp-wk-1:<base32>` string back to key bytes.
- *  Tolerates surrounding whitespace and case (users retype these). */
+ *  Tolerates whitespace (including internal) and case: users retype these
+ *  from paper or paste line-wrapped, and base32 carries no whitespace. */
 export const parseWorkspaceKey = (value: string): Uint8Array<ArrayBuffer> => {
-  const trimmed = value.trim()
+  // Strip ALL whitespace, not just the outer edges. A line-wrapped paste or
+  // a retyped paper backup can carry internal spaces/tabs/newlines; base32
+  // never does, so dropping them here is safe and keeps the decoder strict.
+  const cleaned = value.replace(/\s+/g, '')
   // Case-fold the prefix only. The base32 payload is upper-cased on decode
   // (base32.ts), so a user who upper-cased the WHOLE backup string —
   // `KMP-WK-1:…` — must still parse to honor the documented case tolerance;
   // a case-sensitive `startsWith` would reject exactly that paste.
-  if (trimmed.slice(0, WK_PREFIX.length).toLowerCase() !== WK_PREFIX) {
+  if (cleaned.slice(0, WK_PREFIX.length).toLowerCase() !== WK_PREFIX) {
     throw new Error('workspace key: missing kmp-wk-1: prefix')
   }
-  const bytes = base32ToBytes(trimmed.slice(WK_PREFIX.length))
+  const bytes = base32ToBytes(cleaned.slice(WK_PREFIX.length))
   if (bytes.length !== WK_BYTES) {
     throw new Error(`workspace key: expected ${WK_BYTES} bytes, got ${bytes.length}`)
   }


### PR DESCRIPTION
## Summary

Fixes #192.

`parseWorkspaceKey` only trimmed the outer string, so a workspace-key paste with **internal** whitespace/newlines — a line-wrapped paste, or a printed-on-paper backup retyped with spaces — was passed verbatim to the strict base32 decoder, which threw `base32: invalid input`. A perfectly valid backup looked corrupt: a recovery-UX failure for exactly the "legible on paper / retyped" case the format is meant to support.

## Change

- `src/sync/crypto/workspaceKey.ts`: replace the outer `value.trim()` with `value.replace(/\s+/g, '')`, stripping **all** whitespace (surrounding and internal) before decoding. The cleaning stays at the parse layer, so the generic base32 decoder (`base32.ts`) remains strict. The `kmp-wk-1:` prefix carries no whitespace, so prefix detection and case-folding are unaffected.
- `src/sync/crypto/workspaceKey.test.ts`: add a round-trip test (`tolerates internal whitespace/newlines on paste (#192)`) covering both a line-wrapped payload and a "space between every character" retyped-from-paper case, asserting each parses to the same key bytes as the unwrapped form.

## Verification

`yarn run check` is green — 0 errors, 304 test files / 3349 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZ6XUvvFJAcuM6WUVgY2u)_